### PR TITLE
Benchmarks: Generate HTML summary and deploy it from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ python: "3.6"
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install verilator libevent-dev libjson-c-dev
-  - pip install pexpect
+  - pip install pexpect numpy matplotlib pandas jinja2
 
 install:
   # Get Migen / LiteX / Cores
   - wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
   - python3 litex_setup.py init install
+  # litex_setup.py fails for litedram, which has already been cloned by Travis
+  # now install the local litedram so that it is available for benchmarks script
+  - python3 -m pip install .
 
 before_script:
   # Get RISC-V toolchain
@@ -58,3 +61,19 @@ jobs:
     - env: SDRAM_MODULE=MT40A1G8
     - env: SDRAM_MODULE=MT40A512M16
 
+    - stage: Benchmarks
+      script:
+      - python3 -m test.run_benchmarks test/benchmarks.yml --results-cache cache.json --html
+      # move benchmark artifacts to gh-pages/ directory that will be pushed to gh-pages branch
+      - mkdir -p gh-pages
+      - mv html/summary.html gh-pages/index.html
+      - mv cache.json gh-pages/cache.json
+      - touch gh-pages/.nojekyll
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        token: $GITHUB_TOKEN
+        keep_history: true
+        local_dir: gh-pages
+        on:
+          branch: master

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -4,6 +4,7 @@
 # License: BSD
 
 import csv
+import logging
 import argparse
 from operator import and_
 from functools import reduce
@@ -219,7 +220,12 @@ def main():
     parser.add_argument("--num-generators",   default=1,              help="Number of BIST generators")
     parser.add_argument("--num-checkers",     default=1,              help="Number of BIST checkers")
     parser.add_argument("--access-pattern",                           help="Load access pattern (address, data) from CSV (ignores --bist-*)")
+    parser.add_argument("--log-level",        default="info",         help="Set logging verbosity",
+                        choices=['critical', 'error', 'warning', 'info', 'debug'])
     args = parser.parse_args()
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(getattr(logging, args.log_level.upper()))
 
     soc_kwargs     = soc_sdram_argdict(args)
     builder_kwargs = builder_argdict(args)

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -492,7 +492,8 @@ def run_single_benchmark(func_args):
     # run as separate process, because else we cannot capture all output from verilator
     print('  {}: {}'.format(config.name, ' '.join(config.as_args())))
     try:
-        output = run_python(benchmark.__file__, config.as_args() + ['--output-dir', output_dir])
+        args = config.as_args() + ['--output-dir', output_dir, '--log-level', 'warning']
+        output = run_python(benchmark.__file__, args)
         result = BenchmarkResult(output)
         # exit if checker had any read error
         if result.checker_errors != 0:

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -230,9 +230,12 @@ class ResultsSummary:
     def __init__(self, run_data, plots_dir='plots'):
         self.plots_dir = plots_dir
 
-        # filter out failures
-        self.failed_configs = [data.config for data in run_data if data.result is None]
-        run_data = [data for data in run_data if data.result is not None]
+        # because .sdram_controller_data_width may fail for unimplemented modules
+        def except_none(func):
+            try:
+                return func()
+            except:
+                return None
 
         # gather results into tabular data
         column_mappings = {
@@ -246,14 +249,14 @@ class ResultsSummary:
             'bist_random':      lambda d: getattr(d.config.access_pattern, 'bist_random', None),
             'pattern_file':     lambda d: getattr(d.config.access_pattern, 'pattern_file', None),
             'length':           lambda d: d.config.length,
-            'generator_ticks':  lambda d: d.result.generator_ticks,
-            'checker_errors':   lambda d: d.result.checker_errors,
-            'checker_ticks':    lambda d: d.result.checker_ticks,
-            'ctrl_data_width':  lambda d: d.config.sdram_controller_data_width,
+            'generator_ticks':  lambda d: getattr(d.result, 'generator_ticks', None),  # None means benchmark failure
+            'checker_errors':   lambda d: getattr(d.result, 'checker_errors', None),
+            'checker_ticks':    lambda d: getattr(d.result, 'checker_ticks', None),
+            'ctrl_data_width':  lambda d: except_none(lambda: d.config.sdram_controller_data_width),
             'clk_freq':         lambda d: d.config.sdram_clk_freq,
         }
         columns = {name: [mapping(data) for data in run_data] for name, mapping, in column_mappings.items()}
