### PR TITLE
Add a latency parameter so wdata can be registered

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -120,7 +120,7 @@ def rdata_description(data_width, with_bank):
 
 
 class LiteDRAMNativePort:
-    def __init__(self, mode, address_width, data_width, clock_domain="sys", id=0, with_bank=False):
+    def __init__(self, mode, address_width, data_width, clock_domain="sys", id=0, with_bank=False, write_latency=0):
         self.mode = mode
         self.address_width = address_width
         self.data_width = data_width
@@ -131,6 +131,7 @@ class LiteDRAMNativePort:
 
         self.cmd = stream.Endpoint(cmd_description(address_width))
         self.wdata = stream.Endpoint(wdata_description(data_width, with_bank))
+        self.write_latency = write_latency
         self.rdata = stream.Endpoint(rdata_description(data_width, with_bank))
 
         self.flush = Signal()

--- a/litedram/frontend/crossbar.py
+++ b/litedram/frontend/crossbar.py
@@ -148,10 +148,16 @@ class LiteDRAMCrossbar(Module):
                     new_master_wdata_ready = Signal()
                     self.sync += new_master_wdata_ready.eq(master_wdata_ready)
                     master_wdata_ready = new_master_wdata_ready
-
                     new_master_wbank = Signal(max=self.nbanks)
                     self.sync += new_master_wbank.eq(master_wbank[nm])
                     master_wbank[nm] = new_master_wbank
+                self.comb += self.masters[nm].wdata.ready.eq(master_wdata_ready)
+
+        for nm, master_wdata_ready in enumerate(master_wdata_readys):
+                for i in range(self.write_latency):
+                    new_master_wdata_ready = Signal()
+                    self.sync += new_master_wdata_ready.eq(master_wdata_ready)
+                    master_wdata_ready = new_master_wdata_ready
                 master_wdata_readys[nm] = master_wdata_ready
 
         for nm, master_rdata_valid in enumerate(master_rdata_valids):
@@ -169,8 +175,6 @@ class LiteDRAMCrossbar(Module):
 
         for master, master_ready in zip(self.masters, master_readys):
             self.comb += master.cmd.ready.eq(master_ready)
-        for master, master_wdata_ready in zip(self.masters, master_wdata_readys):
-            self.comb += master.wdata.ready.eq(master_wdata_ready)
         for master, master_rdata_valid in zip(self.masters, master_rdata_valids):
             self.comb += master.rdata.valid.eq(master_rdata_valid)
 


### PR DESCRIPTION
It's really hard to meet timing in the 1:2 controller.  With the reordering controller its not possible to register the wdata input in all cases as its dependent on the wbank parameter.  This optional feature allows the wbank and ready signals to be asserted N cycles early to allow registering of the data bus after MUXing the bank.

N must be less than CWL, and will usually just be 1.  The setting is per master.