### PR TITLE
Add docstrings to litedram.core modules

### DIFF
--- a/litedram/core/bandwidth.py
+++ b/litedram/core/bandwidth.py
@@ -12,6 +12,33 @@ from litex.soc.interconnect.csr import *
 # Bandwidth ----------------------------------------------------------------------------------------
 
 class Bandwidth(Module, AutoCSR):
+    """Measures LiteDRAM bandwidth
+
+    This module works by counting the number of read/write commands issued by
+    the controller during a fixed time period. To copy the values registered
+    during the last finished period, user must write to the `update` register.
+
+    Parameters
+    ----------
+    cmd : Endpoint(cmd_request_rw_layout)
+        Multiplexer endpoint on which all read/write requests are being sent
+    data_width : int, in
+        Data width that can be read back from CSR
+    period_bits : int, in
+        Defines length of bandwidth measurement period = 2^period_bits
+
+    Attributes
+    ----------
+    update : CSR, in
+        Copy the values from last finished period to the status registers
+    nreads : CSRStatus, out
+        Number of READ commands issued during a period
+    nwrites : CSRStatus, out
+        Number of WRITE commands issued during a period
+    data_width : CSRStatus, out
+        Can be read to calculate bandwidth in bits/sec as:
+            bandwidth = (nreads+nwrites) * data_width / period
+    """
     def __init__(self, cmd, data_width, period_bits=24):
         self.update     = CSR()
         self.nreads     = CSRStatus(period_bits)


### PR DESCRIPTION
While writing tests for https://github.com/enjoy-digital/litedram/issues/155 I've been also filling in the documentation of these modules. This PR gathers my notes and adds missing docstrings for `core` modules. Please review them to check if there are no mistakes.

I also found that there was some dead code in `crossbar.py`. It seems that it is not needed, but correct me if I'm wrong. https://github.com/enjoy-digital/litedram/commit/1f246cbb88b9d2c286eb7f3492edbfde93fe02d7 removes these parts, and fixes indentation in the for loops.