-        self.df = df = pd.DataFrame(columns)
+        self._df = df = pd.DataFrame(columns)
 
         # replace None with NaN
         df.fillna(value=np.nan, inplace=True)
@@ -300,6 +303,16 @@ class ResultsSummary:
             'read_latency':     ScalarFormatter(),
         }
 
+    def df(self, ok=True, failures=False):
+        is_failure = lambda df: pd.isna(df['generator_ticks']) | pd.isna(df['checker_ticks']) | pd.isna(df['checker_errors'])
+        df = self._df
+        if not ok:  # remove ok
+            is_ok = ~is_failure(df)
+            df = df[~is_ok]
+        if not failures:  # remove failures
+            df = df[~is_failure(df)]
+        return df
+
     def header(self, text):
         return '===> {}'.format(text)
 
@@ -309,9 +322,9 @@ class ResultsSummary:
             print(self.header(title + ':'))
             print(df)
 
-    def get_summary(self, mask=None, columns=None, column_formatting=None, sort_kwargs=None):
+    def get_summary(self, df, mask=None, columns=None, column_formatting=None, sort_kwargs=None):
         # work on a copy
-        df = self.df.copy()
+        df = df.copy()
 
         if sort_kwargs is not None:
             df = df.sort_values(**sort_kwargs)
@@ -360,7 +373,7 @@ class ResultsSummary:
             ))
 
     def groupped_results(self, formatters=None):
-        df = self.df
+        df = self.df()
 
         if formatters is None:
             formatters = self.text_formatters
@@ -368,26 +381,31 @@ class ResultsSummary:
         common_columns = ['name', 'sdram_module', 'sdram_data_width', 'bist_alternating', 'num_generators', 'num_checkers']
         latency_columns = ['write_latency', 'read_latency']
         performance_columns = ['write_bandwidth', 'read_bandwidth', 'write_efficiency', 'read_efficiency']
+        failure_columns = ['bist_length', 'bist_random', 'pattern_file', 'length', 'generator_ticks', 'checker_errors', 'checker_ticks']
 
