### PR TITLE
Add tests for litedram.frontend.adaptation

### DIFF
--- a/test/test_adaptation.py
+++ b/test/test_adaptation.py
@@ -196,11 +196,12 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
         dut = ConverterDUT(user_data_width=32, native_data_width=256, mem_depth=len(data["expected"]))
         self.converter_readback_test(dut, data["pattern"], data["expected"])
 
-    #  # TODO: implement case when user does not write all words (LiteDRAMNativeWritePortUpConverter)
-    #  def test_converter_up_not_aligned(self):
-    #      data = self.pattern_test_data["8bit_to_32bit_not_aligned"]
-    #      dut = ConverterDUT(user_data_width=8, native_data_width=32, mem_depth=len(data["expected"]))
-    #      self.converter_readback_test(dut, data["pattern"], data["expected"])
+    # TODO: implement case when user does not write all words (LiteDRAMNativeWritePortUpConverter)
+    @unittest.skip("Only full-burst writes currently supported")
+    def test_converter_up_not_aligned(self):
+        data = self.pattern_test_data["8bit_to_32bit_not_aligned"]
+        dut = ConverterDUT(user_data_width=8, native_data_width=32, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
 
     def cdc_readback_test(self, dut, pattern, mem_expected, clocks):
         assert len(set(adr for adr, _ in pattern)) == len(pattern), "Pattern has duplicates!"

--- a/test/test_adaptation.py
+++ b/test/test_adaptation.py
@@ -16,7 +16,7 @@ from litex.gen.sim import *
 
 
 class ConverterDUT(Module):
-    def __init__(self, user_data_width, native_data_width):
+    def __init__(self, user_data_width, native_data_width, mem_depth):
         # write port and converter
         self.write_user_port = LiteDRAMNativeWritePort(address_width=32, data_width=user_data_width)
         self.write_crossbar_port = LiteDRAMNativeWritePort(address_width=32, data_width=native_data_width)
@@ -32,12 +32,86 @@ class ConverterDUT(Module):
         self.submodules += read_converter
 
         # memory
-        self.memory = DRAMMemory(native_data_width, 128)
+        self.memory = DRAMMemory(native_data_width, mem_depth)
+
+    def write_up(self, address, data, we=None):
+        port = self.write_user_port
+        if we is None:
+            we = 2**port.wdata.we.nbits - 1
+        yield port.cmd.valid.eq(1)
+        yield port.cmd.we.eq(1)
+        yield port.cmd.addr.eq(address)
+        yield
+        while (yield port.cmd.ready) == 0:
+            yield
+        yield port.cmd.valid.eq(0)
+        yield
+        yield port.wdata.valid.eq(1)
+        yield port.wdata.data.eq(data)
+        yield port.wdata.we.eq(we)
+        yield
+        while (yield port.wdata.ready) == 0:
+            yield
+        yield port.wdata.valid.eq(0)
+        yield
+
+    def write_down(self, address, data, we=None):
+        # down converter must have all the data available along with cmd
+        # it will set user_port.cmd.ready only when it sends all input words
+        port = self.write_user_port
+        if we is None:
+            we = 2**port.wdata.we.nbits - 1
+        yield port.cmd.valid.eq(1)
+        yield port.cmd.we.eq(1)
+        yield port.cmd.addr.eq(address)
+        yield port.wdata.valid.eq(1)
+        yield port.wdata.data.eq(data)
+        yield port.wdata.we.eq(we)
+        yield
+        # ready goes up only after StrideConverter copied all words
+        while (yield port.cmd.ready) == 0:
+            yield
+        yield port.cmd.valid.eq(0)
+        yield
+        while (yield port.wdata.ready) == 0:
+            yield
+        yield port.wdata.valid.eq(0)
+        yield
+
+    def read(self, address, read_data=True):
+        port = self.read_user_port
+        yield port.cmd.valid.eq(1)
+        yield port.cmd.we.eq(0)
+        yield port.cmd.addr.eq(address)
+        yield
+        while (yield port.cmd.ready) == 0:
+            yield
+        yield port.cmd.valid.eq(0)
+        yield
+        if read_data:
+            while (yield port.rdata.valid) == 0:
+                yield
+            data = (yield port.rdata.data)
+            yield port.rdata.ready.eq(1)
+            yield
+            yield port.rdata.ready.eq(0)
+            yield
+            return data
 
 
-class TestAdaptation(unittest.TestCase):
-    def test_up_converter(self):
-        write_data = [seed_to_data(i, nbits=32) for i in range(16)]
+class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
+    def test_converter_down_ratio_must_be_integer(self):
+        with self.assertRaises(ValueError) as cm:
+            ConverterDUT(user_data_width=64, native_data_width=24, mem_depth=128)
+        self.assertIn("ratio must be an int", str(cm.exception).lower())
+
+    def test_converter_up_ratio_must_be_integer(self):
+        with self.assertRaises(ValueError) as cm:
+            ConverterDUT(user_data_width=32, native_data_width=48, mem_depth=128)
+        self.assertIn("ratio must be an int", str(cm.exception).lower())
+
+    def converter_readback_test(self, dut, pattern, mem_expected):
+        assert len(set(adr for adr, _ in pattern)) == len(pattern), "Pattern has duplicates!"
         read_data = []
 
         @passive
@@ -48,102 +122,70 @@ class TestAdaptation(unittest.TestCase):
                     read_data.append((yield read_port.rdata.data))
                 yield
 
+        def main_generator(dut, pattern):
+            if dut.write_user_port.data_width > dut.write_crossbar_port.data_width:
+                write = dut.write_down
+            else:
+                write = dut.write_up
 
-        def main_generator(write_port, read_port):
-            # write
-            for i in range(16):
-                yield write_port.cmd.valid.eq(1)
-                yield write_port.cmd.we.eq(1)
-                yield write_port.cmd.addr.eq(i)
-                yield
-                while (yield write_port.cmd.ready) == 0:
-                    yield
-                yield write_port.cmd.valid.eq(0)
-                yield
-                yield write_port.wdata.valid.eq(1)
-                yield write_port.wdata.data.eq(write_data[i])
-                yield write_port.wdata.we.eq(0b1111)
-                yield
-                while (yield write_port.wdata.ready) == 0:
-                    yield
-                yield write_port.wdata.valid.eq(0)
-                yield
+            for adr, data in pattern:
+                yield from write(adr, data)
 
-            # read
-            for i in range(16):
-                yield read_port.cmd.valid.eq(1)
-                yield read_port.cmd.we.eq(0)
-                yield read_port.cmd.addr.eq(i)
-                yield
-                while (yield read_port.cmd.ready) == 0:
-                    yield
-                yield read_port.cmd.valid.eq(0)
-                yield
-
-            # delay
-            for i in range(32):
-                yield
-
-        dut = ConverterDUT(user_data_width=32, native_data_width=128)
-        generators = [
-            main_generator(dut.write_user_port, dut.read_user_port),
-            read_handler(dut.read_user_port),
-            dut.memory.write_handler(dut.write_crossbar_port),
-            dut.memory.read_handler(dut.read_crossbar_port)
-        ]
-        run_simulation(dut, generators)
-        self.assertEqual(write_data, read_data)
-
-    def test_down_converter(self):
-        write_data = [seed_to_data(i, nbits=64) for i in range(8)]
-        read_data = []
-
-        @passive
-        def read_handler(read_port):
-            yield read_port.rdata.ready.eq(1)
-            while True:
-                if (yield read_port.rdata.valid):
-                    read_data.append((yield read_port.rdata.data))
-                yield
-
-        def main_generator(write_port, read_port):
-            # write
-            for i in range(8):
-                yield write_port.cmd.valid.eq(1)
-                yield write_port.cmd.we.eq(1)
-                yield write_port.cmd.addr.eq(i)
-                yield write_port.wdata.valid.eq(1)
-                yield write_port.wdata.data.eq(write_data[i])
-                yield write_port.wdata.we.eq(0xff)
-                yield
-                while (yield write_port.cmd.ready) == 0:
-                    yield
-                while (yield write_port.wdata.ready) == 0:
-                    yield
-                yield
-
-            # read
-            yield read_port.rdata.ready.eq(1)
-            for i in range(8):
-                yield read_port.cmd.valid.eq(1)
-                yield read_port.cmd.we.eq(0)
-                yield read_port.cmd.addr.eq(i)
-                yield
-                while (yield read_port.cmd.ready) == 0:
-                    yield
-                yield read_port.cmd.valid.eq(0)
-                yield
+            for adr, _ in pattern:
+                yield from dut.read(adr, read_data=False)
 
             # latency delay
-            for i in range(32):
+            for _ in range(32):
                 yield
 
-        dut = ConverterDUT(user_data_width=64, native_data_width=32)
         generators = [
-            main_generator(dut.write_user_port, dut.read_user_port),
+            main_generator(dut, pattern),
             read_handler(dut.read_user_port),
             dut.memory.write_handler(dut.write_crossbar_port),
-            dut.memory.read_handler(dut.read_crossbar_port)
+            dut.memory.read_handler(dut.read_crossbar_port),
+            timeout_generator(5000),
         ]
         run_simulation(dut, generators)
-        self.assertEqual(write_data, read_data)
+        self.assertEqual(dut.memory.mem, mem_expected)
+        self.assertEqual(read_data, [data for adr, data in pattern])
+
+    def test_converter_1to1(self):
+        data = self.pattern_test_data["64bit"]
+        dut = ConverterDUT(user_data_width=64, native_data_width=64, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    def test_converter_2to1(self):
+        data = self.pattern_test_data["64bit_to_32bit"]
+        dut = ConverterDUT(user_data_width=64, native_data_width=32, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    def test_converter_4to1(self):
+        data = self.pattern_test_data["32bit_to_8bit"]
+        dut = ConverterDUT(user_data_width=32, native_data_width=8, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    def test_converter_8to1(self):
+        data = self.pattern_test_data["64bit_to_8bit"]
+        dut = ConverterDUT(user_data_width=64, native_data_width=8, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    def test_converter_1to2(self):
+        data = self.pattern_test_data["8bit_to_16bit"]
+        dut = ConverterDUT(user_data_width=8, native_data_width=16, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    def test_converter_1to4(self):
+        data = self.pattern_test_data["32bit_to_128bit"]
+        dut = ConverterDUT(user_data_width=32, native_data_width=128, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    def test_converter_1to8(self):
+        data = self.pattern_test_data["32bit_to_256bit"]
+        dut = ConverterDUT(user_data_width=32, native_data_width=256, mem_depth=len(data["expected"]))
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
+
+    #  # TODO: implement case when user does not write all words (LiteDRAMNativeWritePortUpConverter)
+    #  def test_converter_up_not_aligned(self):
+    #      data = self.pattern_test_data["8bit_to_32bit_not_aligned"]
+    #      dut = ConverterDUT(user_data_width=8, native_data_width=32, mem_depth=len(data["expected"]))
+    #      self.converter_readback_test(dut, data["pattern"], data["expected"])

--- a/test/test_bist.py
+++ b/test/test_bist.py
@@ -390,35 +390,36 @@ class TestBIST(MemoryTestDataMixin, unittest.TestCase):
         run_simulation(dut, generators)
 
     # FIXME: synchronization between CSRs: `start` and `base`, `done` and `errors`
-    #  def test_bist_csr_cdc(self):
-    #      class DUT(Module):
-    #          def __init__(self):
-    #              port_kwargs = dict(address_width=32, data_width=32, clock_domain="async")
-    #              self.write_port = LiteDRAMNativeWritePort(**port_kwargs)
-    #              self.read_port = LiteDRAMNativeReadPort(**port_kwargs)
-    #              self.submodules.generator = LiteDRAMBISTGenerator(self.write_port)
-    #              self.submodules.checker = LiteDRAMBISTChecker(self.read_port)
-    #
-    #      def main_generator(dut, mem):
-    #          generator = GenCheckCSRDriver(dut.generator)
-    #          checker = GenCheckCSRDriver(dut.checker)
-    #          yield from self.bist_test(generator, checker, mem)
-    #
-    #      # dut
-    #      dut = DUT()
-    #      mem = DRAMMemory(32, 48)
-    #
-    #      generators = {
-    #          "sys": [
-    #              main_generator(dut, mem),
-    #          ],
-    #          "async": [
-    #              mem.write_handler(dut.write_port),
-    #              mem.read_handler(dut.read_port)
-    #          ]
-    #      }
-    #      clocks = {
-    #          "sys": 10,
-    #          "async": (7, 3),
-    #      }
-    #      run_simulation(dut, generators, clocks)
+    @unittest.skip("CSRs CDC synchronization problem (issue #167)")
+    def test_bist_csr_cdc(self):
+        class DUT(Module):
+            def __init__(self):
+                port_kwargs = dict(address_width=32, data_width=32, clock_domain="async")
+                self.write_port = LiteDRAMNativeWritePort(**port_kwargs)
+                self.read_port = LiteDRAMNativeReadPort(**port_kwargs)
+                self.submodules.generator = LiteDRAMBISTGenerator(self.write_port)
+                self.submodules.checker = LiteDRAMBISTChecker(self.read_port)
+
+        def main_generator(dut, mem):
+            generator = GenCheckCSRDriver(dut.generator)
+            checker = GenCheckCSRDriver(dut.checker)
+            yield from self.bist_test(generator, checker, mem)
+
+        # dut
+        dut = DUT()
+        mem = DRAMMemory(32, 48)
+
+        generators = {
+            "sys": [
+                main_generator(dut, mem),
+            ],
+            "async": [
+                mem.write_handler(dut.write_port),
+                mem.read_handler(dut.read_port)
+            ]
+        }
+        clocks = {
+            "sys": 10,
+            "async": (7, 3),
+        }
+        run_simulation(dut, generators, clocks)


### PR DESCRIPTION
Part of  https://github.com/enjoy-digital/litedram/issues/156.

This adds tests for up/down converters with different conversion ratios and for CDC.

I've also added [test_converter_up_not_aligned](https://github.com/antmicro/litedram/blob/jboc/unit-tests/test/test_adaptation.py#L199) for up-converter when the pattern is not composed of groups of `ratio` consecutive words ([example pattern](https://github.com/antmicro/litedram/blob/0afacba2ca4f1b69831bdd1b83c4cd09875cd763/test/common.py#L356)), but this currently fails so I commented out that test. Do we want to support this case in `LiteDRAMNativeWritePortUpConverter` in the future or this test case is unnecessary?