### PR TITLE
add 32MB SDRAM for hadbadge

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -190,6 +190,15 @@ class AS4C32M16(SDRAMModule):
     technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=None)
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=18, tRCD=18, tWR=12, tRFC=(None, 60), tFAW=None, tRAS=None)}
 
+class AS4C32M8(SDRAMModule):
+    memtype = "SDR"
+    # geometry
+    nbanks = 4
+    nrows  = 8192
+    ncols  = 1024
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 15))
+    speedgrade_timings = {"default": _SpeedgradeTimings(tRP=20, tRCD=20, tWR=15, tRFC=(None, 66), tFAW=None, tRAS=44)}
 
 # DDR ----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Add AS4C32M8SA-7TCN 32MB SDRAM used on cartridge PCB by Jacob Creedon (@jcreedon) for the [Hackaday Supercon 2019 badge](https://hackaday.io/project/167255-2019-hackaday-superconference-badge) which has an ECP5 FPGA.

These changes are from [a fork](https://github.com/mwelling/litedram) by Michael Welling (@mwelling)

In addition to @mwelling, thank you to Jacob Creedon (@jcreedon), @GregDavill, Tim Ansell (@mithro), and Sean Cross (@xobs) who all helped get Linux working on this badge.

KiCad design files by @jcreedon for the SDRAM cartridge are [available on GitHub](https://github.com/jcreedon/dram-cart/).

There is also a [shared project](https://oshpark.com/shared_projects/IQSl2lid) to order the SDRAM cartridge PCB.

Refer to [my blog post](https://blog.oshpark.com/2019/12/20/boot-linux-on-this-hackaday-supercon-badge-with-this-sdram-cartridge/) for more information.