### PR TITLE
phy/model: add burst_length value for ddr4 memories

### DIFF
--- a/litedram/phy/model.py
+++ b/litedram/phy/model.py
@@ -117,6 +117,7 @@ class SDRAMPHYModel(Module):
             "LPDDR": 2,
             "DDR2":  2,
             "DDR3":  2,
+            "DDR4":  2,
             }[settings.memtype]
 
         addressbits   = module.geom_settings.addressbits


### PR DESCRIPTION
It appears that only thing that prevents us from using this model with DDR4 memories is `burst_length` value, initially I've set it to 2 as this value is used by all DDR memory types.