### PR TITLE
Benchmarks: add timeout parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
 
     - stage: Benchmarks
       script:
-      - python3 -m test.run_benchmarks test/benchmarks.yml --results-cache cache.json --html --heartbeat 60
+      - python3 -m test.run_benchmarks test/benchmarks.yml --results-cache cache.json --html --heartbeat 60 --timeout 540
       # move benchmark artifacts to gh-pages/ directory that will be pushed to gh-pages branch
       - mkdir -p gh-pages
       - mv html/summary.html gh-pages/index.html


### PR DESCRIPTION
Travis normally times out a build after no output for 10 minutes. We've added a "heartbeat" to prevent this from canceling benchmarks, but it would be nice to have a timeout for some situations (e.g. when `$finish` is somehow never executed). 

In this PR I've added a `--timeout` parameter for CI builds. It seems that a single benchmark case takes ~30s, so the timeout of 9 minutes that I've added is somehow overestimated, if you want we can change it.