### PR TITLE
modules: add MTA4ATF51264HZ DDR4 SO-DIMM

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -612,3 +612,20 @@ class KVR21SE15S84(SDRAMModule):
         "2133": _SpeedgradeTimings(tRP=13.5, tRCD=13.5, tWR=15, tRFC=trfc, tFAW=(20, 25), tRAS=33),
     }
     speedgrade_timings["default"] = speedgrade_timings["2133"]
+
+class MTA4ATF51264HZ(SDRAMModule):
+    memtype = "DDR4"
+    # geometry
+    ngroupbanks = 4
+    ngroups     = 2
+    nbanks      = ngroups * ngroupbanks
+    nrows       = 65536
+    ncols       = 1024
+    # timings
+    trefi = {"1x": 64e6/8192,   "2x": (64e6/8192)/2, "4x": (64e6/8192)/4}
+    trfc  = {"1x": (None, 350), "2x": (None, 260),   "4x": (None, 160)}
+    technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 4.9), tZQCS=(128, 80))
+    speedgrade_timings = {
+        "2133": _SpeedgradeTimings(tRP=13.5, tRCD=13.5, tWR=15, tRFC=trfc, tFAW=(20, 25), tRAS=33),
+    }
+    speedgrade_timings["default"] = speedgrade_timings["2133"]


### PR DESCRIPTION
This PR adds DDR4 SO-DIMM module that works on the ZCU104 board
This module was tested as part of litex-hub/litex-boards#49