-        yield 'Latency', self.get_summary(
+        yield 'Latency', self.get_summary(df,
             mask=df['is_latency'] == True,
             columns=common_columns + latency_columns,
             column_formatting=formatters,
         )
-        yield 'Custom access pattern', self.get_summary(
+        yield 'Custom access pattern', self.get_summary(df,
             mask=(df['is_latency'] == False) & (~pd.isna(df['pattern_file'])),
             columns=common_columns + ['length', 'pattern_file'] + performance_columns,
             column_formatting=formatters,
         ),
-        yield 'Sequential access pattern', self.get_summary(
+        yield 'Sequential access pattern', self.get_summary(df,
             mask=(df['is_latency'] == False) & (pd.isna(df['pattern_file'])) & (df['bist_random'] == False),
             columns=common_columns + ['bist_length'] + performance_columns, # could be length
             column_formatting=formatters,
         ),
-        yield 'Random access pattern', self.get_summary(
+        yield 'Random access pattern', self.get_summary(df,
             mask=(df['is_latency'] == False) & (pd.isna(df['pattern_file'])) & (df['bist_random'] == True),
             columns=common_columns + ['bist_length'] + performance_columns,
             column_formatting=formatters,
+        ),
+        yield 'Failures', self.get_summary(self.df(ok=False, failures=True),
+            columns=common_columns + failure_columns,
+            column_formatting=None,
         ),
 
     def plot_summary(self, plots_dir='plots', backend='Agg', theme='default', save_format='png', **savefig_kw):
@@ -440,14 +458,6 @@ class ResultsSummary:
         fig.tight_layout()
 
         return axis
-
-    def failures_summary(self):
-        if len(self.failed_configs) > 0:
-            print(self.header('Failures:'))
-            for config in self.failed_configs:
-                print('  {}: {}'.format(config.name, config.as_args()))
-        else:
-            print(self.header('All benchmarks ok.'))
 
 # Run ----------------------------------------------------------------------------------------------
 
@@ -618,7 +628,6 @@ def main(argv=None):
     if _summary:
         summary = ResultsSummary(run_data)
         summary.text_summary()
-        summary.failures_summary()
         if args.html:
             summary.html_summary(args.html_output_dir)
         if args.plot:

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -12,6 +12,7 @@ import re
 import sys
 import json
 import argparse
+import datetime
 import subprocess
 from collections import defaultdict, namedtuple
 
@@ -211,6 +212,20 @@ def efficiency_fmt(eff):
     return '{:.1f} %'.format(eff * 100)
 
 
+def get_git_file_path(filename):
+    cmd = ['git', 'ls-files', '--full-name', filename]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, cwd=os.path.dirname(__file__))
+    return proc.stdout.decode().strip() if proc.returncode == 0 else ''
+
+
+def get_git_revision_hash(short=False):
+    short = ['--short'] if short else []
+    #  cmd = ['git', 'rev-parse', *short, 'HEAD']
+    cmd = ['git', 'rev-parse', *short, 'origin/master']
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, cwd=os.path.dirname(__file__))
+    return proc.stdout.decode().strip() if proc.returncode == 0 else ''
+
+
 class ResultsSummary:
     def __init__(self, run_data, plots_dir='plots'):
         self.plots_dir = plots_dir
@@ -317,10 +332,38 @@ class ResultsSummary:
             self.print_df(title, df)
             print()
 
-    def groupped_results(self, formatted=True):
+    def html_summary(self, output_dir):
+        import jinja2
+
+        tables = {}
+        names = {}
+        for title, df in self.groupped_results():
+            table_id = title.lower().replace(' ', '_')
+
+            tables[table_id] = df.to_html(table_id=table_id, border=0)
+            names[table_id] = title
+
+        template_dir = os.path.join(os.path.dirname(__file__), 'summary')
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_dir))
+        template = env.get_template('summary.html.jinja2')
+
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, 'summary.html'), 'w') as f:
+            f.write(template.render(
+                title='LiteDRAM benchmarks summary',
+                tables=tables,
+                names=names,
+                script_path=get_git_file_path(__file__),
+                revision=get_git_revision_hash(),
+                revision_short=get_git_revision_hash(short=True),
+                generation_date=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            ))
+
+    def groupped_results(self, formatters=None):
         df = self.df
 
-        formatters = self.text_formatters if formatted else {}
+        if formatters is None:
+            formatters = self.text_formatters
 
         common_columns = ['name', 'sdram_module', 'sdram_data_width', 'bist_alternating', 'num_generators', 'num_checkers']
         latency_columns = ['write_latency', 'read_latency']
@@ -333,17 +376,17 @@ class ResultsSummary:
         )
         yield 'Custom access pattern', self.get_summary(
             mask=(df['is_latency'] == False) & (~pd.isna(df['pattern_file'])),
-            columns=common_columns + performance_columns + ['length', 'pattern_file'],
+            columns=common_columns + ['length', 'pattern_file'] + performance_columns,
             column_formatting=formatters,
         ),
         yield 'Sequential access pattern', self.get_summary(
             mask=(df['is_latency'] == False) & (pd.isna(df['pattern_file'])) & (df['bist_random'] == False),
-            columns=common_columns + performance_columns + ['bist_length'], # could be length
+            columns=common_columns + ['bist_length'] + performance_columns, # could be length
             column_formatting=formatters,
         ),
         yield 'Random access pattern', self.get_summary(
             mask=(df['is_latency'] == False) & (pd.isna(df['pattern_file'])) & (df['bist_random'] == True),
-            columns=common_columns + performance_columns + ['bist_length'],
+            columns=common_columns + ['bist_length'] + performance_columns,
             column_formatting=formatters,
         ),
 
