### PR TITLE
This adds support for tRC timing parameters

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -43,7 +43,7 @@ class GeomSettings:
 
 
 class TimingSettings:
-    def __init__(self, tRP, tRCD, tWR, tWTR, tREFI, tRFC, tFAW, tCCD, tRRD):
+    def __init__(self, tRP, tRCD, tWR, tWTR, tREFI, tRFC, tFAW, tCCD, tRRD, tRC):
         self.tRP = tRP
         self.tRCD = tRCD
         self.tWR = tWR
@@ -53,6 +53,7 @@ class TimingSettings:
         self.tFAW = tFAW
         self.tCCD = tCCD
         self.tRRD = tRRD
+        self.tRC = tRC
 
 
 def cmd_layout(address_width):

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -35,6 +35,7 @@ class SDRAMModule:
             tFAW=None if self.get("tFAW") is None else self.ck_ns_to_cycles(*self.get("tFAW")),
             tCCD=None if self.get("tCCD") is None else self.ck_ns_to_cycles(*self.get("tCCD")),
             tRRD=None if self.get("tRRD") is None else self.ns_to_cycles_trrd(self.get("tRRD")),
+            tRC=None if self.get("tRC") is None else self.ns_to_cycles(self.get("tRC"))
         )
 
     def get(self, name):
@@ -252,24 +253,28 @@ class MT41J128M16(SDRAMModule):
     tWR_1066  = 13.1
     tRFC_1066 = 86
     tFAW_1066 = (27, None)
+    tRC_1066 = 50.625
     # DDR3-1333
     tRP_1333  = 13.5
     tRCD_1333 = 13.5
     tWR_1333  = 13.5
     tRFC_1333 = 107
     tFAW_1333 = (30, None)
+    tRC_1333 = 49.5
     # DDR3-1600
     tRP_1600  = 13.75
     tRCD_1600 = 13.75
     tWR_1600  = 13.75
     tRFC_1600 = 128
     tFAW_1600 = (32, None)
+    tRC_1600 = 48.75
     # API retro-compatibility
     tRP  = tRP_1600
     tRCD = tRCD_1600
     tWR  = tWR_1600
     tRFC = tRFC_1600
     tFAW = tFAW_1600
+    tRC = tRC_1600
 
 
 class MT41K128M16(MT41J128M16):


### PR DESCRIPTION
I'm getting these timing failures on random sequences that are only across 2 banks.  More rarely with wider patterns.