### PR TITLE
Benchmark: Print heartbeat message during runs in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
 
     - stage: Benchmarks
       script:
-      - python3 -m test.run_benchmarks test/benchmarks.yml --results-cache cache.json --html
+      - python3 -m test.run_benchmarks test/benchmarks.yml --results-cache cache.json --html --heartbeat 60
       # move benchmark artifacts to gh-pages/ directory that will be pushed to gh-pages branch
       - mkdir -p gh-pages
       - mv html/summary.html gh-pages/index.html

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -584,6 +584,7 @@ def main(argv=None):
     parser.add_argument('--fail-fast',        action='store_true', help='Exit on any benchmark error, do not continue')
     parser.add_argument('--output-dir',       default='build',     help='Directory to store benchmark build output')
     parser.add_argument('--njobs',            default=0, type=int, help='Use N parallel jobs to run benchmarks (default=0, which uses CPU count)')
+    parser.add_argument('--heartbeat',        default=0, type=int, help='Print heartbeat message with given interval (default=0 => never)')
     parser.add_argument('--results-cache',                         help="""Use given JSON file as results cache. If the file exists,
                                                                            it will be loaded instead of running actual benchmarks,
                                                                            else benchmarks will be run normally, and then saved
@@ -617,7 +618,12 @@ def main(argv=None):
         names_to_load = [c.name for c in configurations]
         run_data = [data for  data in cache if data.config.name in names_to_load]
     else:  # run all the benchmarks normally
+        if args.heartbeat:
+            heartbeat_cmd = ['/bin/sh', '-c', 'while true; do sleep %d; echo Heartbeat...; done' % args.heartbeat]
+            heartbeat = subprocess.Popen(heartbeat_cmd)
         run_data = run_benchmarks(configurations, args.output_dir, args.njobs, not args.fail_fast)
+        if args.heartbeat:
+            heartbeat.kill()
 
     # store outputs in cache
     if args.results_cache and not cache_exists:


### PR DESCRIPTION
This PR adds `--heartbeat` argument that is being used in CI to print heartbeat messages every 60 seconds. 

This solves the issue mentioned in https://github.com/enjoy-digital/litedram/pull/146#issuecomment-588089239. After some tests I've found that we need to print in a child process instead of the main process, as both `stdout` and `stderr` from main process seem to be buffered by Travis. This behavior can be reproduced using:
```
python -m test.run_benchmarks test/benchmarks.yml --njobs 2 --regex 'test_[0-3]$' >/tmp/output 2>&1
```
and then reading the file, e.g. `tail -f /tmp/output`.

Another option would be to print something on `stderr` in `benchmark.py` (e.g. `argv`), as with the current solution, because of Travis buffering, we don't get real-time feedback which tests is currently being run.

