### PR TITLE
Bank reordering

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -169,3 +169,26 @@ def cmd_request_rw_layout(a, ba):
         ("is_write", 1),
         ("is_activate", 1)
     ]
+
+class tXXDController(Module):
+    def __init__(self, txxd):
+        self.valid = valid = Signal()
+        self.ready = ready = Signal(reset=1)
+        ready.attr.add("no_retiming")
+
+        # # #
+
+        if txxd is not None:
+            count = Signal(max=max(txxd, 2))
+            self.sync += \
+                If(valid,
+                    count.eq(txxd-1),
+                    If((txxd - 1) == 0,
+                        ready.eq(1)
+                    ).Else(
+                        ready.eq(0)
+                    )
+                ).Elif(~ready,
+                    count.eq(count - 1),
+                    If(count == 1, ready.eq(1))
+                )

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -166,5 +166,6 @@ def cmd_request_rw_layout(a, ba):
     return cmd_request_layout(a, ba) + [
         ("is_cmd", 1),
         ("is_read", 1),
-        ("is_write", 1)
+        ("is_write", 1),
+        ("is_activate", 1)
     ]

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -33,6 +33,8 @@ class BankMachine(Module):
         self.refresh_req = Signal()
         self.refresh_gnt = Signal()
         self.want_writes = Signal()
+        self.has_writes = Signal()
+        self.has_reads = Signal()
         a = settings.geom.addressbits
         ba = settings.geom.bankbits + log2_int(nranks)
         self.cmd = cmd = stream.Endpoint(cmd_request_rw_layout(a, ba))
@@ -78,7 +80,9 @@ class BankMachine(Module):
                 cmd_buffer.valid.eq(cmd_bufferRead.source.valid),
                 cmd_buffer.we.eq(cmd_bufferRead.source.we),
                 cmd_buffer.addr.eq(cmd_bufferRead.source.addr)
