### PR TITLE
Benchmark: add simultaneous Write/Read and random address generation

### DIFF
--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -29,6 +29,7 @@ class LiteDRAMBenchmarkSoC(SimSoC):
         bist_base        = 0x00000000,
         bist_length      = 1024,
         bist_random      = False,
+        bist_alternating = False,
         pattern_init     = None,
         **kwargs):
 
@@ -58,13 +59,16 @@ class LiteDRAMBenchmarkSoC(SimSoC):
                 bist_checker.length.eq(bist_length),
                 bist_checker.random.eq(bist_random),
             ]
+
+            assert not (bist_random and not bist_alternating), \
+                'Write to random address may overwrite previously written data before reading!'
         else:
-            # TODO: run checker in parallel to avoid overwriting previously written data
-            address_set = set()
-            for addr, _ in pattern_init:
-                assert addr not in address_set, \
-                    'Duplicate address 0x%08x in pattern_init, write will overwrite previous value!' % addr
-                address_set.add(addr)
+            if not bist_alternating:
+                address_set = set()
+                for addr, _ in pattern_init:
+                    assert addr not in address_set, \
+                        'Duplicate address 0x%08x in pattern_init, write will overwrite previous value!' % addr
+                    address_set.add(addr)
 
             bist_generator = _LiteDRAMPatternGenerator(self.sdram.crossbar.get_port(), init=pattern_init)
             bist_checker = _LiteDRAMPatternChecker(self.sdram.crossbar.get_port(), init=pattern_init)
@@ -89,20 +93,36 @@ class LiteDRAMBenchmarkSoC(SimSoC):
                 NextState("BIST-GENERATOR")
             )
         )
-        fsm.act("BIST-GENERATOR",
-            bist_generator.start.eq(1),
-            *generator_config,
-            If(bist_generator.done,
-                NextState("BIST-CHECKER")
+        if bist_alternating:
+            fsm.act("BIST-GENERATOR",
+                bist_generator.start.eq(1),
+                bist_checker.start.eq(1),
+                # force generator to wait for checker and vice versa
+                bist_generator.run.eq(bist_checker.ready),
+                bist_checker.run.eq(bist_generator.ready),
+                *generator_config,
+                *checker_config,
+                If(bist_checker.done,
+                    NextState("DISPLAY")
+                )
             )
-        )
-        fsm.act("BIST-CHECKER",
-            bist_checker.start.eq(1),
-            *checker_config,
-            If(bist_checker.done,
-                NextState("DISPLAY")
+        else:
+            fsm.act("BIST-GENERATOR",
+                bist_generator.start.eq(1),
+                bist_generator.run.eq(1),
+                *generator_config,
+                If(bist_generator.done,
+                    NextState("BIST-CHECKER")
+                )
             )
-        )
+            fsm.act("BIST-CHECKER",
+                bist_checker.start.eq(1),
+                bist_checker.run.eq(1),
+                *checker_config,
+                If(bist_checker.done,
+                    NextState("DISPLAY")
+                )
+            )
         fsm.act("DISPLAY",
             display.eq(1),
             NextState("FINISH")
@@ -149,6 +169,7 @@ def main():
     parser.add_argument("--bist-base",        default="0x00000000",   help="Base address of the test (default=0)")
     parser.add_argument("--bist-length",      default="1024",         help="Length of the test (default=1024)")
     parser.add_argument("--bist-random",      action="store_true",    help="Use random data during the test")
+    parser.add_argument("--bist-alternating", action="store_true",    help="Perform alternating writes/reads (WRWRWR... instead of WWW...RRR...)")
     parser.add_argument("--access-pattern",                           help="Load access pattern (address, data) from CSV (ignores --bist-*)")
     args = parser.parse_args()
 
@@ -164,6 +185,7 @@ def main():
     soc_kwargs["bist_base"]        = int(args.bist_base, 0)
     soc_kwargs["bist_length"]      = int(args.bist_length, 0)
     soc_kwargs["bist_random"]      = args.bist_random
+    soc_kwargs["bist_alternating"] = args.bist_alternating
 
     if args.access_pattern:
         soc_kwargs["pattern_init"] = load_access_pattern(args.access_pattern)

--- a/test/benchmarks.yml
+++ b/test/benchmarks.yml
@@ -5,7 +5,7 @@
         "bist_alternating": true,
         "access_pattern": {
             "bist_length": 1,
-            "bist_random": false
+            "bist_random": true
         }
     },
     "test_1": {
@@ -13,7 +13,7 @@
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 1024,
+            "bist_length": 1,
             "bist_random": false
         }
     },
@@ -22,59 +22,59 @@
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": false
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_3": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 1,
+            "bist_length": 1024,
             "bist_random": false
         }
     },
     "test_4": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 1024,
