### PR TITLE
init: improve legibility of generated/sdram_phy.h (cosmetic)

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -416,19 +416,19 @@ __attribute__((unused)) static void command_p{n}(int cmd)
     for n in range(nphases):
         sdram_dfii_pix_wrdata_addr.append("CSR_SDRAM_DFII_PI{n}_WRDATA_ADDR".format(n=n))
     r += """
-const unsigned long sdram_dfii_pix_wrdata_addr[{n}] = {{
-    {sdram_dfii_pix_wrdata_addr}
+const unsigned long sdram_dfii_pix_wrdata_addr[DFII_NPHASES] = {{
+\t{sdram_dfii_pix_wrdata_addr}
 }};
-""".format(n=nphases, sdram_dfii_pix_wrdata_addr=",\n\t".join(sdram_dfii_pix_wrdata_addr))
+""".format(sdram_dfii_pix_wrdata_addr=",\n\t".join(sdram_dfii_pix_wrdata_addr))
 
     sdram_dfii_pix_rddata_addr = []
     for n in range(nphases):
         sdram_dfii_pix_rddata_addr.append("CSR_SDRAM_DFII_PI{n}_RDDATA_ADDR".format(n=n))
     r += """
-const unsigned long sdram_dfii_pix_rddata_addr[{n}] = {{
-    {sdram_dfii_pix_rddata_addr}
+const unsigned long sdram_dfii_pix_rddata_addr[DFII_NPHASES] = {{
+\t{sdram_dfii_pix_rddata_addr}
 }};
-""".format(n=nphases, sdram_dfii_pix_rddata_addr=",\n\t".join(sdram_dfii_pix_rddata_addr))
+""".format(sdram_dfii_pix_rddata_addr=",\n\t".join(sdram_dfii_pix_rddata_addr))
     r += "\n"
 
     init_sequence, mr1 = get_sdram_phy_init_sequence(phy_settings, timing_settings)


### PR DESCRIPTION
Use DFII_NPHASES constant (defined earlier in the file) to size the
two 'sdram_dfii_pix_[wrdata|rddata]_addr' arrays, instead of a bare
number. Additionally, ensure the first array element is indented by
a tab, same as the ones following it.
