### PR TITLE
RFC (don't pull yet): Allowing direct access to CSR (I/O) registers

### DIFF
--- a/examples/nexys4ddr_config.py
+++ b/examples/nexys4ddr_config.py
@@ -3,7 +3,7 @@ from litedram.phy import A7DDRPHY
 
 core_config = {
     # General ------------------------------------------------------------------
-    "cpu":        "vexriscv",  # Type of CPU used for init/calib (vexriscv, lm32)
+    "cpu":        "None",  # Type of CPU used for init/calib (vexriscv, lm32)
     "speedgrade": -1,          # FPGA speedgrade
     "memtype":    "DDR2",      # DRAM type
 
@@ -24,7 +24,10 @@ core_config = {
     "cmd_buffer_depth": 16,    # Depth of the command buffer
 
     # User Ports ---------------------------------------------------------------
-    "user_ports_nb":       2,     # Number of user ports
+    "user_ports_nb":       1,     # Number of user ports
     "user_ports_type":     "axi", # Type of ports (axi, native)
-    "user_ports_id_width": 32,    # AXI identifier width
+    "user_ports_id_width": 4,    # AXI identifier width
+
+    # CSR Port -----------------------------------------------------------------
+    "expose_csr_port": "yes", # expose access to CSR (I/O) ports
 }


### PR DESCRIPTION
I'd like to generate a LiteDRAM controller (or, better yet, LiteX "virtual motherboard") exposing an AXI port for the CPU's cached-RAM access, and a "raw" CSR port for I/O. (As an aside, this would fit really well the RocketChip, which routes cached-RAM access over a separate AXI port from the one it uses for MMIO, so it wouldn't make a lot of sense to have both those AXI ports be masters on the same shared interconnect, but I digress :)

I'd like to take advantage of LiteX commit ef1c7784 which introduced the option to expose direct access to the CSR bus, and have modified the litedram_gen script as shown in the accompanying patch.

The one problem I'm having is that I think line 250 of the patch is probably wrong and doesn't actually connect me to the master interface of the CSR bus, but rather generates unconnected wires in the resulting verilog.

Any help connecting to the real CSR bus much appreciated!