### PR TITLE
Count ACTIVATE commands in Bandwidth

### DIFF
--- a/litedram/core/bandwidth.py
+++ b/litedram/core/bandwidth.py
@@ -51,10 +51,10 @@ class Bandwidth(Module, AutoCSR):
 
         self.sync += [
             Cat(counter, period).eq(counter + 1),
-            If(period,
-                nreads_r.eq(nreads),
-                nwrites_r.eq(nwrites),
-                nacts_r.eq(nacts),
+            If(self.update.re,
+                self.nreads.status.eq(nreads),
+                self.nwrites.status.eq(nwrites),
+                self.nactivates.status.eq(nacts),
                 nreads.eq(0),
                 nwrites.eq(0),
                 nacts.eq(0),
@@ -63,13 +63,8 @@ class Bandwidth(Module, AutoCSR):
                     If(cmd_is_read, nreads.eq(nreads + 1)),
                     If(cmd_is_write, nwrites.eq(nwrites + 1)),
                 ),
-                If(cmd_act_valid, & cmd_act_ready,
+                If(cmd_act_valid,  # cmd_act_ready never gets activated
                     If(cmd_act_is_act, nacts.eq(nacts + 1))
                 )
             ),
-            If(self.update.re,
-                self.nreads.status.eq(nreads_r),
-                self.nwrites.status.eq(nwrites_r),
-                self.nactivates.status.eq(nacts_r),
-            )
         ]

--- a/litedram/core/controller.py
+++ b/litedram/core/controller.py
@@ -25,7 +25,7 @@ class ControllerSettings(Settings):
         write_time          = 16,
 
         # Bandwidth
-        with_bandwidth      = False,
+        with_bandwidth      = True,
 
         # Refresh
         with_refresh        = True,

--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -327,4 +327,4 @@ class Multiplexer(Module, AutoCSR):
 
         if settings.with_bandwidth:
             data_width = settings.phy.dfi_databits*settings.phy.nphases
-            self.submodules.bandwidth = Bandwidth(self.choose_req.cmd, data_width)
+            self.submodules.bandwidth = Bandwidth(self.choose_req.cmd, self.choose_cmd.cmd, data_width)


### PR DESCRIPTION
This adds a register that counts activates so that we can measure bus efficiency.

As far as I understand it was not possible to refresh counters until period elapses, so software would have to constantly write to `update` and check if counters have been reset. I've changed the logic so that writing to `update` resets the counters for the sake of benchmarking. This allows to reset counters before starting benchmark, but this breaks bandwidth measurements. 
Should I create separate CSR that will be updated in this manner and leave the previous logic intact?