@@ -352,7 +395,7 @@ class ResultsSummary:
         import matplotlib.pyplot as plt
         plt.style.use(theme)
 
-        for title, df in self.groupped_results(formatted=False):
+        for title, df in self.groupped_results(formatters={}):
             for column in self.plot_xticks_formatters.keys():
                 if column not in df.columns or df[column].empty:
                     continue
@@ -520,6 +563,8 @@ def main(argv=None):
     parser.add_argument('--names',            nargs='*',           help='Limit benchmarks to given names')
     parser.add_argument('--regex',                                 help='Limit benchmarks to names matching the regex')
     parser.add_argument('--not-regex',                             help='Limit benchmarks to names not matching the regex')
+    parser.add_argument('--html',             action='store_true', help='Generate HTML summary')
+    parser.add_argument('--html-output-dir',  default='html',      help='Output directory for generated HTML')
     parser.add_argument('--plot',             action='store_true', help='Generate plots with results summary')
     parser.add_argument('--plot-format',      default='png',       help='Specify plots file format (default=png)')
     parser.add_argument('--plot-backend',     default='Agg',       help='Optionally specify matplotlib GUI backend')
@@ -574,6 +619,8 @@ def main(argv=None):
         summary = ResultsSummary(run_data)
         summary.text_summary()
         summary.failures_summary()
+        if args.html:
+            summary.html_summary(args.html_output_dir)
         if args.plot:
             summary.plot_summary(
                 plots_dir=args.plot_output_dir,

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -220,8 +220,7 @@ def get_git_file_path(filename):
 
 def get_git_revision_hash(short=False):
     short = ['--short'] if short else []
-    #  cmd = ['git', 'rev-parse', *short, 'HEAD']
-    cmd = ['git', 'rev-parse', *short, 'origin/master']
+    cmd = ['git', 'rev-parse', *short, 'HEAD']
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, cwd=os.path.dirname(__file__))
     return proc.stdout.decode().strip() if proc.returncode == 0 else ''
 

--- a/test/summary/summary.css
+++ b/test/summary/summary.css
@@ -1,0 +1,100 @@
+body {
+  font-family: 'Roboto', sans-serif;
+}
+
+footer {
+  text-align: center;
+  font-size: 10px;
+  padding: 20px;
+}
+
+.dataTables_filter {
+  margin: 15px 50px 10px 50px;
+}
+
+.dataTables_filter input {
+  width: 400px;
+}
+
+.table-select {
+  width: 100%;
+  margin: 0 auto;
+}
+
+.table-select ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.table-select li {
+  float: left;
+}
+
+.table-select li a {
+  display: block;
+  padding: 10px 0px;
+  margin: 0px 20px;
+  text-align: center;
+  text-decoration: none;
+  font-size: 18px;
+  color:inherit;
+  border-bottom: 1px solid;
+  border-color: #ccc;
+  transition: 0.2s;
+}
+
+.table-select li a:hover {
+  border-color: #111;
+}
+
+/* did not work, .focus() couldn't turn it on */
+/* .table-select li a:focus { */
+/*   border-color: #222; */
+/* } */
+.table-select-active {
+  border-color: #111 !important;
+}
+
+.tables-wrapper {
+  width: 100%;
+  margin: auto;
+}
+
+.loading {
+  z-index: 999;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-right: -50%;
+  transform: translate(-50%, -50%);
+}
+
+/* Loading animation */
+.lds-dual-ring {
+  display: inline-block;
+  width: 80px;
+  height: 80px;
+}
+.lds-dual-ring:after {
+  content: " ";
+  display: block;
+  width: 64px;
+  height: 64px;
+  margin: 8px;
+  border-radius: 50%;
+  border: 6px solid #fff;
+  border-color: #aaa transparent #aaa transparent;
+  animation: lds-dual-ring 1.2s linear infinite;
+}
+@keyframes lds-dual-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+/* vim: set ts=2 sw=2: */

