### PR TITLE
frontend/[axi,wishbone]: add data_width match assertion, add base_address to LiteDRAMWishbone2Native

### DIFF
--- a/litedram/frontend/axi.py
+++ b/litedram/frontend/axi.py
@@ -32,6 +32,7 @@ class LiteDRAMAXIPort(AXIInterface):
 class LiteDRAMAXI2NativeW(Module):
     def __init__(self, axi, port, buffer_depth, base_address):
         assert axi.address_width >= log2_int(base_address)
+        assert axi.data_width == port.data_width
         self.cmd_request = Signal()
         self.cmd_grant = Signal()
 
@@ -99,6 +100,7 @@ class LiteDRAMAXI2NativeW(Module):
 class LiteDRAMAXI2NativeR(Module):
     def __init__(self, axi, port, buffer_depth, base_address):
         assert axi.address_width >= log2_int(base_address)
+        assert axi.data_width == port.data_width
         self.cmd_request = Signal()
         self.cmd_grant = Signal()
 

--- a/litedram/frontend/wishbone.py
+++ b/litedram/frontend/wishbone.py
@@ -7,10 +7,12 @@ from migen import *
 
 
 class LiteDRAMWishbone2Native(Module):
-    def __init__(self, wishbone, port):
+    def __init__(self, wishbone, port, base_address=0x00000000):
         assert len(wishbone.dat_w) == len(port.wdata.data)
 
         # # #
+
+        adr_offset = base_address >> log2_int(port.data_width//8)
 
         # Control
         self.submodules.fsm = fsm = FSM(reset_state="CMD")
@@ -43,7 +45,7 @@ class LiteDRAMWishbone2Native(Module):
         # Datapath
         self.comb += [
             # cmd
-            port.cmd.addr.eq(wishbone.adr),
+            port.cmd.addr.eq(wishbone.adr - adr_offset),
             # write
             port.wdata.we.eq(wishbone.sel),
             port.wdata.data.eq(wishbone.dat_w),


### PR DESCRIPTION
Rocket's 'mem_axi' and LiteDRAM's native ports both happen to have the same (64-bit) data width, (EDIT: true only on the nexys4ddr -- on the versa, liteDRAM is 128bit!) and therefore can be connected together using LiteDRAMAXI2Native() (see https://github.com/enjoy-digital/litex/pull/284).

However, we should ensure that axi and native ports have the same data width, in case we ever end up trying to connect interfaces with non-matching data width!