-            "bist_random": false
+            "bist_length": 8192,
+            "bist_random": true
         }
     },
     "test_5": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
             "bist_length": 8192,
             "bist_random": false
         }
     },
     "test_6": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
         "access_pattern": {
             "bist_length": 1,
             "bist_random": false
         }
     },
     "test_7": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": false
         }
     },
     "test_8": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
         "access_pattern": {
             "bist_length": 8192,
             "bist_random": false
@@ -83,41 +83,32 @@
     "test_9": {
         "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
             "bist_length": 1,
-            "bist_random": false
+            "bist_random": true
         }
     },
     "test_10": {
         "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 1024,
+            "bist_length": 1,
             "bist_random": false
         }
     },
     "test_11": {
         "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": false
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_12": {
-        "sdram_module": "MT47H64M16",
-        "sdram_data_width": 32,
-        "bist_alternating": true,
-        "access_pattern": {
-            "bist_length": 1,
-            "bist_random": false
-        }
-    },
-    "test_13": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
@@ -125,8 +116,17 @@
             "bist_random": false
         }
     },
+    "test_13": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": true
+        }
+    },
     "test_14": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
@@ -135,7 +135,7 @@
         }
     },
     "test_15": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
         "access_pattern": {
@@ -144,7 +144,7 @@
         }
     },
     "test_16": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
         "access_pattern": {
@@ -153,7 +153,7 @@
         }
     },
     "test_17": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
         "access_pattern": {
@@ -162,105 +162,111 @@
         }
     },
     "test_18": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
             "bist_length": 1,
-            "bist_random": false
+            "bist_random": true
         }
     },
     "test_19": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 1024,
+            "bist_length": 1,
             "bist_random": false
         }
     },
     "test_20": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": false
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_21": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
-        "access_pattern": {
-            "bist_length": 1,
-            "bist_random": false
-        }
-    },
-    "test_22": {
-        "sdram_module": "MT48LC16M16",
-        "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": false
         }
     },
-    "test_23": {
-        "sdram_module": "MT48LC16M16",
+    "test_22": {
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": true
+        }
+    },
+    "test_23": {
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
         "access_pattern": {
             "bist_length": 8192,
             "bist_random": false
         }
     },
     "test_24": {
-        "sdram_module": "MT41K128M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1,
+            "bist_random": false
         }
     },
     "test_25": {
-        "sdram_module": "MT41K128M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1024,
+            "bist_random": false
         }
     },
     "test_26": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT47H64M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 8192,
+            "bist_random": false
         }
     },
     "test_27": {
-        "sdram_module": "MT46V32M16",
-        "sdram_data_width": 32,
-        "bist_alternating": false,
-        "access_pattern": {
-            "pattern_file": "access_pattern.csv"
-        }
-    },
-    "test_28": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT48LC16M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_28": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
         }
     },
     "test_29": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT48LC16M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_30": {
@@ -268,10 +274,112 @@
         "sdram_data_width": 32,
         "bist_alternating": true,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1024,
+            "bist_random": false
         }
     },
     "test_31": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": true