-            )
+            ),
+            self.has_writes.eq(cmd_bufferWrite.source.valid),
+            self.has_reads.eq(cmd_bufferWrite.source.valid)
         ]
 
         slicer = _AddressSlicer(settings.geom.colbits, address_align)

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -216,18 +216,20 @@ class BankMachine(Module):
             track_close.eq(1)
         )
         fsm.act("ACTIVATE",
-            sel_row_addr.eq(1),
-            track_open.eq(1),
-            cmd.valid.eq(1),
-            cmd.is_cmd.eq(1),
-            cmd.is_activate.eq(1),
-            If(cmd.ready,
-                NextState("TRCD")
-            ),
-            cmd.ras.eq(1)
+            If(activate_allowed,
+                sel_row_addr.eq(1),
+                track_open.eq(1),
+                cmd.valid.eq(1),
+                cmd.is_cmd.eq(1),
+                cmd.is_activate.eq(1),
+                If(cmd.ready,
+                    NextState("TRCD")
+                ),
+                cmd.ras.eq(1)
+            )
         )
         fsm.act("REFRESH",
-            If(twtpcon.ready,
+            If(twtpcon.ready & precharge_allowed,
                 self.refresh_gnt.eq(1),
             ),
             track_close.eq(1),

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -161,6 +161,7 @@ class BankMachine(Module):
                 track_open.eq(1),
                 cmd.valid.eq(1),
                 cmd.is_cmd.eq(1),
+                cmd.is_activate.eq(1),
                 If(cmd.ready,
                     NextState("TRCD")
                 ),

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -115,7 +115,7 @@ class BankMachine(Module):
         ]
         self.comb += [
             self.has_writes.eq(cmd_bufferWrite.source.valid),
-            self.has_reads.eq(cmd_bufferWrite.source.valid)
+            self.has_reads.eq(cmd_bufferRead.source.valid)
         ]
 
         # Address generation

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -5,6 +5,7 @@ from migen.genlib.misc import WaitTimer
 from litex.soc.interconnect import stream
 
 from litedram.core.multiplexer import *
+from litedram.common import *
 
 
 class _AddressSlicer:
@@ -116,28 +117,23 @@ class BankMachine(Module):
 
         # Respect write-to-precharge specification
         write_latency = math.ceil(settings.phy.cwl / settings.phy.nphases)
-        precharge_time = write_latency + settings.timing.tWR - 1 + settings.timing.tCCD # AL=0
-        precharge_timer = WaitTimer(precharge_time)
-        self.submodules += precharge_timer
-        self.comb += precharge_timer.wait.eq(~(cmd.valid & cmd.ready & cmd.is_write))
+        precharge_time = write_latency + settings.timing.tWR + settings.timing.tCCD # AL=0
+        self.submodules.twtpcon = twtpcon = tXXDController(precharge_time)
+        self.comb += twtpcon.valid.eq(cmd.valid & cmd.ready & cmd.is_write)
 
         # Respect tRC activate-activate time
         activate_allowed = Signal(reset=1)
         if settings.timing.tRC is not None:
-            trc_time = settings.timing.tRC - 1
-            trc_timer = WaitTimer(trc_time)
-            self.submodules += trc_timer
-            self.comb += trc_timer.wait.eq(~(cmd.valid & cmd.ready & track_open))
-            self.comb += activate_allowed.eq(trc_timer.done)
+            self.submodules.trccon = trccon = tXXDController(settings.timing.tRC)
+            self.comb += trccon.valid.eq(cmd.valid & cmd.ready & track_open)
+            self.comb += activate_allowed.eq(trccon.ready)
 
         # Respect tRAS activate-precharge time
         precharge_allowed = Signal(reset=1)
         if settings.timing.tRAS is not None:
-            tras_time = settings.timing.tRAS - 1
-            tras_timer = WaitTimer(tras_time)
-            self.submodules += tras_timer
-            self.comb += tras_timer.wait.eq(~(cmd.valid & cmd.ready & track_open))
-            self.comb += precharge_allowed.eq(tras_timer.done)
+            self.submodules.trascon = trascon = tXXDController(settings.timing.tRAS)
+            self.comb += trascon.valid.eq(cmd.valid & cmd.ready & track_open)
+            self.comb += precharge_allowed.eq(trascon.ready)
 
         # Auto Precharge
         if settings.with_auto_precharge:
@@ -194,7 +190,7 @@ class BankMachine(Module):
         )
         fsm.act("PRECHARGE",
             # Note: we are presenting the column address, A10 is always low
-            If(precharge_timer.done & precharge_allowed,
+            If(twtpcon.ready & precharge_allowed,
                 cmd.valid.eq(1),
                 If(cmd.ready,
                     NextState("TRP")
@@ -206,13 +202,13 @@ class BankMachine(Module):
             track_close.eq(1)
         )
         fsm.act("AUTOPRECHARGE",
-            If(precharge_timer.done & precharge_allowed,
+            If(twtpcon.ready & precharge_allowed,
                 NextState("TRP")
             ),
             track_close.eq(1)
         )
         fsm.act("REFRESH",
-            If(precharge_timer.done,
+            If(twtpcon.ready,
                 self.refresh_gnt.eq(1),
             ),
             track_close.eq(1),

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -220,6 +220,7 @@ class BankMachine(Module):
             track_open.eq(1),
             cmd.valid.eq(1),
             cmd.is_cmd.eq(1),
+            cmd.is_activate.eq(1),
             If(cmd.ready,
                 NextState("TRCD")
             ),

--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -61,9 +61,12 @@ class BankMachine(Module):
             cmd_bufferRead.sink.valid.eq(cmd_buffer_lookahead.source.valid & ~cmd_buffer_lookahead.source.we),
             cmd_bufferWrite.sink.valid.eq(cmd_buffer_lookahead.source.valid & cmd_buffer_lookahead.source.we),
 
-            cmd_buffer_lookahead.source.ready.eq(
-                ((cmd_bufferRead.sink.ready | cmd_bufferRead.source.ready) & ~cmd_buffer_lookahead.source.we)
-                | ((cmd_bufferWrite.sink.ready | cmd_bufferWrite.source.ready) & cmd_buffer_lookahead.source.we)),
+            cmd_buffer_lookahead.source.ready.eq(req.rdata_valid | req.wdata_ready
+                | (cmd_buffer_lookahead.source.we & cmd_bufferWrite.source.ready)
+                | (~cmd_buffer_lookahead.source.we & cmd_bufferRead.source.ready)),
+            #cmd_buffer_lookahead.source.ready.eq(
+            #    ((cmd_bufferRead.sink.ready | cmd_bufferRead.source.ready) & ~cmd_buffer_lookahead.source.we)
+            #    | ((cmd_bufferWrite.sink.ready | cmd_bufferWrite.source.ready) & cmd_buffer_lookahead.source.we)),
 
             cmd_bufferRead.source.ready.eq(req.rdata_valid),
             cmd_bufferWrite.source.ready.eq(req.wdata_ready),

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -46,7 +46,7 @@ class _CommandChooser(Module):
             cmd.valid.eq(choices[arbiter.grant])
         ]
 
-        for name in ["a", "ba", "is_read", "is_write", "is_cmd"]:
+        for name in ["a", "ba", "is_read", "is_write", "is_cmd", "is_activate"]:
             choices = Array(getattr(req, name) for req in requests)
             self.comb += getattr(cmd, name).eq(choices[arbiter.grant])
 
@@ -128,29 +128,6 @@ class _Steerer(Module):
                 phase.wrdata_en.eq(wrdata_ens[sel])
             ]
 
-
-class tXXDController(Module):
-    def __init__(self, txxd):
-        self.valid = valid = Signal()
-        self.ready = ready = Signal(reset=1)
-        ready.attr.add("no_retiming")
-
-        # # #
-
-        if txxd is not None:
-            count = Signal(max=max(txxd, 2))
-            self.sync += \
-                If(valid,
-                    count.eq(txxd-1),
-                    If((txxd - 1) == 0,
-                        ready.eq(1)
-                    ).Else(
-                        ready.eq(0)
-                    )
-                ).Elif(~ready,
-                    count.eq(count - 1),
-                    If(count == 1, ready.eq(1))
-                )
 
 
 class tFAWController(Module):

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -201,6 +201,9 @@ class Multiplexer(Module, AutoCSR):
                 choose_req.want_activates.eq(ras_allowed),
             ]
 
+        for bm in bank_machines:
+            self.comb += bm.want_writes.eq(choose_req.want_writes)
+
         # Command steering
         nop = Record(cmd_request_layout(settings.geom.addressbits,
                                         log2_int(len(bank_machines))))

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -72,7 +72,7 @@ class _CommandChooser(Module):
         return self.cmd.valid & self.cmd.ready
 
     def activate(self):
-        return self.cmd.ras & ~self.cmd.cas & ~self.cmd.we
+        return self.cmd.is_activate
 
     def write(self):
         return self.cmd.is_write

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -46,17 +46,9 @@ class _CommandChooser(Module):
             cmd.valid.eq(choices[arbiter.grant])
         ]
 
-        for name in ["a", "ba", "is_read", "is_write", "is_cmd", "is_activate"]:
+        for name in ["a", "ba", "cas", "ras", "we", "is_read", "is_write", "is_cmd", "is_activate"]:
             choices = Array(getattr(req, name) for req in requests)
             self.comb += getattr(cmd, name).eq(choices[arbiter.grant])
-
-        for name in ["cas", "ras", "we"]:
-            # we should only assert those signals when valid is 1
-            choices = Array(getattr(req, name) for req in requests)
-            self.comb += \
-                If(cmd.valid,
-                    getattr(cmd, name).eq(choices[arbiter.grant])
-                )
 
         for i, request in enumerate(requests):
             self.comb += \

--- a/litedram/frontend/crossbar.py
+++ b/litedram/frontend/crossbar.py
@@ -148,10 +148,16 @@ class LiteDRAMCrossbar(Module):
                     new_master_wdata_ready = Signal()
                     self.sync += new_master_wdata_ready.eq(master_wdata_ready)
                     master_wdata_ready = new_master_wdata_ready
-
                     new_master_wbank = Signal(max=self.nbanks)
                     self.sync += new_master_wbank.eq(master_wbank[nm])
                     master_wbank[nm] = new_master_wbank
+                self.comb += self.masters[nm].wdata.ready.eq(master_wdata_ready)
+
+        for nm, master_wdata_ready in enumerate(master_wdata_readys):
+                for i in range(self.write_latency):
+                    new_master_wdata_ready = Signal()
+                    self.sync += new_master_wdata_ready.eq(master_wdata_ready)
+                    master_wdata_ready = new_master_wdata_ready
                 master_wdata_readys[nm] = master_wdata_ready
 
         for nm, master_rdata_valid in enumerate(master_rdata_valids):
@@ -169,8 +175,8 @@ class LiteDRAMCrossbar(Module):
 
         for master, master_ready in zip(self.masters, master_readys):
             self.comb += master.cmd.ready.eq(master_ready)
-        for master, master_wdata_ready in zip(self.masters, master_wdata_readys):
-            self.comb += master.wdata.ready.eq(master_wdata_ready)
+#        for master, master_wdata_ready in zip(self.masters, master_wdata_readys):
+#            self.comb += master.wdata.ready.eq(master_wdata_ready)
         for master, master_rdata_valid in zip(self.masters, master_rdata_valids):
             self.comb += master.rdata.valid.eq(master_rdata_valid)
 

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -41,7 +41,7 @@ class SDRAMModule:
             tWTR=self.ck_ns_to_cycles(*self.get("tWTR")),
             tFAW=None if self.get("tFAW") is None else self.ck_ns_to_cycles(*self.get("tFAW")),
             tCCD=None if self.get("tCCD") is None else self.ck_ns_to_cycles(*self.get("tCCD")),
-            tRRD=None if self.get("tRRD") is None else self.ns_to_cycles_trrd(self.get("tRRD")),
+            tRRD=None if self.get("tRRD") is None else self.ck_ns_to_cycles(*self.get("tRRD")),
             tRC=None if self.get("tRC") is None else self.ns_to_cycles(self.get("tRC")),
             tRAS=None if self.get("tRAS") is None else self.ns_to_cycles(self.get("tRAS"))
         )
@@ -65,20 +65,6 @@ class SDRAMModule:
                     return getattr(self, name)
                 except:
                     return None
-
-
-    def ns_to_cycles_trrd(self, t):
-        lower_bound = {
-            "1:1" : 4,
-            "1:2" : 2,
-            "1:4" : 1
-        }
-        if (t is None):
-            if self.memtype == "DDR3":
-                return lower_bound[self.rate]
-            else:
-                return 0    #Review: Is this needed for DDR2 and below?
-        return max(lower_bound[self.rate], self.ns_to_cycles(t, margin=False))
 
     def ns_to_cycles(self, t, margin=True):
         clk_period_ns = 1e9/self.clk_freq
@@ -216,7 +202,7 @@ class MT41J128M16(SDRAMModule):
     nrows  = 16384
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=10)
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10))
     speedgrade_timings = {
         "800": _SpeedgradeTimings(tRP=13.1, tRCD=13.1, tWR=13.1, tRFC=64, tFAW=(None, 50), tRC=50.625, tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.1, tRCD=13.1, tWR=13.1, tRFC=86, tFAW=(None, 50), tRC=50.625, tRAS=37.5),
@@ -237,7 +223,7 @@ class MT41J256M16(SDRAMModule):
     nrows  = 32768
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=10)
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4,10))
     speedgrade_timings = {
         "800": _SpeedgradeTimings(tRP=13.1, tRCD=13.1, tWR=13.1, tRFC=139, tFAW=(None, 50), tRC=50.625, tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.1, tRCD=13.1, tWR=13.1, tRFC=138, tFAW=(None, 50), tRC=50.625, tRAS=37.5),
@@ -262,7 +248,7 @@ class K4B2G1646FBCK0(SDRAMModule):  ### TODO: optimize and revalidate all timing
     tREFI = 7800  # 3900 refresh more often at 85C+
     tWTR  = (14, 35)
     tCCD  = (4, None)
-    tRRD  = 10  # 4 * clk = 10ns
+    tRRD  = (4, 10)  # 4 * clk = 10ns
     # speedgrade related timings
     # DDR3-1600
     tRP_1600  = 13.125


### PR DESCRIPTION
This is in bank reordering + 1:2 timing fixes.  I've been testing the 1:2 Phy heavily, **I haven't tested 1:4.  This will need to be done prior to merging**.  The 1:4 Phy has different behavior in the bank machine so its quite possible there are issues there.  The changes are quite extensive so I'm issuing the PR early to start discussions.

Analysis shows that the bulk of the delay in random access at speeds achievable by 7 series parts is R/W bus turnarounds.  So this only reorders reads and writes to minimize turnarounds.  I'm seeing 3x improvement in throughput on the random Read+Update pattern. (originally 20%, now 60% bus efficiency).

This reordering does not change the ordering guarantees from the perspective of the client.  We ensure the reads/writes to the same address are issued in sequence and so everyone can benefit.