### PR TITLE
Improve speed of benchmark runner

### DIFF
--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -3,6 +3,10 @@
 # This file is Copyright (c) 2020 Jędrzej Boczar <jboczar@antmicro.com>
 # License: BSD
 
+# Limitations/TODO
+# - add configurable sdram_clk_freq - using hardcoded value now
+# - sdram_controller_data_width - try to expose the value from litex_sim to avoid duplicated code
+
 import os
 import re
 import sys
@@ -388,7 +392,7 @@ class ResultsSummary:
 
         return axis
 
-    def failuers_summary(self):
+    def failures_summary(self):
         if len(self.failed_configs) > 0:
             print(self.header('Failures:'))
             for config in self.failed_configs:
@@ -523,7 +527,7 @@ def main(argv=None):
     if _summary:
         summary = ResultsSummary(run_data)
         summary.text_summary()
-        summary.failuers_summary()
+        summary.failures_summary()
         if args.plot:
             summary.plot_summary(
                 plots_dir=args.plot_output_dir,

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -362,21 +362,29 @@ class ResultsSummary:
         if backend != 'Agg':
             plt.show()
 
-    def plot_df(self, title, df, column, save_format='png', save_filename=None):
+    def plot_df(self, title, df, column, fig_width=6.4, fig_min_height=2.2, save_format='png', save_filename=None):
         if save_filename is None:
             save_filename = os.path.join(self.plots_dir, title.lower().replace(' ', '_'))
 
         axis = df.plot(kind='barh', x='name', y=column, title=title, grid=True, legend=False)
+        fig = axis.get_figure()
+
         if column in self.plot_xticks_formatters:
             axis.xaxis.set_major_formatter(self.plot_xticks_formatters[column])
             axis.xaxis.set_tick_params(rotation=15)
         axis.spines['top'].set_visible(False)
         axis.spines['right'].set_visible(False)
         axis.set_axisbelow(True)
+        axis.set_ylabel('')  # no need for label as we have only one series
 
-        #  # force xmax to 100%
-        #  if column in ['write_efficiency', 'read_efficiency']:
-        #      axis.set_xlim(right=1.0)
+        # for large number of rows, the bar labels start overlapping
+        # use fixed ratio between number of rows and height of figure
+        n_ok = 16
+        new_height = (fig_width / n_ok) * len(df)
+        fig.set_size_inches(fig_width, max(fig_min_height, new_height))
+
+        # remove empty spaces
+        fig.tight_layout()
 
         return axis
 


### PR DESCRIPTION
These changes should significantly speed up the process of running benchmarks and generating summary:
1. We can run benchmarks as parallel jobs using `multiprocessing`, by default `os.cpu_count()` is used, but it can be controller with `--njobs`.
2. By default, we continue running even if some benchmarks fail, and a summary of failures will be displayed at the end. `--fail-fast` can be specified if we want to exit on any error.
3. Removed the code that instantiated `LiteDRAMBenchmarkSoC`, as it was taking a lot of time to do it for each configuration.
4.  I've fixed problem with plots being unreadable when there are too many entries; now we just increase figure size as needed.

About 3:
`LiteDRAMBenchmarkSoC` was only used to retrieve clock frequency and interface data width. Now data width is just calculated from SDRAM module class and the clock frequency is hardcoded as it is done [here](https://github.com/enjoy-digital/litex/blob/1d70ef6958bfc11cafc80d29e0ad5550d9d0fc89/litex/tools/litex_sim.py#L184) in `litex_sim.py`. 
Maybe we could avoid hard coding it, by exposing this frequency as a global variable in `litex_sim.py` and importing it here? This would at least fail fast if the variable was removed in `litex_sim.py`, but maybe there exists a better solution.