### PR TITLE
ADD: KX2 DDR3 module

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -375,6 +375,19 @@ class K4B2G1646F(SDRAMModule):
     }
     speedgrade_timings["default"] = speedgrade_timings["1600"]
 
+class H5TC4G63CFR(SDRAMModule):
+    memtype = "DDR3"
+    # geometry
+    nbanks = 8
+    nrows  = 16384
+    ncols  = 1024
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 7.5), tZQCS=(64, 80))
+    speedgrade_timings = {
+        "800":  _SpeedgradeTimings(tRP=15,     tRCD=15,     tWR=15, tRFC=(260, None), tFAW=(None, 40), tRAS=37.5),
+    }
+    speedgrade_timings["default"] = speedgrade_timings["800"]
+
 
 class IS43TR16128B(SDRAMModule):
     memtype = "DDR3"


### PR DESCRIPTION
This PR adds support for the H5TC4G63CFR DDR3 RAM module used on the enclustra KX2 board as specified here:
https://www.enclustra.com/en/products/fpga-modules/mercury-kx2/