### PR TITLE
Benchmark: use variable number of BIST generators/checkers

### DIFF
--- a/litedram/frontend/bist.py
+++ b/litedram/frontend/bist.py
@@ -324,17 +324,17 @@ class LiteDRAMBISTGenerator(Module, AutoCSR):
     """
     def __init__(self, dram_port):
         ashift, awidth = get_ashift_awidth(dram_port)
-        self.reset  = CSR()
-        self.start  = CSR()
-        self.done   = CSRStatus()
+        self.reset       = CSR()
+        self.start       = CSR()
+        self.done        = CSRStatus()
         self.run         = CSRStorage()
         self.ready       = CSRStatus()
-        self.base   = CSRStorage(awidth)
+        self.base        = CSRStorage(awidth)
         self.end         = CSRStorage(awidth)
-        self.length = CSRStorage(awidth)
+        self.length      = CSRStorage(awidth)
         self.random_data = CSRStorage()
         self.random_addr = CSRStorage()
-        self.ticks  = CSRStatus(32)
+        self.ticks       = CSRStatus(32)
 
         # # #
 
@@ -675,18 +675,18 @@ class LiteDRAMBISTChecker(Module, AutoCSR):
     """
     def __init__(self, dram_port):
         ashift, awidth = get_ashift_awidth(dram_port)
-        self.reset  = CSR()
-        self.start  = CSR()
-        self.done   = CSRStatus()
+        self.reset       = CSR()
+        self.start       = CSR()
+        self.done        = CSRStatus()
         self.run         = CSRStorage()
         self.ready       = CSRStatus()
-        self.base   = CSRStorage(awidth)
+        self.base        = CSRStorage(awidth)
         self.end         = CSRStorage(awidth)
-        self.length = CSRStorage(awidth)
+        self.length      = CSRStorage(awidth)
         self.random_data = CSRStorage()
         self.random_addr = CSRStorage()
-        self.ticks  = CSRStatus(32)
-        self.errors = CSRStatus(32)
+        self.ticks       = CSRStatus(32)
+        self.errors      = CSRStatus(32)
 
         # # #
 

--- a/test/benchmarks.yml
+++ b/test/benchmarks.yml
@@ -1,8 +1,23 @@
+# ============================================================
+# Auto-generated on 2020-02-12 15:41:38 by ./gen_config.py
+# ------------------------------------------------------------
+# {'name_format': 'test_%d',
+#  'sdram_module': ['MT41K128M16', 'MT46V32M16', 'MT48LC16M16'],
+#  'sdram_data_width': [32],
+#  'bist_alternating': [True, False],
+#  'bist_length': [1, 1024],
+#  'bist_random': [True, False],
+#  'num_generators': [1, 3],
+#  'num_checkers': [1, 3],
+#  'access_pattern': ['access_pattern.csv']}
+# ============================================================
 {
     "test_0": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1,
             "bist_random": true
@@ -12,6 +27,8 @@
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1,
             "bist_random": false
@@ -21,6 +38,8 @@
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": true
@@ -30,6 +49,8 @@
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": false
@@ -39,8 +60,10 @@
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1,
             "bist_random": true
         }
     },
@@ -48,24 +71,30 @@
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1,
             "bist_random": false
         }
     },
     "test_6": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 1,
-            "bist_random": false
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_7": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": false
@@ -74,315 +103,943 @@
     "test_8": {
         "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": false
+            "bist_length": 1,
+            "bist_random": true
         }
     },
     "test_9": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1,
-            "bist_random": true
+            "bist_random": false
         }
     },
     "test_10": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 1,
-            "bist_random": false
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_11": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1024,
-            "bist_random": true
+            "bist_random": false
         }
     },
     "test_12": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 1024,
-            "bist_random": false
-        }
-    },
-    "test_13": {
-        "sdram_module": "MT46V32M16",
-        "sdram_data_width": 32,
-        "bist_alternating": true,
-        "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1,
             "bist_random": true
         }
     },
-    "test_14": {
-        "sdram_module": "MT46V32M16",
+    "test_13": {
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1,
             "bist_random": false
         }
     },
-    "test_15": {
-        "sdram_module": "MT46V32M16",
+    "test_14": {
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 1,
+            "bist_length": 1024,
+            "bist_random": true
+        }
+    },
+    "test_15": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
             "bist_random": false
         }
     },
     "test_16": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 1024,
+            "bist_length": 1,
             "bist_random": false
         }
     },
     "test_17": {
-        "sdram_module": "MT46V32M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1024,
             "bist_random": false
         }
     },
     "test_18": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
