### PR TITLE
dma: expose reservation level in the reader

### DIFF
--- a/litedram/frontend/dma.py
+++ b/litedram/frontend/dma.py
@@ -39,6 +39,9 @@ class LiteDRAMDMAReader(Module):
 
     source : Record("data")
         Source for DRAM word results from reading.
+
+    rsv_level: Signal()
+        FIFO reservation level counter
     """
 
     def __init__(self, port, fifo_depth=16, fifo_buffered=False):
@@ -74,15 +77,15 @@ class LiteDRAMDMAReader(Module):
         # incremented when data is planned to be queued
         # decremented when data is dequeued
         data_dequeued = Signal()
-        rsv_level = Signal(max=fifo_depth+1)
+        self.rsv_level = Signal(max=fifo_depth+1)
         self.sync += [
             If(request_issued,
-                If(~data_dequeued, rsv_level.eq(rsv_level + 1))
+                If(~data_dequeued, self.rsv_level.eq(self.rsv_level + 1))
             ).Elif(data_dequeued,
-                rsv_level.eq(rsv_level - 1)
+                self.rsv_level.eq(self.rsv_level - 1)
             )
         ]
-        self.comb += request_enable.eq(rsv_level != fifo_depth)
+        self.comb += request_enable.eq(self.rsv_level != fifo_depth)
 
         # FIFO
         fifo = stream.SyncFIFO([("data", port.data_width)], fifo_depth, fifo_buffered)


### PR DESCRIPTION
I propose to expose the rsv_level of LiteDRAMDMAReader as an attribute.
This change does not break anything and allows for example to start burst read operations only when the FIFO has enough data:

dma_reader = LiteDRAMDMAReader(...)
read_trigger.eq(dma_reader.rsv_level >= video_line_width)