### PR TITLE
PhySettings: set missing databits parameter for S6QuarterRateDDRPHY

### DIFF
--- a/litedram/phy/s6ddrphy.py
+++ b/litedram/phy/s6ddrphy.py
@@ -421,6 +421,7 @@ class S6QuarterRateDDRPHY(Module):
 
         self.settings = PhySettings(
             memtype="DDR3",
+            databits=databits,
             dfi_databits=2*databits,
             nranks=nranks,
             nphases=nphases,


### PR DESCRIPTION
It looks like 50e1d478db66570d68316525ecb37bfc434f25c3 missed this one.