-        "access_pattern": {
-            "bist_length": 1,
-            "bist_random": true
-        }
-    },
-    "test_19": {
-        "sdram_module": "MT47H64M16",
-        "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
             "bist_length": 1,
             "bist_random": false
         }
     },
-    "test_20": {
-        "sdram_module": "MT47H64M16",
+    "test_19": {
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
             "bist_length": 1024,
-            "bist_random": true
+            "bist_random": false
+        }
+    },
+    "test_20": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
         }
     },
     "test_21": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": false
         }
     },
     "test_22": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": true
+            "bist_length": 1,
+            "bist_random": false
         }
     },
     "test_23": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT41K128M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1024,
             "bist_random": false
         }
     },
     "test_24": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1,
-            "bist_random": false
+            "bist_random": true
         }
     },
     "test_25": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 1024,
+            "bist_length": 1,
             "bist_random": false
         }
     },
     "test_26": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": false
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_27": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "bist_length": 1,
-            "bist_random": true
+            "bist_length": 1024,
+            "bist_random": false
         }
     },
     "test_28": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_29": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
             "bist_length": 1,
             "bist_random": false
         }
     },
-    "test_29": {
-        "sdram_module": "MT48LC16M16",
+    "test_30": {
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": true
-        }
-    },
-    "test_30": {
-        "sdram_module": "MT48LC16M16",
-        "sdram_data_width": 32,
-        "bist_alternating": true,
-        "access_pattern": {
-            "bist_length": 1024,
-            "bist_random": false
         }
     },
     "test_31": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
         "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": true
-        }
-    },
-    "test_32": {
-        "sdram_module": "MT48LC16M16",
-        "sdram_data_width": 32,
-        "bist_alternating": true,
-        "access_pattern": {
-            "bist_length": 8192,
+            "bist_length": 1024,
             "bist_random": false
         }
     },
-    "test_33": {
-        "sdram_module": "MT48LC16M16",
+    "test_32": {
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_33": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1,
             "bist_random": false
         }
     },
     "test_34": {
-        "sdram_module": "MT48LC16M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": true
+        }
+    },
+    "test_35": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
         "access_pattern": {
             "bist_length": 1024,
             "bist_random": false
         }
     },
-    "test_35": {
-        "sdram_module": "MT48LC16M16",
-        "sdram_data_width": 32,
-        "bist_alternating": false,
-        "access_pattern": {
-            "bist_length": 8192,
-            "bist_random": false
-        }
-    },
     "test_36": {
-        "sdram_module": "MT41K128M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1,
+            "bist_random": true
         }
     },
     "test_37": {
-        "sdram_module": "MT41K128M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1,
+            "bist_random": false
         }
     },
     "test_38": {
         "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1024,
+            "bist_random": true
         }
     },
     "test_39": {
         "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": false,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1024,
+            "bist_random": false
         }
     },
     "test_40": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
-        "bist_alternating": true,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1,
+            "bist_random": false
         }
     },
     "test_41": {
-        "sdram_module": "MT47H64M16",
+        "sdram_module": "MT46V32M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
-            "pattern_file": "access_pattern.csv"
+            "bist_length": 1024,
+            "bist_random": false
         }
     },
     "test_42": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_43": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_44": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_45": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_46": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_47": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_48": {
         "sdram_module": "MT48LC16M16",
         "sdram_data_width": 32,
         "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_49": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_50": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": true
+        }
+    },
+    "test_51": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_52": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_53": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_54": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": true
+        }
+    },
+    "test_55": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_56": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_57": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_58": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": true
+        }
+    },
+    "test_59": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_60": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": true
+        }
+    },
+    "test_61": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_62": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": true
+        }
+    },
+    "test_63": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_64": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_65": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_66": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_67": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_68": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_69": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_70": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1,
+            "bist_random": false
+        }
+    },
+    "test_71": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "bist_length": 1024,
+            "bist_random": false
+        }
+    },
+    "test_72": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
         "access_pattern": {
             "pattern_file": "access_pattern.csv"
         }
     },
