### PR TITLE
Benchmarks: fix with_uart parameter

### DIFF
--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -235,6 +235,8 @@ def main():
     sim_config.add_module("serial2console", "serial")
 
     # Configuration --------------------------------------------------------------------------------
+    soc_kwargs["with_uart"]        = False
+
     soc_kwargs["sdram_module"]     = args.sdram_module
     soc_kwargs["sdram_data_width"] = int(args.sdram_data_width)
     soc_kwargs["sdram_verbosity"]  = int(args.sdram_verbosity)

--- a/test/run_benchmarks.py
+++ b/test/run_benchmarks.py
@@ -664,6 +664,10 @@ def main(argv=None):
                 transparent=args.plot_transparent,
             )
 
+    # exit with error when there is no single benchmark that succeeded
+    succeeded = sum(1 if d.result is not None else 0 for d in run_data)
+    if succeeded == 0:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Due to https://github.com/enjoy-digital/litex/commit/b29f443fe51511df908a644a17bc2a8a1f1566cc removing the default parameter value, we need to set it explicitly.

To prevent something like this from being unnoticed (e.g. https://travis-ci.org/github/enjoy-digital/litedram/jobs/661098966?utm_medium=notification&utm_source=github_status succeeds) `run_benchmarks.py` will now fail in case all benchmarks failed.