### PR TITLE
Update the write-to-precharge timings so it works with 1:2

### DIFF
--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -1,3 +1,4 @@
+import math
 from migen import *
 from migen.genlib.misc import WaitTimer
 
@@ -84,7 +85,8 @@ class BankMachine(Module):
         ]
 
         # Respect write-to-precharge specification
-        precharge_time = 2 + settings.timing.tWR - 1 + 1
+        write_latency = math.ceil(settings.phy.cwl / settings.phy.nphases)
+        precharge_time = write_latency + settings.timing.tWR - 1 + settings.timing.tCCD
         precharge_timer = WaitTimer(precharge_time)
         self.submodules += precharge_timer
         self.comb += precharge_timer.wait.eq(~(cmd.valid & cmd.ready & cmd.is_write))


### PR DESCRIPTION
This updates the formula so it doesn't use hardcoded numbers.  I believe it correctly accounts for the total end-to-end write time, however the datasheet mentions a timing parameter AL that I don't see us use anywhere.  The latency between the command and start of transmission of the write data is supposed to be CWL + AL.

Tested with the 1:2 and 1:4 Phys.