### PR TITLE
modules: Add support for Micron MT47H32M16 DDR2 RAM

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -218,6 +218,17 @@ class MT47H128M8(SDRAMModule):
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 127.5), tFAW=None, tRAS=None)}
 
 
+class MT47H32M16(SDRAMModule):
+    memtype = "DDR2"
+    # geometry
+    nbanks = 4
+    nrows  = 8192
+    ncols  = 1024
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(None, 7.5), tCCD=(2, None), tRRD=None)
+    speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 127.5), tFAW=None, tRAS=None)}
+
+
 class MT47H64M16(SDRAMModule):
     memtype = "DDR2"
     # geometry


### PR DESCRIPTION
Hi,
this adds support for the Micron MT47H32M16 family of DDR2 RAMs.
They are (except for being half the size and having half the bank count) identical to the MT47H64M16 already supported, so they could also be written with less duplication.