### PR TITLE
modules: MT18KSF1G72HZ: use float as tWR value

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -467,7 +467,7 @@ class MT18KSF1G72HZ(SDRAMModule):
     speedgrade_timings = {
         "1066": _SpeedgradeTimings(tRP=15,     tRCD=15,     tWR=15,             tRFC=(86,  None), tFAW=(None, 50), tRAS=None),
         "1333": _SpeedgradeTimings(tRP=15,     tRCD=15,     tWR=15,             tRFC=(107, None), tFAW=(None, 45), tRAS=None),
-        "1600": _SpeedgradeTimings(tRP=13.125, tRCD=13.125, tWR=(13.125, None), tRFC=(128, None), tFAW=(None, 40), tRAS=None),
+        "1600": _SpeedgradeTimings(tRP=13.125, tRCD=13.125, tWR=13.125,         tRFC=(128, None), tFAW=(None, 40), tRAS=None),
     }
     speedgrade_timings["default"] = speedgrade_timings["1600"]
 


### PR DESCRIPTION
Fixes error:

```
$ litex_sim --with-sdram --sdram-module MT18KSF1G72HZ
Traceback (most recent call last):
  File "bin/litex_sim", line 11, in <module>
    load_entry_point('litex', 'console_scripts', 'litex_sim')()
  File "litex/litex/tools/litex_sim.py", line 301, in main
    **soc_kwargs)
  File "litex/litex/tools/litex_sim.py", line 187, in __init__
    sdram_module     = sdram_module_cls(sdram_clk_freq, sdram_rate)
  File "litedram/litedram/modules.py", line 65, in __init__
  File "litedram/litedram/modules.py", line 110, in ns_to_cycles
TypeError: can only concatenate tuple (not "float") to tuple
```