### PR TITLE
Test: add tests for BIST modules with different access patterns

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1,5 +1,6 @@
 # This file is Copyright (c) 2016-2019 Florent Kermarrec <florent@enjoy-digital.fr>
 # This file is Copyright (c) 2016 Tim 'mithro' Ansell <mithro@mithis.com>
+# This file is Copyright (c) 2020 Antmicro <www.antmicro.com>
 # License: BSD
 
 import random
@@ -89,3 +90,200 @@ class DRAMMemory:
                     yield
                     yield dram_port.cmd.ready.eq(0)
             yield
+
+class MemoryTestDataMixin:
+    @property
+    def bist_test_data(self):
+        data = {
+            "8bit": dict(
+                base=2,
+                end=2 + 8,  # (end - base) must be pow of 2
+                length=5,
+                #                       2     3     4     5     6     7=2+5
+                expected=[0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x00],
+            ),
+            "32bit": dict(
+                base=0x04,
+                end=0x04 + 8,
+                length=5 * 4,
+                expected=[
+                    0x00000000,  # 0x00
+                    0x00000000,  # 0x04
+                    0x00000001,  # 0x08
+                    0x00000002,  # 0x0c
+                    0x00000003,  # 0x10
+                    0x00000004,  # 0x14
+                    0x00000000,  # 0x18
+                    0x00000000,  # 0x1c
+                ],
+            ),
+            "64bit": dict(
+                base=0x10,
+                end=0x10 + 8,
+                length=5 * 8,
+                expected=[
+                    0x0000000000000000,  # 0x00
+                    0x0000000000000000,  # 0x08
+                    0x0000000000000000,  # 0x10
+                    0x0000000000000001,  # 0x18
+                    0x0000000000000002,  # 0x20
+                    0x0000000000000003,  # 0x28
+                    0x0000000000000004,  # 0x30
+                    0x0000000000000000,  # 0x38
+                ],
+            ),
+            "32bit_masked": dict(
+                base=0x04,
+                end=0x04 + 0x04,  # TODO: fix address masking to be consistent
+                length=6 * 4,
+                expected=[  # due to masking
+                    0x00000000,  # 0x00
+                    0x00000004,  # 0x04
+                    0x00000005,  # 0x08
+                    0x00000002,  # 0x0c
+                    0x00000003,  # 0x10
+                    0x00000000,  # 0x14
+                    0x00000000,  # 0x18
+                    0x00000000,  # 0x1c
+                ],
+            ),
+        }
+        data["32bit_long_sequential"] = dict(
+            base=16,
+            end=16 + 128,
+            length=64,
+            expected=[0x00000000] * 128
+        )
+        expected = data["32bit_long_sequential"]["expected"]
+        expected[16//4:(16 + 64)//4] = list(range(64//4))
+        return data
+
+    @property
+    def pattern_test_data(self):
+        data = {
+            "8bit": dict(
+                pattern=[
+                    # address, data
+                    (0x00, 0xaa),
+                    (0x05, 0xbb),
+                    (0x02, 0xcc),
+                    (0x07, 0xdd),
+                ],
+                expected=[
+                    # data, address
+                    0xaa,  # 0x00
+                    0x00,  # 0x01
+                    0xcc,  # 0x02
+                    0x00,  # 0x03
+                    0x00,  # 0x04
+                    0xbb,  # 0x05
+                    0x00,  # 0x06
+                    0xdd,  # 0x07
+                ],
+            ),
+            "32bit": dict(
+                pattern=[
+                    # address, data
+                    (0x00, 0xabadcafe),
+                    (0x07, 0xbaadf00d),
+                    (0x02, 0xcafefeed),
+                    (0x01, 0xdeadc0de),
+                ],
+                expected=[
+                    # data, address
+                    0xabadcafe,  # 0x00
+                    0xdeadc0de,  # 0x04
+                    0xcafefeed,  # 0x08
+                    0x00000000,  # 0x0c
+                    0x00000000,  # 0x10
+                    0x00000000,  # 0x14
+                    0x00000000,  # 0x18
+                    0xbaadf00d,  # 0x1c
+                ],
+            ),
+            "64bit": dict(
+                pattern=[
+                    # address, data
+                    (0x00, 0x0ddf00dbadc0ffee),
+                    (0x05, 0xabadcafebaadf00d),
+                    (0x02, 0xcafefeedfeedface),
+                    (0x07, 0xdeadc0debaadbeef),
+                ],
+                expected=[
+                    # data, address
+                    0x0ddf00dbadc0ffee,  # 0x00
+                    0x0000000000000000,  # 0x08
+                    0xcafefeedfeedface,  # 0x10
+                    0x0000000000000000,  # 0x18
+                    0x0000000000000000,  # 0x20
+                    0xabadcafebaadf00d,  # 0x28
+                    0x0000000000000000,  # 0x30
+                    0xdeadc0debaadbeef,  # 0x38
+                ],
+            ),
+            "32bit_not_aligned": dict(
+                pattern=[
+                    # address, data
+                    (0x00, 0xabadcafe),
+                    (0x07, 0xbaadf00d),
+                    (0x02, 0xcafefeed),
+                    (0x01, 0xdeadc0de),
+                ],
+                expected=[
+                    # data, address
+                    0xabadcafe,  # 0x00
+                    0xdeadc0de,  # 0x04
+                    0xcafefeed,  # 0x08
+                    0x00000000,  # 0x0c
+                    0x00000000,  # 0x10
+                    0x00000000,  # 0x14
+                    0x00000000,  # 0x18
+                    0xbaadf00d,  # 0x1c
+                ],
+            ),
+            "32bit_duplicates": dict(
+                pattern=[
+                    # address, data
+                    (0x00, 0xabadcafe),
+                    (0x07, 0xbaadf00d),
+                    (0x00, 0xcafefeed),
+                    (0x07, 0xdeadc0de),
+                ],
+                expected=[
+                    # data, address
+                    0xcafefeed,  # 0x00
+                    0x00000000,  # 0x04
+                    0x00000000,  # 0x08
+                    0x00000000,  # 0x0c
+                    0x00000000,  # 0x10
+                    0x00000000,  # 0x14
+                    0x00000000,  # 0x18
+                    0xdeadc0de,  # 0x1c
+                ],
+            ),
+            "32bit_sequential": dict(
+                pattern=[
+                    # address, data
+                    (0x02, 0xabadcafe),
+                    (0x03, 0xbaadf00d),
+                    (0x04, 0xcafefeed),
+                    (0x05, 0xdeadc0de),
+                ],
+                expected=[
+                    # data, address
+                    0x00000000,  # 0x00
+                    0x00000000,  # 0x04
+                    0xabadcafe,  # 0x08
+                    0xbaadf00d,  # 0x0c
+                    0xcafefeed,  # 0x10
+                    0xdeadc0de,  # 0x14
+                    0x00000000,  # 0x18
+                    0x00000000,  # 0x1c
+                ],
+            ),
+            "32bit_long_sequential": dict(pattern=[], expected=[0] * 64),
+        }
+        for i in range(32):
+            data["32bit_long_sequential"]["pattern"].append((i, 64 + i))
+            data["32bit_long_sequential"]["expected"][i] = 64 + i
+        return data

--- a/test/test_bist.py
+++ b/test/test_bist.py
@@ -95,8 +95,7 @@ class DMAWriterDriver:
             yield self.dma.sink.data.eq(data)
             while not (yield self.dma.sink.ready):
                 yield
-            while (yield self.dma.sink.ready):
-                yield
+            yield
         yield self.dma.sink.valid.eq(0)
 
     @staticmethod
@@ -104,8 +103,7 @@ class DMAWriterDriver:
         for _ in range(n):
             while not (yield port.wdata.ready):
                 yield
-            while (yield port.wdata.ready):
-                yield
+            yield
 
 
 class DMAReaderDriver:
@@ -130,10 +128,8 @@ class DMAReaderDriver:
     def read_handler(self):
         yield self.dma.source.ready.eq(1)
         while True:
-            while not (yield self.dma.source.valid):
-                yield
-            data = (yield self.dma.source.data)
-            self.data.append(data)
+            if (yield self.dma.source.valid):
+                self.data.append((yield self.dma.source.data))
             yield
 
 

--- a/test/test_bist.py
+++ b/test/test_bist.py
@@ -29,12 +29,15 @@ class GenCheckDriver:
         yield self.module.reset.eq(0)
         yield
 
-    def run(self, base, length, end=None):
+    def configure(self, base, length, end=None):
+        # for non-pattern generators/checkers
         if end is None:
             end = base + 0x100000
         yield self.module.base.eq(base)
         yield self.module.end.eq(end)
         yield self.module.length.eq(length)
+
+    def run(self):
         yield self.module.run.eq(1)
         yield self.module.start.eq(1)
         yield
@@ -101,7 +104,8 @@ class TestBIST(unittest.TestCase):
                 yield from init_generator(dut)
 
             yield from generator.reset()
-            yield from generator.run(base, length, end=end)
+            yield from generator.configure(base, length, end=end)
+            yield from generator.run()
             yield
 
         dut = DUT()
@@ -176,25 +180,30 @@ class TestBIST(unittest.TestCase):
 
             # write
             yield from generator.reset()
-            yield from generator.run(16, 64)
+            yield from generator.configure(16, 64)
+            yield from generator.run()
 
             # read (no errors)
             yield from checker.reset()
-            yield from checker.run(16, 64)
+            yield from checker.configure(16, 64)
+            yield from checker.run()
             assert checker.errors == 0
 
             # corrupt memory (using generator)
             yield from generator.reset()
-            yield from generator.run(16 + 60, 64)
+            yield from generator.configure(16 + 60, 64)
+            yield from generator.run()
 
             # read (4 errors)
             yield from checker.reset()
-            yield from checker.run(16, 64)
+            yield from checker.configure(16, 64)
+            yield from checker.run()
             assert checker.errors != 0
 
             # read (no errors)
             yield from checker.reset()
-            yield from checker.run(16 + 60, 64)
+            yield from checker.configure(16 + 60, 64)
+            yield from checker.run()
             assert checker.errors == 0
 
         # dut

--- a/test/test_bist.py
+++ b/test/test_bist.py
@@ -142,77 +142,77 @@ class TestBIST(unittest.TestCase):
         # define common test data used for both generator and checker tests
         self.bist_test_data = {
             "8bit": dict(
-                base = 2,
-                end = 2 + 8,  # (end - base) must be pow of 2
-                length = 5,
+                base=2,
+                end=2 + 8,  # (end - base) must be pow of 2
+                length=5,
                 #                       2     3     4     5     6     7=2+5
-                expected = [0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x00],
+                expected=[0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x00],
             ),
             "32bit": dict(
-                base = 0x04,
-                end = 0x04 + 8,
-                length = 5 * 4,
-                expected = [
-                    0x00000000, # 0x00
-                    0x00000000, # 0x04
-                    0x00000001, # 0x08
-                    0x00000002, # 0x0c
-                    0x00000003, # 0x10
-                    0x00000004, # 0x14
-                    0x00000000, # 0x18
-                    0x00000000, # 0x1c
+                base=0x04,
+                end=0x04 + 8,
+                length=5 * 4,
+                expected=[
+                    0x00000000,  # 0x00
+                    0x00000000,  # 0x04
+                    0x00000001,  # 0x08
+                    0x00000002,  # 0x0c
+                    0x00000003,  # 0x10
+                    0x00000004,  # 0x14
+                    0x00000000,  # 0x18
+                    0x00000000,  # 0x1c
                 ],
             ),
             "64bit": dict(
-                base = 0x10,
-                end = 0x10 + 8,
-                length = 5 * 8,
-                expected = [
-                    0x0000000000000000, # 0x00
-                    0x0000000000000000, # 0x08
-                    0x0000000000000000, # 0x10
-                    0x0000000000000001, # 0x18
-                    0x0000000000000002, # 0x20
-                    0x0000000000000003, # 0x28
-                    0x0000000000000004, # 0x30
-                    0x0000000000000000, # 0x38
+                base=0x10,
+                end=0x10 + 8,
+                length=5 * 8,
+                expected=[
+                    0x0000000000000000,  # 0x00
+                    0x0000000000000000,  # 0x08
+                    0x0000000000000000,  # 0x10
+                    0x0000000000000001,  # 0x18
+                    0x0000000000000002,  # 0x20
+                    0x0000000000000003,  # 0x28
+                    0x0000000000000004,  # 0x30
+                    0x0000000000000000,  # 0x38
                 ],
             ),
             "32bit_masked": dict(
-                base = 0x04,
-                end = 0x04 + 0x04,  # TODO: fix address masking to be consistent
-                length = 6 * 4,
-                expected = [  # due to masking
-                    0x00000000, # 0x00
-                    0x00000004, # 0x04
-                    0x00000005, # 0x08
-                    0x00000002, # 0x0c
-                    0x00000003, # 0x10
-                    0x00000000, # 0x14
-                    0x00000000, # 0x18
-                    0x00000000, # 0x1c
+                base=0x04,
+                end=0x04 + 0x04,  # TODO: fix address masking to be consistent
+                length=6 * 4,
+                expected=[  # due to masking
+                    0x00000000,  # 0x00
+                    0x00000004,  # 0x04
+                    0x00000005,  # 0x08
+                    0x00000002,  # 0x0c
+                    0x00000003,  # 0x10
+                    0x00000000,  # 0x14
+                    0x00000000,  # 0x18
+                    0x00000000,  # 0x1c
                 ],
             ),
         }
         self.bist_test_data["32bit_long_sequential"] = dict(
-            base = 16,
-            end = 16 + 128,
-            length = 64,
-            expected = [0x00000000] * 128
+            base=16,
+            end=16 + 128,
+            length=64,
+            expected=[0x00000000] * 128
         )
         expected = self.bist_test_data["32bit_long_sequential"]["expected"]
         expected[16//4:(16 + 64)//4] = list(range(64//4))
 
         self.pattern_test_data = {
             "8bit": dict(
-                pattern = [
+                pattern=[
                     # address, data
                     (0x00, 0xaa),
                     (0x05, 0xbb),
                     (0x02, 0xcc),
                     (0x07, 0xdd),
                 ],
-                expected = [
+                expected=[
                     # data, address
                     0xaa,  # 0x00
                     0x00,  # 0x01
@@ -225,14 +225,14 @@ class TestBIST(unittest.TestCase):
                 ],
             ),
             "32bit": dict(
-                pattern = [
+                pattern=[
                     # address, data
                     (0x00, 0xabadcafe),
                     (0x07, 0xbaadf00d),
                     (0x02, 0xcafefeed),
                     (0x01, 0xdeadc0de),
                 ],
-                expected = [
+                expected=[
                     # data, address
                     0xabadcafe,  # 0x00
                     0xdeadc0de,  # 0x04
@@ -245,14 +245,14 @@ class TestBIST(unittest.TestCase):
                 ],
             ),
             "64bit": dict(
-                pattern = [
+                pattern=[
                     # address, data
                     (0x00, 0x0ddf00dbadc0ffee),
                     (0x05, 0xabadcafebaadf00d),
                     (0x02, 0xcafefeedfeedface),
                     (0x07, 0xdeadc0debaadbeef),
                 ],
-                expected = [
+                expected=[
                     # data, address
                     0x0ddf00dbadc0ffee,  # 0x00
                     0x0000000000000000,  # 0x08
@@ -265,14 +265,14 @@ class TestBIST(unittest.TestCase):
                 ],
             ),
             "32bit_not_aligned": dict(
-                pattern = [
+                pattern=[
                     # address, data
                     (0x00, 0xabadcafe),
                     (0x07, 0xbaadf00d),
                     (0x02, 0xcafefeed),
                     (0x01, 0xdeadc0de),
                 ],
-                expected = [
+                expected=[
                     # data, address
                     0xabadcafe,  # 0x00
                     0xdeadc0de,  # 0x04
@@ -285,14 +285,14 @@ class TestBIST(unittest.TestCase):
                 ],
             ),
             "32bit_duplicates": dict(
-                pattern = [
+                pattern=[
                     # address, data
                     (0x00, 0xabadcafe),
                     (0x07, 0xbaadf00d),
                     (0x00, 0xcafefeed),
                     (0x07, 0xdeadc0de),
                 ],
-                expected = [
+                expected=[
                     # data, address
                     0xcafefeed,  # 0x00
                     0x00000000,  # 0x04
@@ -305,14 +305,14 @@ class TestBIST(unittest.TestCase):
                 ],
             ),
             "32bit_sequential": dict(
-                pattern = [
+                pattern=[
                     # address, data
                     (0x02, 0xabadcafe),
                     (0x03, 0xbaadf00d),
                     (0x04, 0xcafefeed),
                     (0x05, 0xdeadc0de),
                 ],
-                expected = [
+                expected=[
                     # data, address
                     0x00000000,  # 0x00
                     0x00000000,  # 0x04
@@ -330,6 +330,8 @@ class TestBIST(unittest.TestCase):
             data = self.pattern_test_data["32bit_long_sequential"]
             data["pattern"].append((i, 64 + i))
             data["expected"][i] = 64 + i
+
+    # Generator ------------------------------------------------------------------------------------
 
     def test_generator(self):
         def main_generator(dut):
@@ -364,14 +366,16 @@ class TestBIST(unittest.TestCase):
         run_simulation(dut, generators)
         self.assertEqual(self.errors, 0)
 
-    def generator_test(self, mem_expected, data_width, pattern=None, config_args=None, check_mem=True):
-        assert pattern is None or config_args is None, "_LiteDRAMBISTGenerator xor _LiteDRAMPatternGenerator"
+    def generator_test(self, mem_expected, data_width, pattern=None, config_args=None,
+                       check_mem=True):
+        assert pattern is None or config_args is None, \
+            "_LiteDRAMBISTGenerator xor _LiteDRAMPatternGenerator"
 
         class DUT(Module):
             def __init__(self):
                 self.write_port = LiteDRAMNativeWritePort(address_width=32, data_width=data_width)
                 if pattern is not None:
-                    self.submodules.generator = _LiteDRAMPatternGenerator(self.write_port, init=pattern)
+                    self.submodules.generator = _LiteDRAMPatternGenerator(self.write_port, pattern)
                 else:
                     self.submodules.generator = _LiteDRAMBISTGenerator(self.write_port)
                 self.mem = DRAMMemory(data_width, len(mem_expected))
@@ -392,6 +396,8 @@ class TestBIST(unittest.TestCase):
         if check_mem:
             self.assertEqual(dut.mem.mem, mem_expected)
         return dut
+
+    # _LiteDRAMBISTGenerator -----------------------------------------------------------------------
 
     def test_bist_generator_8bit(self):
         data = self.bist_test_data["8bit"]
@@ -428,7 +434,8 @@ class TestBIST(unittest.TestCase):
     def test_bist_generator_random_data(self):
         data = self.bist_test_data["32bit"]
         data["random_data"] = True
-        dut = self.generator_test(data.pop("expected"), data_width=32, config_args=data, check_mem=False)
+        dut = self.generator_test(data.pop("expected"), data_width=32, config_args=data,
+                                  check_mem=False)
         # only check that there are no duplicates and that data is not a simple sequence
         mem = [val for val in dut.mem.mem if val != 0]
         self.assertEqual(len(set(mem)), len(mem), msg="Duplicate values in memory")
@@ -437,12 +444,15 @@ class TestBIST(unittest.TestCase):
     def test_bist_generator_random_addr(self):
         data = self.bist_test_data["32bit"]
         data["random_addr"] = True
-        dut = self.generator_test(data.pop("expected"), data_width=32, config_args=data, check_mem=False)
+        dut = self.generator_test(data.pop("expected"), data_width=32, config_args=data,
+                                  check_mem=False)
         # with random address and address wrapping (generator.end) we _can_ have duplicates
         # we can at least check that the values written are not an ordered sequence
         mem = [val for val in dut.mem.mem if val != 0]
         self.assertNotEqual(mem, list(range(len(mem))), msg="Values are a sequence")
         self.assertLess(max(mem), data["length"], msg="Too big value found")
+
+    # _LiteDRAMPatternGenerator --------------------------------------------------------------------
 
     def test_pattern_generator_8bit(self):
         data = self.pattern_test_data["8bit"]
@@ -468,8 +478,11 @@ class TestBIST(unittest.TestCase):
         data = self.pattern_test_data["32bit_sequential"]
         self.generator_test(data["expected"], data_width=32, pattern=data["pattern"])
 
+    # _LiteDRAMBISTChecker -------------------------------------------------------------------------
+
     def checker_test(self, memory, data_width, pattern=None, config_args=None, check_errors=False):
-        assert pattern is None or config_args is None, "_LiteDRAMBISTChecker xor _LiteDRAMPatternChecker"
+        assert pattern is None or config_args is None, \
+            "_LiteDRAMBISTChecker xor _LiteDRAMPatternChecker"
 
         class DUT(Module):
             def __init__(self):
@@ -513,6 +526,8 @@ class TestBIST(unittest.TestCase):
         memory = data.pop("expected")
         self.checker_test(memory, data_width=32, config_args=data)
 
+    # _LiteDRAMPatternChecker ----------------------------------------------------------------------
+
     def test_pattern_checker_8bit(self):
         data = self.pattern_test_data["8bit"]
         self.checker_test(memory=data["expected"], data_width=8, pattern=data["pattern"])
@@ -535,6 +550,8 @@ class TestBIST(unittest.TestCase):
         dut, checker = self.checker_test(
             memory=data["expected"], data_width=32, pattern=data["pattern"], check_errors=False)
         self.assertEqual(checker.errors, num_duplicates)
+
+    # LiteDRAMBISTGenerator and LiteDRAMBISTChecker ------------------------------------------------
 
     def bist_test(self, generator, checker, mem):
         # write
@@ -621,8 +638,9 @@ class TestBIST(unittest.TestCase):
     def test_bist_csr_cdc(self):
         class DUT(Module):
             def __init__(self):
-                self.write_port = LiteDRAMNativeWritePort(address_width=32, data_width=32, clock_domain="async")
-                self.read_port = LiteDRAMNativeReadPort(address_width=32, data_width=32, clock_domain="async")
+                port_kwargs = dict(address_width=32, data_width=32, clock_domain="async")
+                self.write_port = LiteDRAMNativeWritePort(**port_kwargs)
+                self.read_port = LiteDRAMNativeReadPort(**port_kwargs)
                 self.submodules.generator = LiteDRAMBISTGenerator(self.write_port)
                 self.submodules.checker = LiteDRAMBISTChecker(self.read_port)
 
@@ -649,6 +667,8 @@ class TestBIST(unittest.TestCase):
             "async": (7, 3),
         }
         run_simulation(dut, generators, clocks)
+
+    # LiteDRAMDMAWriter ----------------------------------------------------------------------------
 
     def dma_writer_test(self, pattern, mem_expected, data_width, **kwargs):
         class DUT(Module):
@@ -699,6 +719,8 @@ class TestBIST(unittest.TestCase):
     def test_dma_writer_duplicates(self):
         data = self.pattern_test_data["32bit_duplicates"]
         self.dma_writer_test(data["pattern"], data["expected"], data_width=32)
+
+    # LiteDRAMDMAReader ----------------------------------------------------------------------------
 
     def dma_reader_test(self, pattern, mem_expected, data_width, **kwargs):
         class DUT(Module):

--- a/test/test_bist.py
+++ b/test/test_bist.py
@@ -3,7 +3,6 @@
 # License: BSD
 
 import unittest
-import random
 
 from migen import *
 
@@ -89,14 +88,14 @@ class TestBIST(unittest.TestCase):
     def setUp(self):
         # define common test data used for both generator and checker tests
         self.bist_test_data = {
-            '8bit': dict(
+            "8bit": dict(
                 base = 2,
                 end = 2 + 8,  # (end - base) must be pow of 2
                 length = 5,
                 #                       2     3     4     5     6     7=2+5
                 expected = [0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x00],
             ),
-            '32bit': dict(
+            "32bit": dict(
                 base = 0x04,
                 end = 0x04 + 8,
                 length = 5 * 4,
@@ -111,7 +110,7 @@ class TestBIST(unittest.TestCase):
                     0x00000000, # 0x1c
                 ],
             ),
-            '64bit': dict(
+            "64bit": dict(
                 base = 0x10,
                 end = 0x10 + 8,
                 length = 5 * 8,
@@ -126,7 +125,7 @@ class TestBIST(unittest.TestCase):
                     0x0000000000000000, # 0x38
                 ],
             ),
-            '32bit_masked': dict(
+            "32bit_masked": dict(
                 base = 0x04,
                 end = 0x04 + 0x04,  # TODO: fix address masking to be consistent
                 length = 6 * 4,
@@ -142,17 +141,17 @@ class TestBIST(unittest.TestCase):
                 ],
             ),
         }
-        self.bist_test_data['32bit_long_sequential'] = dict(
+        self.bist_test_data["32bit_long_sequential"] = dict(
             base = 16,
             end = 16 + 128,
             length = 64,
             expected = [0x00000000] * 128
         )
-        expected = self.bist_test_data['32bit_long_sequential']['expected']
+        expected = self.bist_test_data["32bit_long_sequential"]["expected"]
         expected[16//4:(16 + 64)//4] = list(range(64//4))
 
         self.pattern_test_data = {
-            '8bit': dict(
+            "8bit": dict(
                 pattern = [
                     # address, data
                     (0x00, 0xaa),
@@ -172,7 +171,7 @@ class TestBIST(unittest.TestCase):
                     0xdd,  # 0x07
                 ],
             ),
-            '32bit': dict(
+            "32bit": dict(
                 pattern = [
                     # address, data
                     (0x00, 0xabadcafe),
@@ -192,7 +191,7 @@ class TestBIST(unittest.TestCase):
                     0xbaadf00d,  # 0x1c
                 ],
             ),
-            '64bit': dict(
+            "64bit": dict(
                 pattern = [
                     # address, data
                     (0x00, 0x0ddf00dbadc0ffee),
@@ -212,7 +211,7 @@ class TestBIST(unittest.TestCase):
                     0xdeadc0debaadbeef,  # 0x38
                 ],
             ),
-            '32bit_not_aligned': dict(
+            "32bit_not_aligned": dict(
                 pattern = [
                     # address, data
                     (0x00, 0xabadcafe),
@@ -232,7 +231,7 @@ class TestBIST(unittest.TestCase):
                     0xbaadf00d,  # 0x1c
                 ],
             ),
-            '32bit_duplicates': dict(
+            "32bit_duplicates": dict(
                 pattern = [
                     # address, data
                     (0x00, 0xabadcafe),
@@ -252,7 +251,7 @@ class TestBIST(unittest.TestCase):
                     0xdeadc0de,  # 0x1c
                 ],
             ),
-            '32bit_sequential': dict(
+            "32bit_sequential": dict(
                 pattern = [
                     # address, data
                     (0x02, 0xabadcafe),
@@ -275,8 +274,6 @@ class TestBIST(unittest.TestCase):
         }
 
     def test_generator(self):
-        port = LiteDRAMNativeWritePort(address_width=32, data_width=32)
-
         def main_generator(dut):
             self.errors = 0
 
@@ -304,13 +301,13 @@ class TestBIST(unittest.TestCase):
         # dut
         dut = Generator(23, n_state=23, taps=[17, 22])
 
-         # simulation
+        # simulation
         generators = [main_generator(dut)]
         run_simulation(dut, generators)
         self.assertEqual(self.errors, 0)
 
     def generator_test(self, mem_expected, data_width, pattern=None, config_args=None, check_mem=True):
-        assert pattern is None or config_args is None, '_LiteDRAMBISTGenerator xor _LiteDRAMPatternGenerator'
+        assert pattern is None or config_args is None, "_LiteDRAMBISTGenerator xor _LiteDRAMPatternGenerator"
 
         class DUT(Module):
             def __init__(self):
@@ -339,8 +336,8 @@ class TestBIST(unittest.TestCase):
         return dut
 
     def test_bist_generator_8bit(self):
-        data = self.bist_test_data['8bit']
-        self.generator_test(data.pop('expected'), data_width=8, config_args=data)
+        data = self.bist_test_data["8bit"]
+        self.generator_test(data.pop("expected"), data_width=8, config_args=data)
 
     def test_bist_generator_range_must_be_pow2(self):
         # NOTE:
@@ -348,73 +345,73 @@ class TestBIST(unittest.TestCase):
         # but it would be better if this restriction didn't hold, this test
         # is here just to notice the change if it happens unintentionally
         # and may be removed if we start supporting arbitrary ranges
-        data = self.bist_test_data['8bit']
-        data['end'] += 1
-        reference = data.pop('expected')
+        data = self.bist_test_data["8bit"]
+        data["end"] += 1
+        reference = data.pop("expected")
         dut = self.generator_test(reference, data_width=8, config_args=data, check_mem=False)
         self.assertNotEqual(dut.mem.mem, reference)
 
     def test_bist_generator_32bit(self):
-        data = self.bist_test_data['32bit']
-        self.generator_test(data.pop('expected'), data_width=32, config_args=data)
+        data = self.bist_test_data["32bit"]
+        self.generator_test(data.pop("expected"), data_width=32, config_args=data)
 
     def test_bist_generator_64bit(self):
-        data = self.bist_test_data['64bit']
-        self.generator_test(data.pop('expected'), data_width=64, config_args=data)
+        data = self.bist_test_data["64bit"]
+        self.generator_test(data.pop("expected"), data_width=64, config_args=data)
 
     def test_bist_generator_32bit_address_masked(self):
-        data = self.bist_test_data['32bit_masked']
-        self.generator_test(data.pop('expected'), data_width=32, config_args=data)
+        data = self.bist_test_data["32bit_masked"]
+        self.generator_test(data.pop("expected"), data_width=32, config_args=data)
 
     def test_bist_generator_32bit_long_sequential(self):
-        data = self.bist_test_data['32bit_long_sequential']
-        self.generator_test(data.pop('expected'), data_width=32, config_args=data)
+        data = self.bist_test_data["32bit_long_sequential"]
+        self.generator_test(data.pop("expected"), data_width=32, config_args=data)
 
     def test_bist_generator_random_data(self):
-        data = self.bist_test_data['32bit']
-        data['random_data'] = True
-        dut = self.generator_test(data.pop('expected'), data_width=32, config_args=data, check_mem=False)
+        data = self.bist_test_data["32bit"]
+        data["random_data"] = True
+        dut = self.generator_test(data.pop("expected"), data_width=32, config_args=data, check_mem=False)
         # only check that there are no duplicates and that data is not a simple sequence
         mem = [val for val in dut.mem.mem if val != 0]
-        self.assertEqual(len(set(mem)), len(mem), msg='Duplicate values in memory')
-        self.assertNotEqual(mem, list(range(len(mem))), msg='Values are a sequence')
+        self.assertEqual(len(set(mem)), len(mem), msg="Duplicate values in memory")
+        self.assertNotEqual(mem, list(range(len(mem))), msg="Values are a sequence")
 
     def test_bist_generator_random_addr(self):  # write whole memory and check if there are no repetitions?
-        data = self.bist_test_data['32bit']
-        data['random_addr'] = True
-        dut = self.generator_test(data.pop('expected'), data_width=32, config_args=data, check_mem=False)
+        data = self.bist_test_data["32bit"]
+        data["random_addr"] = True
+        dut = self.generator_test(data.pop("expected"), data_width=32, config_args=data, check_mem=False)
         # with random address and address wrapping (generator.end) we _can_ have duplicates
         # we can at least check that the values written are not an ordered sequence
         mem = [val for val in dut.mem.mem if val != 0]
-        self.assertNotEqual(mem, list(range(len(mem))), msg='Values are a sequence')
-        self.assertLess(max(mem), data['length'], msg='Too big value found')
+        self.assertNotEqual(mem, list(range(len(mem))), msg="Values are a sequence")
+        self.assertLess(max(mem), data["length"], msg="Too big value found")
 
     def test_pattern_generator_8bit(self):
-        data = self.pattern_test_data['8bit']
-        self.generator_test(data['expected'], data_width=8, pattern=data['pattern'])
+        data = self.pattern_test_data["8bit"]
+        self.generator_test(data["expected"], data_width=8, pattern=data["pattern"])
 
     def test_pattern_generator_32bit(self):
-        data = self.pattern_test_data['32bit']
-        self.generator_test(data['expected'], data_width=32, pattern=data['pattern'])
+        data = self.pattern_test_data["32bit"]
+        self.generator_test(data["expected"], data_width=32, pattern=data["pattern"])
 
     def test_pattern_generator_64bit(self):
-        data = self.pattern_test_data['64bit']
-        self.generator_test(data['expected'], data_width=64, pattern=data['pattern'])
+        data = self.pattern_test_data["64bit"]
+        self.generator_test(data["expected"], data_width=64, pattern=data["pattern"])
 
     def test_pattern_generator_32bit_not_aligned(self):
-        data = self.pattern_test_data['32bit_not_aligned']
-        self.generator_test(data['expected'], data_width=32, pattern=data['pattern'])
+        data = self.pattern_test_data["32bit_not_aligned"]
+        self.generator_test(data["expected"], data_width=32, pattern=data["pattern"])
 
     def test_pattern_generator_32bit_duplicates(self):
-        data = self.pattern_test_data['32bit_duplicates']
-        self.generator_test(data['expected'], data_width=32, pattern=data['pattern'])
+        data = self.pattern_test_data["32bit_duplicates"]
+        self.generator_test(data["expected"], data_width=32, pattern=data["pattern"])
 
     def test_pattern_generator_32bit_sequential(self):
-        data = self.pattern_test_data['32bit_sequential']
-        self.generator_test(data['expected'], data_width=32, pattern=data['pattern'])
+        data = self.pattern_test_data["32bit_sequential"]
+        self.generator_test(data["expected"], data_width=32, pattern=data["pattern"])
 
     def checker_test(self, memory, data_width, pattern=None, config_args=None, check_errors=False):
-        assert pattern is None or config_args is None, '_LiteDRAMBISTChecker xor _LiteDRAMPatternChecker'
+        assert pattern is None or config_args is None, "_LiteDRAMBISTChecker xor _LiteDRAMPatternChecker"
 
         class DUT(Module):
             def __init__(self):
@@ -444,40 +441,41 @@ class TestBIST(unittest.TestCase):
         return dut, checker
 
     def test_bist_checker_8bit(self):
-        data = self.bist_test_data['8bit']
-        memory = data.pop('expected')
+        data = self.bist_test_data["8bit"]
+        memory = data.pop("expected")
         self.checker_test(memory, data_width=8, config_args=data)
 
     def test_bist_checker_32bit(self):
-        data = self.bist_test_data['32bit']
-        memory = data.pop('expected')
+        data = self.bist_test_data["32bit"]
+        memory = data.pop("expected")
         self.checker_test(memory, data_width=32, config_args=data)
 
     def test_bist_checker_64bit(self):
-        data = self.bist_test_data['32bit']
-        memory = data.pop('expected')
+        data = self.bist_test_data["32bit"]
+        memory = data.pop("expected")
         self.checker_test(memory, data_width=32, config_args=data)
 
     def test_pattern_checker_8bit(self):
-        data = self.pattern_test_data['8bit']
-        self.checker_test(memory=data['expected'], data_width=8, pattern=data['pattern'])
+        data = self.pattern_test_data["8bit"]
+        self.checker_test(memory=data["expected"], data_width=8, pattern=data["pattern"])
 
     def test_pattern_checker_32bit(self):
-        data = self.pattern_test_data['32bit']
-        self.checker_test(memory=data['expected'], data_width=32, pattern=data['pattern'])
+        data = self.pattern_test_data["32bit"]
+        self.checker_test(memory=data["expected"], data_width=32, pattern=data["pattern"])
 
     def test_pattern_checker_64bit(self):
-        data = self.pattern_test_data['64bit']
-        self.checker_test(memory=data['expected'], data_width=64, pattern=data['pattern'])
+        data = self.pattern_test_data["64bit"]
+        self.checker_test(memory=data["expected"], data_width=64, pattern=data["pattern"])
 
     def test_pattern_checker_32bit_not_aligned(self):
-        data = self.pattern_test_data['32bit_not_aligned']
-        self.checker_test(memory=data['expected'], data_width=32, pattern=data['pattern'])
+        data = self.pattern_test_data["32bit_not_aligned"]
+        self.checker_test(memory=data["expected"], data_width=32, pattern=data["pattern"])
 
     def test_pattern_checker_32bit_duplicates(self):
-        data = self.pattern_test_data['32bit_duplicates']
-        num_duplicates = len(data['pattern']) - len(set(adr for adr, _ in data['pattern']))
-        dut, checker = self.checker_test(memory=data['expected'], data_width=32, pattern=data['pattern'], check_errors=False)
+        data = self.pattern_test_data["32bit_duplicates"]
+        num_duplicates = len(data["pattern"]) - len(set(adr for adr, _ in data["pattern"]))
+        dut, checker = self.checker_test(
+            memory=data["expected"], data_width=32, pattern=data["pattern"], check_errors=False)
         self.assertEqual(checker.errors, num_duplicates)
 
     def bist_test(self, generator, checker, mem):
@@ -534,7 +532,7 @@ class TestBIST(unittest.TestCase):
             main_generator(dut, mem),
             mem.write_handler(dut.write_port),
             mem.read_handler(dut.read_port)
-         ]
+        ]
         run_simulation(dut, generators)
 
     def test_bist_csr(self):
@@ -559,14 +557,14 @@ class TestBIST(unittest.TestCase):
             main_generator(dut, mem),
             mem.write_handler(dut.write_port),
             mem.read_handler(dut.read_port)
-         ]
+        ]
         run_simulation(dut, generators)
 
     def test_bist_csr_cdc(self):
         class DUT(Module):
             def __init__(self):
-                self.write_port = LiteDRAMNativeWritePort(address_width=32, data_width=32, clock_domain='async')
-                self.read_port = LiteDRAMNativeReadPort(address_width=32, data_width=32, clock_domain='async')
+                self.write_port = LiteDRAMNativeWritePort(address_width=32, data_width=32, clock_domain="async")
+                self.read_port = LiteDRAMNativeReadPort(address_width=32, data_width=32, clock_domain="async")
                 self.submodules.generator = LiteDRAMBISTGenerator(self.write_port)
                 self.submodules.checker = LiteDRAMBISTChecker(self.read_port)
 
@@ -580,16 +578,16 @@ class TestBIST(unittest.TestCase):
         mem = DRAMMemory(32, 48)
 
         generators = {
-            'sys': [
+            "sys": [
                 main_generator(dut, mem),
             ],
-            'async': [
+            "async": [
                 mem.write_handler(dut.write_port),
                 mem.read_handler(dut.read_port)
             ]
         }
         clocks = {
-            'sys': 10,
-            'async': (7, 3),
+            "sys": 10,
+            "async": (7, 3),
         }
         run_simulation(dut, generators, clocks)

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -1,0 +1,165 @@
+# This file is Copyright (c) 2020 Antmicro <www.antmicro.com>
+# License: BSD
+
+import unittest
+
+from migen import *
+
+from litex.gen.sim import *
+
+from litedram.common import *
+from litedram.frontend.dma import *
+
+from test.common import *
+
+
+class DMAWriterDriver:
+    def __init__(self, dma):
+        self.dma = dma
+
+    def write(self, pattern):
+        yield self.dma.sink.valid.eq(1)
+        for adr, data in pattern:
+            yield self.dma.sink.address.eq(adr)
+            yield self.dma.sink.data.eq(data)
+            while not (yield self.dma.sink.ready):
+                yield
+            yield
+        yield self.dma.sink.valid.eq(0)
+
+    @staticmethod
+    def wait_complete(port, n):
+        for _ in range(n):
+            while not (yield port.wdata.ready):
+                yield
+            yield
+
+
+class DMAReaderDriver:
+    def __init__(self, dma):
+        self.dma = dma
+        self.data = []
+
+    def read(self, address_list):
+        n_last = len(self.data)
+        yield self.dma.sink.valid.eq(1)
+        for adr in address_list:
+            yield self.dma.sink.address.eq(adr)
+            while not (yield self.dma.sink.ready):
+                yield
+            while (yield self.dma.sink.ready):
+                yield
+        yield self.dma.sink.valid.eq(0)
+        while len(self.data) < n_last + len(address_list):
+            yield
+
+    @passive
+    def read_handler(self):
+        yield self.dma.source.ready.eq(1)
+        while True:
+            if (yield self.dma.source.valid):
+                self.data.append((yield self.dma.source.data))
+            yield
+
+
+class TestDMA(MemoryTestDataMixin, unittest.TestCase):
+
+    # LiteDRAMDMAWriter ----------------------------------------------------------------------------
+
+    def dma_writer_test(self, pattern, mem_expected, data_width, **kwargs):
+        class DUT(Module):
+            def __init__(self):
+                self.port = LiteDRAMNativeWritePort(address_width=32, data_width=data_width)
+                self.submodules.dma = LiteDRAMDMAWriter(self.port, **kwargs)
+
+        dut = DUT()
+        driver = DMAWriterDriver(dut.dma)
+        mem = DRAMMemory(data_width, len(mem_expected))
+
+        generators = [
+            driver.write(pattern),
+            driver.wait_complete(dut.port, len(pattern)),
+            mem.write_handler(dut.port),
+        ]
+        run_simulation(dut, generators)
+        self.assertEqual(mem.mem, mem_expected)
+
+    def test_dma_writer_single(self):
+        pattern = [(0x04, 0xdeadc0de)]
+        mem_expected = [0] * 32
+        mem_expected[0x04] = 0xdeadc0de
+        self.dma_writer_test(pattern, mem_expected, data_width=32)
+
+    def test_dma_writer_multiple(self):
+        data = self.pattern_test_data["32bit"]
+        self.dma_writer_test(data["pattern"], data["expected"], data_width=32)
+
+    def test_dma_writer_sequential(self):
+        data = self.pattern_test_data["32bit_sequential"]
+        self.dma_writer_test(data["pattern"], data["expected"], data_width=32)
+
+    def test_dma_writer_long_sequential(self):
+        data = self.pattern_test_data["32bit_long_sequential"]
+        self.dma_writer_test(data["pattern"], data["expected"], data_width=32)
+
+    def test_dma_writer_no_fifo(self):
+        data = self.pattern_test_data["32bit_long_sequential"]
+        self.dma_writer_test(data["pattern"], data["expected"], data_width=32,
+                             fifo_depth=1)
+
+    def test_dma_writer_fifo_buffered(self):
+        data = self.pattern_test_data["32bit_long_sequential"]
+        self.dma_writer_test(data["pattern"], data["expected"], data_width=32,
+                             fifo_buffered=True)
+
+    def test_dma_writer_duplicates(self):
+        data = self.pattern_test_data["32bit_duplicates"]
+        self.dma_writer_test(data["pattern"], data["expected"], data_width=32)
+
+    # LiteDRAMDMAReader ----------------------------------------------------------------------------
+
+    def dma_reader_test(self, pattern, mem_expected, data_width, **kwargs):
+        class DUT(Module):
+            def __init__(self):
+                self.port = LiteDRAMNativeReadPort(address_width=32, data_width=data_width)
+                self.submodules.dma = LiteDRAMDMAReader(self.port, **kwargs)
+
+        dut = DUT()
+        driver = DMAReaderDriver(dut.dma)
+        mem = DRAMMemory(data_width, len(mem_expected), init=mem_expected)
+
+        generators = [
+            driver.read([adr for adr, data in pattern]),
+            driver.read_handler(),
+            mem.read_handler(dut.port),
+        ]
+        run_simulation(dut, generators)
+        self.assertEqual(driver.data, [data for adr, data in pattern])
+
+    def test_dma_reader_single(self):
+        pattern = [(0x04, 0xdeadc0de)]
+        mem_expected = [0] * 32
+        mem_expected[0x04] = 0xdeadc0de
+        self.dma_reader_test(pattern, mem_expected, data_width=32)
+
+    def test_dma_reader_multiple(self):
+        data = self.pattern_test_data["32bit"]
+        self.dma_reader_test(data["pattern"], data["expected"], data_width=32)
+
+    def test_dma_reader_sequential(self):
+        data = self.pattern_test_data["32bit_sequential"]
+        self.dma_reader_test(data["pattern"], data["expected"], data_width=32)
+
+    def test_dma_reader_long_sequential(self):
+        data = self.pattern_test_data["32bit_long_sequential"]
+        self.dma_reader_test(data["pattern"], data["expected"], data_width=32)
+
+    def test_dma_reader_no_fifo(self):
+        data = self.pattern_test_data["32bit_long_sequential"]
+        self.dma_reader_test(data["pattern"], data["expected"], data_width=32,
+                             fifo_depth=1)
+
+    def test_dma_reader_fifo_buffered(self):
+        data = self.pattern_test_data["32bit_long_sequential"]
+        self.dma_reader_test(data["pattern"], data["expected"], data_width=32,
+                             fifo_buffered=True)


### PR DESCRIPTION
This PR adds tests for `_LiteDRAMBISTGenerator`, `_LiteDRAMPatternGenerator`, `_LiteDRAMBISTChecker`, `_LiteDRAMPatternChecker`. Test data definitions are created in `setUp` and then used as reference in different test.

It tests current pattern addressing (not https://github.com/enjoy-digital/litedram/issues/164).

If you would prefer to wait for all the BIST related tests, than I can just commit to this PR.