-    "test_43": {
+    "test_73": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_74": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_75": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_76": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_77": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_78": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_79": {
+        "sdram_module": "MT41K128M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_80": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_81": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_82": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_83": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_84": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_85": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_86": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_87": {
+        "sdram_module": "MT46V32M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_88": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_89": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_90": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_91": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": true,
+        "num_generators": 3,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_92": {
         "sdram_module": "MT48LC16M16",
         "sdram_data_width": 32,
         "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_93": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 1,
+        "num_checkers": 3,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_94": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 1,
+        "access_pattern": {
+            "pattern_file": "access_pattern.csv"
+        }
+    },
+    "test_95": {
+        "sdram_module": "MT48LC16M16",
+        "sdram_data_width": 32,
+        "bist_alternating": false,
+        "num_generators": 3,
+        "num_checkers": 3,
         "access_pattern": {
             "pattern_file": "access_pattern.csv"
         }

--- a/test/gen_config.py
+++ b/test/gen_config.py
@@ -1,49 +1,57 @@
 #!/usr/bin/env python
 
+import sys
 import json
+import pprint
 import argparse
+import datetime
 import itertools
 
-default_modules = [
-    'IS42S16160',
-    'IS42S16320',
-    'MT48LC4M16',
-    'MT48LC16M16',
-    'AS4C16M16',
-    'AS4C32M16',
-    'AS4C32M8',
-    'M12L64322A',
-    'M12L16161A',
-    'MT46V32M16',
-    'MT46H32M16',
-    'MT46H32M32',
-    'MT47H128M8',
-    'MT47H32M16',
-    'MT47H64M16',
-    'P3R1GE4JGF',
-    'MT41K64M16',
-    'MT41J128M16',
-    'MT41K128M16',
-    'MT41J256M16',
-    'MT41K256M16',
-    'K4B1G0446F',
-    'K4B2G1646F',
-    'H5TC4G63CFR',
-    'IS43TR16128B',
-    'MT8JTF12864',
-    'MT8KTF51264',
-    #  'MT18KSF1G72HZ',
-    #  'AS4C256M16D3A',
-    #  'MT16KTF1G64HZ',
-    #  'EDY4016A',
-    #  'MT40A1G8',
-    #  'MT40A512M16',
-]
-default_bist_alternatings = [True, False]
-default_data_widths = [32]
-default_bist_lengths = [1, 1024, 8192]
-default_bist_randoms = [True, False]
-default_access_patterns = ['access_pattern.csv']
+
+defaults = {
+    '--sdram-module': [
+        'IS42S16160',
+        'IS42S16320',
+        'MT48LC4M16',
+        'MT48LC16M16',
+        'AS4C16M16',
+        'AS4C32M16',
+        'AS4C32M8',
+        'M12L64322A',
+        'M12L16161A',
+        'MT46V32M16',
+        'MT46H32M16',
+        'MT46H32M32',
+        'MT47H128M8',
+        'MT47H32M16',
+        'MT47H64M16',
+        'P3R1GE4JGF',
+        'MT41K64M16',
+        'MT41J128M16',
+        'MT41K128M16',
+        'MT41J256M16',
+        'MT41K256M16',
+        'K4B1G0446F',
+        'K4B2G1646F',
+        'H5TC4G63CFR',
+        'IS43TR16128B',
+        'MT8JTF12864',
+        'MT8KTF51264',
+        #  'MT18KSF1G72HZ',
+        #  'AS4C256M16D3A',
+        #  'MT16KTF1G64HZ',
+        #  'EDY4016A',
+        #  'MT40A1G8',
+        #  'MT40A512M16',
+    ],
+    '--sdram-data-width': [32],
+    '--bist-alternating': [True, False],
+    '--bist-length':      [1, 4096],
+    '--bist-random':      [True, False],
+    '--num-generators':   [1],
+    '--num-checkers':     [1],
+    '--access-pattern':   ['access_pattern.csv']
+}
 
 
 def convert_string_arg(args, arg, type):
@@ -54,59 +62,76 @@ def convert_string_arg(args, arg, type):
     setattr(args, arg, [map_func[type](val) if not isinstance(val, type) else val for val in getattr(args, arg)])
 
 
+def generate_header(args):
+    header = 'Auto-generated on {} by {}'.format(
+        datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        sys.argv[0],
+    )
+    args_str = pprint.pformat(vars(args), sort_dicts=False)
+    arg_lines = args_str.split('\n')
+    lines = [60*'=', header, 60*'-', *arg_lines, 60*'=']
+    return '\n'.join('# ' + line for line in lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description='Generate configuration for all possible argument combinations.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--sdram-modules',     nargs='+', default=default_modules,           help='--sdram-module options')
-    parser.add_argument('--sdram-data-widths', nargs='+', default=default_data_widths,       help='--sdram-data-width options')
-    parser.add_argument('--bist-alternatings', nargs='+', default=default_bist_alternatings, help='--bist-alternating options')
-    parser.add_argument('--bist-lengths',      nargs='+', default=default_bist_lengths,      help='--bist-length options')
-    parser.add_argument('--bist-randoms',      nargs='+', default=default_bist_randoms,      help='--bist-random options')
-    parser.add_argument('--access-patterns',   nargs='+', default=default_access_patterns,   help='--access-pattern options')
-    parser.add_argument('--name-format',                  default='test_%d',                 help='Name format for i-th test')
+    parser.add_argument('--name-format', default='test_%d', help='Name format for i-th test')
+    for name, default in defaults.items():
+        parser.add_argument(name, nargs='+', default=default, help='%s options' % name)
     args = parser.parse_args()
 
     # make sure not to write those as strings
-    convert_string_arg(args, 'sdram_data_widths', int)
-    convert_string_arg(args, 'bist_alternatings', bool)
-    convert_string_arg(args, 'bist_lengths',      int)
-    convert_string_arg(args, 'bist_randoms',      bool)
+    convert_string_arg(args, 'sdram_data_width', int)
+    convert_string_arg(args, 'bist_alternating', bool)
+    convert_string_arg(args, 'bist_length',      int)
+    convert_string_arg(args, 'bist_random',      bool)
+    convert_string_arg(args, 'num_generators',   int)
+    convert_string_arg(args, 'num_checkers',     int)
 
-    bist_product = itertools.product(args.sdram_modules, args.sdram_data_widths, args.bist_alternatings,
-                                     args.bist_lengths, args.bist_randoms)
-    pattern_product = itertools.product(args.sdram_modules, args.sdram_data_widths, args.bist_alternatings,
-                                        args.access_patterns)
+    common_args = ('sdram_module', 'sdram_data_width', 'bist_alternating', 'num_generators', 'num_checkers')
+    generated_pattern_args = ('bist_length', 'bist_random')
+    custom_pattern_args = ('access_pattern', )
+
+    def generated_pattern_configuration(values):
+        config = dict(zip(common_args + generated_pattern_args, values))
+        # move access pattern parameters deeper
+        config['access_pattern'] = {
+            'bist_length': config.pop('bist_length'),
+            'bist_random': config.pop('bist_random'),
+        }
+        return config
+
+    def custom_pattern_configuration(values):
+        config = dict(zip(common_args + custom_pattern_args, values))
+        # "rename" --access-pattern to access_pattern.pattern_file due to name difference between
+        # command line args and run_benchmarks.py configuration format
+        config['access_pattern'] = {
+            'pattern_file': config.pop('access_pattern'),
+        }
+        return config
+
+    # iterator over the product of given command line arguments
+    def args_product(names):
+        return itertools.product(*(getattr(args, name) for name in names))
+
+    generated_pattern_iter = zip(itertools.repeat(generated_pattern_configuration), args_product(common_args + generated_pattern_args))
+    custom_pattern_iter = zip(itertools.repeat(custom_pattern_configuration), args_product(common_args + custom_pattern_args))
 
     i = 0
     configurations = {}
-    for module, data_width, bist_alternating, bist_length, bist_random in bist_product:
-        if bist_random and not bist_alternating:
+    for config_generator, values in itertools.chain(generated_pattern_iter, custom_pattern_iter):
+        config = config_generator(values)
+        # ignore unsupported case: bist_random=True and bist_alternating=False
+        if config['access_pattern'].get('bist_random', False) and not config['bist_alternating']:
             continue
-        configurations[args.name_format % i] = {
-            'sdram_module':     module,
-            'sdram_data_width': data_width,
-            'bist_alternating': bist_alternating,
-            'access_pattern': {
-                'bist_length':  bist_length,
-                'bist_random':  bist_random,
-            }
-        }
-        i += 1
-    for module, data_width, bist_alternating, access_pattern in pattern_product:
-        if bist_random and not bist_alternating:
-            continue
-        configurations[args.name_format % i] = {
-            'sdram_module':     module,
-            'sdram_data_width': data_width,
-            'bist_alternating': bist_alternating,
-            'access_pattern': {
-                'pattern_file': access_pattern,
-            }
-        }
+        configurations[args.name_format % i] = config
         i += 1
 
     json_str = json.dumps(configurations, indent=4)
+    print(generate_header(args))
     print(json_str)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes https://github.com/enjoy-digital/litedram/issues/114.

This adds an option to specify `--num-generators` and `--num-checkers` for `benchmark.py` to have more than one generator/checker. 

Max value of ticks is used as the final benchmark result (for generator ticks, checker ticks and checker errors). In the final bandwidth/efficiency calculations the number of data is multiplied according to the number of generators/checkers.

I've also updated `gen_config.py`. It is useful for testing purpose, but product of all options quickly results in over 1000 benchmarks, so for real benchmarks we should most likely specify configurations by hand anyway.