+        }
+    },
+    "test_32": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
+    },
+    "test_33": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_34": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_35": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
+    },
+    "test_36": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_37": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_38": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_39": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_40": {
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_41": {
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_42": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_43": {
         "sdram_module": "MT48LC16M16",
         "sdram_data_width": 32,
         "bist_alternating": false,

--- a/test/benchmarks.yml
+++ b/test/benchmarks.yml
@@ -1,193 +1,282 @@
 {
-    # sequential access
     "test_0": {
-      "sdram_module":     'MT48LC16M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      4096,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_1": {
-      "sdram_module":     'MT48LC16M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      512,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_2": {
-      "sdram_module":     'MT46V32M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      512,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
     "test_3": {
-      "sdram_module":     'MT46V32M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      2048,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_4": {
-      "sdram_module":     'MT47H64M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_5": {
-      "sdram_module":     'MT47H64M16',
-      "sdram_data_width": 16,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
     "test_6": {
-      "sdram_module":     'MT41K128M16',
-      "sdram_data_width": 16,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_7": {
-      "sdram_module":     'MT41K128M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
-
-    # latency
     "test_8": {
-      "sdram_module":     'MT48LC16M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
     "test_9": {
-      "sdram_module":     'MT46V32M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_10": {
-      "sdram_module":     'MT47H64M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_11": {
-      "sdram_module":     'MT41K128M16',
-      "sdram_data_width": 16,
-      "access_pattern":   {
-        "bist_length":      1,
-        "bist_random":      False,
-      }
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
-
-    # random access
     "test_12": {
-      "sdram_module":     'MT48LC16M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      True,
-      }
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_13": {
-      "sdram_module":     'MT46V32M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      True,
-      }
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_14": {
-      "sdram_module":     'MT47H64M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      True,
-      }
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
     "test_15": {
-      "sdram_module":     'MT41K128M16',
-      "sdram_data_width": 16,
-      "access_pattern":   {
-        "bist_length":      1024,
-        "bist_random":      True,
-      }
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
-
-    # custom access pattern
     "test_16": {
-      "sdram_module":     'MT48LC16M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv"
-      }
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_17": {
-      "sdram_module":     'MT48LC16M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
     "test_18": {
-      "sdram_module":     'MT46V32M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_19": {
-      "sdram_module":     'MT46V32M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_20": {
-      "sdram_module":     'MT47H64M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
     "test_21": {
-      "sdram_module":     'MT47H64M16',
-      "sdram_data_width": 16,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
     },
     "test_22": {
-      "sdram_module":     'MT41K128M16',
-      "sdram_data_width": 16,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
     },
     "test_23": {
-      "sdram_module":     'MT41K128M16',
-      "sdram_data_width": 32,
-      "access_pattern":   {
-        "pattern_file":   "access_pattern.csv",
-      }
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "bist_length": 8192,
+            "bist_random": false
+        }
     },
+    "test_24": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_25": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_26": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_27": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_28": {
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_29": {
+        "sdram_module": "MT47H64M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_30": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_31": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    }
 }

--- a/test/gen_config.py
+++ b/test/gen_config.py
@@ -42,7 +42,7 @@ default_modules = [
 default_bist_alternatings = [True, False]
 default_data_widths = [32]
 default_bist_lengths = [1, 1024, 8192]
-default_bist_randoms = [False]
+default_bist_randoms = [True, False]
 default_access_patterns = ['access_pattern.csv']
 
 

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -438,7 +438,7 @@ def run_single_benchmark(func_args):
         # exit if checker had any read error
         if result.checker_errors != 0:
             raise RuntimeError('Error during benchmark: checker_errors = {}, args = {}'.format(
-                result.checker_errors, args
+                result.checker_errors, config.as_args()
             ))
     except Exception as e:
         if ignore_failures:

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -87,7 +87,7 @@ class CustomAccess(Settings):
 
 
 class BenchmarkConfiguration(Settings):
-    def __init__(self, name, sdram_module, sdram_data_width, access_pattern):
+    def __init__(self, name, sdram_module, sdram_data_width, bist_alternating, access_pattern):
         self.set_attributes(locals())
 
     def as_args(self):
@@ -95,6 +95,8 @@ class BenchmarkConfiguration(Settings):
             '--sdram-module=%s' % self.sdram_module,
             '--sdram-data-width=%d' % self.sdram_data_width,
         ]
+        if self.bist_alternating:
+            args.append('--bist-alternating')
         args += self.access_pattern.as_args()
         return args
 
@@ -219,6 +221,7 @@ class ResultsSummary:
             'name':             lambda d: d.config.name,
             'sdram_module':     lambda d: d.config.sdram_module,
             'sdram_data_width': lambda d: d.config.sdram_data_width,
+            'bist_alternating': lambda d: d.config.bist_alternating,
             'bist_length':      lambda d: getattr(d.config.access_pattern, 'bist_length', None),
             'bist_random':      lambda d: getattr(d.config.access_pattern, 'bist_random', None),
             'pattern_file':     lambda d: getattr(d.config.access_pattern, 'pattern_file', None),
@@ -310,7 +313,7 @@ class ResultsSummary:
 
         formatters = self.text_formatters if formatted else {}
 
-        common_columns = ['name', 'sdram_module', 'sdram_data_width']
+        common_columns = ['name', 'sdram_module', 'sdram_data_width', 'bist_alternating']
         latency_columns = ['write_latency', 'read_latency']
         performance_columns = ['write_bandwidth', 'read_bandwidth', 'write_efficiency', 'read_efficiency']
 
@@ -319,12 +322,6 @@ class ResultsSummary:
             columns=common_columns + latency_columns,
             column_formatting=formatters,
         )
-        #  yield 'Any access pattern', self.get_summary(
-        #      mask=(df['is_latency'] == False),
-        #      columns=common_columns + performance_columns + ['length', 'bist_random', 'pattern_file'],
-        #      column_formatting=self.text_formatters,
-            #  **kwargs,
-        #  ),
         yield 'Custom access pattern', self.get_summary(
             mask=(df['is_latency'] == False) & (~pd.isna(df['pattern_file'])),
             columns=common_columns + performance_columns + ['length', 'pattern_file'],

--- a/test/test_bist.py
+++ b/test/test_bist.py
@@ -31,7 +31,9 @@ class GenCheckDriver:
 
     def run(self, base, length):
         yield self.module.base.eq(base)
+        yield self.module.end.eq(base + 0x100000)
         yield self.module.length.eq(length)
+        yield self.module.run.eq(1)
         yield self.module.start.eq(1)
         yield
         yield self.module.start.eq(0)


### PR DESCRIPTION
Closes https://github.com/enjoy-digital/litedram/issues/133.
Partially implements https://github.com/enjoy-digital/litedram/issues/114 (still single generator and checker).

I've added random address generation as suggested in https://github.com/enjoy-digital/litedram/issues/133, but limiting values makes them not unique, so to actually use such generator, I had to also implement simultaneous write/read.

To allow for alternating write/read patterns, I added `run` and `ready` signals to generators and checkers. When `run` is low, generator will stop writing/reading and go to `WAIT` state until `run` is high again. To have the previous behaviour, we can just set `run.eq(1)`, and by cross-connecting the signals between generator and checker, we can make them perform alternating write/read. 

Currently it is still not possible to run non-alternating write/read with random addressing, as the data will get overwritten before checker reads it, so there is an assertion in `benchmark.py`.

I've also updated benchmark configuration, runner and summary generation to include these new options.