--- a/test/summary/summary.html.jinja2
+++ b/test/summary/summary.html.jinja2
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.css">
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/fixedheader/3.1.5/js/dataTables.fixedHeader.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/fixedheader/3.1.5/css/fixedHeader.dataTables.min.css">
+
+    <style type="text/css" media="all">
+{% include 'summary.css' %}
+{# Calculate size of table selection elements so that they take up whole space #}
+.table-select li {
+  width: calc(100% / {{ tables.keys() | length }});
+}
+    </style>
+  </head>
+  <body>
+    {# Loading symbol that gets hidden after initialisation of all tables #}
+    <div class="loading lds-dual-ring"></div>
+
+    {# Bar for selecting the current data table #}
+    <div class="table-select">
+      <ul>
+        {% for id, name in names.items() %}
+          <li id='{{ id }}-button'><a href="#">{{ name }}</a></li>
+        {% endfor %}
+      </ul>
+      {# <hr/> #}
+    </div>
+
+    {# Display of the current data table #}
+    <div class="tables-wrapper">
+      {% for id, table in tables.items() %}
+        {# Hide tables not to show them before all DataTables are loaded #}
+        <div id="{{ id }}-div" style="display: none;">
+          {{ table }}
+        </div>
+      {% endfor %}
+    </div>
+  </body>
+
+  <footer id="footer">
+    <a href="https://github.com/enjoy-digital/litedram">LiteDRAM</a> is a part of <a href="https://github.com/enjoy-digital/litex">Litex</a>.
+    <br>
+    Generated using
+    <a href="https://github.com/enjoy-digital/litedram/blob/{{ revision }}/{{ script_path }}">{{ script_path }}</a>,
+    revision
+    <a href="https://github.com/enjoy-digital/litedram/commit/{{ revision }}">{{ revision_short }}</a>,
+    {{ generation_date }}.
+  </footer>
+
+  {# Script last, so that for large tables we get some content on the page before loading tables #}
+  <script>
+    {# Ids of the data tables #}
+    table_ids = [
+      {% for id in tables.keys() %}
+        '{{ id }}',
+    {% endfor %}
+    ];
+
+    {# Show table with given id and hide all the others #}
+    show_table = function(id) {
+      if (!table_ids.includes(id)) {
+        console.log('Error: show_table(' + id + ')');
+        return;
+      }
+      for (var table_div of $('.tables-wrapper').children()) {
+        if (table_div.id) {
+          var table_div = $('#' + table_div.id)
+          if (table_div.attr('id') == id + '-div') {
+            table_div.show();
+          } else {
+            table_div.hide();
+          }
+        }
+      }
+    }
+
+    // sort human-readable values assuming format "123 Kb", only first letter of unit is used
+    jQuery.fn.dataTable.ext.type.order['file-size-pre'] = function(data) {
+      var matches = data.match(/^(\d+(?:\.\d+)?)\s*([a-z]+)/i);
+      var multipliers = {
+        k: Math.pow(2, 10),
+        m: Math.pow(2, 20),
+        g: Math.pow(2, 30),
+        t: Math.pow(2, 40),
+      };
+
+      console.log(matches);
+      if (matches) {
+        var float = parseFloat(matches[1]);
+        var prefix = matches[2].toLowerCase()[0];
+        var multiplier = multipliers[prefix];
+        if (multiplier) {
+          float = float * multiplier;
+          console.log(matches, float, multiplier);
+        }
+        return float;
+      } else {
+        return -1;
+      };
+    };
+
+    {# Initialization after DOM has been loaded #}
+    $(document).ready(function() {
+      // generate data tables
+      for (var id of table_ids) {
+        // add human readable class to all bandwidth columns
+        var columns = $('#' + id + ' > thead > tr > th').filter(function(index) {
+          return $(this).text().toLowerCase().includes('bandwidth');
+        });
+        console.log(columns)
+        columns.addClass('human-readable-data');
+
+        // construct data table
+        table = $('#' + id);
+        table.DataTable({
+          paging: false,
+          fixedHeader: true,
+          columnDefs: [
+            { type: 'file-size', targets: [ 'human-readable-data' ] },
+            { className: 'dt-body-right', targets: [ '_all' ] },
+            { className: 'dt-head-center', targets: [ '_all' ] },
+          ]
+        });
+        table.addClass("stripe");
+        table.addClass("hover");
+        table.addClass("order-column");
+        table.addClass("cell-border");
+        table.addClass("row-border");
+      }
+
+      // add click handlers that change the table being shown
+      for (var id of table_ids) {
+        var ahref = $('#' + id + '-button a');
+        // use nested closure so that we avoid the situation
+        // where all click handlers end up with the last id
+        ahref.click(function(table_id) {
+          return function() {
+            // get rid of this class after first click
+            $('.table-select a').removeClass('table-select-active');
+            $(this).addClass('table-select-active');
+            show_table(table_id);
+          }
+        }(id))
+      }
+
+      // show the first one
+      $('#' + table_ids[0] + '-button a:first').click();
+
+      // hide all elements of class loading
+      $('.loading').hide();
+    });
+  </script>
+</html>
+{# vim: set ts=2 sts=2 sw=2 et: #}


### PR DESCRIPTION
This PR adds benchmarks summary in HTML format and deployment to GitHub Pages.
Closes https://github.com/enjoy-digital/litedram/issues/110.

**Travis:**

Benchmarks are being run in Travis and deployed using GitHub Pages. The results are stored on the `gh-pages` branch. We would then need to [enable GitHub Pages in repo settings](https://help.github.com/en/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) for `enjoy-digital/litedram` and configure it to use `gh-pages` branch. The results should then appear at [enjoy-digital.github.io/litedram/](https://enjoy-digital.github.io/litedram/).

[Here](https://docs.travis-ci.com/user/deployment/pages/#setting-the-github-token) is some more information about Travis/gh-pages. 
Options used in `.travis.yml`:
* `deploy.keep_history = true` - instead of force pushing to the repository we have commits with previous versions of the summaries, this way we'll be able to compare results across history
* `deploy.on.branch = master` - deployment is skipped on branches other than master; or maybe we could entirely skip benchmarks on other branches?
* `deploy.token` - secure variable `GITHUB_TOKEN` is being used, you would need to [generate it](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) (need only `public_repo`) and set it as [repository variable](https://docs.travis-ci.com/user/environment-variables#defining-variables-in-repository-settings)

**HTML summary:**

The generated summary consists only of tables with results (example summary: [summary.zip](https://github.com/enjoy-digital/litedram/files/4214090/summary.zip)). As for now it doesn't include plots. Tables are probably more practical, as we have options to sort by whichever column we want and we have much more information available. Plots show results by test name, which is often meaningless without looking at the YAML configuration, but it is not easy to include the configuration in the plots. Maybe by switching to something like [Plotly](https://plot.ly/javascript/) and adding dynamic legend on hover.

During deployment we store the HTML page and results cache JSON file. We could maybe store SVG plots too, although they can be generated using the JSON cache.

The generated HTML page includes the time of generation and `litedram` commit hash, but maybe we should also store this version information in a separate file as I could not find a way to provide custom commit message.

Additionally `b7ed91d` changes logging level in `benchmark.py` to `WARNING` as the logs are displayed on standard error which is not captured by `run_benchmarks.py`.