### PR TITLE
Out of Order Completion

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -105,7 +105,7 @@ def rdata_description(dw, with_bank):
 
 class LiteDRAMPort:
     def __init__(self, mode, aw, dw, cd="sys", id=0,
-        with_data_bank=False):
+        reorder=False):
         self.mode = mode
         self.aw = aw
         self.dw = dw
@@ -115,9 +115,11 @@ class LiteDRAMPort:
         self.lock = Signal()
 
         self.cmd = stream.Endpoint(cmd_description(aw))
-        self.wdata = stream.Endpoint(wdata_description(dw, with_data_bank))
-        self.rdata = stream.Endpoint(rdata_description(dw, with_data_bank))
+        self.wdata = stream.Endpoint(wdata_description(dw, reorder))
+        self.rdata = stream.Endpoint(rdata_description(dw, reorder))
 
+        if reorder:
+            print("WARNING: Reordering controller is experimental")
         self.flush = Signal()
 
 

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -60,6 +60,7 @@ def data_layout(dw, bankbits):
     return [
         ("wdata",       dw, DIR_M_TO_S),
         ("wdata_we", dw//8, DIR_M_TO_S),
+        ("wbank",   bankbits, DIR_S_TO_M),
         ("rdata",       dw, DIR_S_TO_M),
         ("rbank",   bankbits, DIR_S_TO_M)
     ]
@@ -82,14 +83,18 @@ def cmd_description(aw):
         ("adr", aw)
     ]
 
-def wdata_description(dw):
+def wdata_description(dw, nbanks):
     return [
         ("data", dw),
-        ("we",   dw//8)
+        ("we",   dw//8),
+        ("bank", nbanks)
     ]
 
 def rdata_description(dw, nbanks):
-    return [("data", dw), ("bank", nbanks)]
+    return [
+        ("data", dw), 
+        ("bank", nbanks)
+    ]
 
 
 class LiteDRAMPort:
@@ -103,7 +108,7 @@ class LiteDRAMPort:
         self.lock = Signal()
 
         self.cmd = stream.Endpoint(cmd_description(aw))
-        self.wdata = stream.Endpoint(wdata_description(dw))
+        self.wdata = stream.Endpoint(wdata_description(dw, bankbits))
         self.rdata = stream.Endpoint(rdata_description(dw, bankbits))
 
         self.flush = Signal()

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -114,6 +114,8 @@ class LiteDRAMPort:
 
         self.lock = Signal()
 
+        self.reorder = reorder
+
         self.cmd = stream.Endpoint(cmd_description(aw))
         self.wdata = stream.Endpoint(wdata_description(dw, reorder))
         self.rdata = stream.Endpoint(rdata_description(dw, reorder))

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -138,16 +138,17 @@ class Multiplexer(Module, AutoCSR):
         # tRRD Command Timing
         tRRD = settings.timing.tRRD
         trrd_allowed = Signal(reset=1)
-        activate_count = Signal(max=tRRD)
         is_act_cmd = Signal()
         self.comb += is_act_cmd.eq(choose_cmd.cmd.ras & ~choose_cmd.cmd.cas & ~choose_cmd.cmd.we)
-        self.sync += \
-            If(choose_cmd.cmd.ready & choose_cmd.cmd.valid & is_act_cmd,
-                activate_count.eq(tRRD-1)
-            ).Elif(~activate_allowed,
-                activate_count.eq(activate_count-1)
-            )
-        self.comb += trrd_allowed.eq(activate_count == 0)
+        if tRRD > 1:
+            activate_count = Signal(max=tRRD)
+            self.sync += \
+                If(choose_cmd.cmd.ready & choose_cmd.cmd.valid & is_act_cmd,
+                    activate_count.eq(tRRD-1)
+                ).Elif(~activate_allowed,
+                    activate_count.eq(activate_count-1)
+                )
+            self.comb += trrd_allowed.eq(activate_count == 0)
         
         # tFAW Command Timing
         tfaw = settings.timing.tFAW

--- a/litedram/frontend/crossbar.py
+++ b/litedram/frontend/crossbar.py
@@ -26,19 +26,19 @@ class LiteDRAMCrossbar(Module):
 
         self.masters = []
 
-    def get_port(self, mode="both", dw=None, cd="sys", reverse=False):
+    def get_port(self, mode="both", dw=None, cd="sys", reverse=False, reorder=False):
         if self.finalized:
             raise FinalizeError
         if dw is None:
             dw = self.dw
 
         # crossbar port
-        port = LiteDRAMPort(mode, self.rca_bits + self.bank_bits, self.dw, "sys", len(self.masters))
+        port = LiteDRAMPort(mode, self.rca_bits + self.bank_bits, self.dw, "sys", len(self.masters), reorder)
         self.masters.append(port)
 
         # clock domain crossing
         if cd != "sys":
-            new_port = LiteDRAMPort(mode, port.aw, port.dw, cd, port.id)
+            new_port = LiteDRAMPort(mode, port.aw, port.dw, cd, port.id, reorder)
             self.submodules += LiteDRAMPortCDC(new_port, port)
             port = new_port
 
@@ -48,7 +48,7 @@ class LiteDRAMCrossbar(Module):
                 adr_shift = -log2_int(dw//self.dw)
             else:
                 adr_shift = log2_int(self.dw//dw)
-            new_port = LiteDRAMPort(mode, port.aw + adr_shift, dw, cd, port.id)
+            new_port = LiteDRAMPort(mode, port.aw + adr_shift, dw, cd, port.id, reorder)
             self.submodules += ClockDomainsRenamer(cd)(LiteDRAMPortConverter(new_port, port, reverse))
             port = new_port
 


### PR DESCRIPTION
This pull request implements the following:

- Configurable out of order (per port)
- Write bank to allow the interface to reconstruct the actual order of operations
- Tested with one out of order port and one in order
- Prints a warning that reordering is still experimental