### PR TITLE
modules: Add MTA18ASF2G72PZ DDR4 RDIMM

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -792,3 +792,21 @@ class MTA4ATF51264HZ(SDRAMModule):
         "2133": _SpeedgradeTimings(tRP=13.5, tRCD=13.5, tWR=15, tRFC=trfc, tFAW=(20, 25), tRAS=33),
     }
     speedgrade_timings["default"] = speedgrade_timings["2133"]
+
+# DDR4 (RDIMM) -------------------------------------------------------------------------------------
+class MTA18ASF2G72PZ(SDRAMModule):
+    memtype = "DDR4"
+    # geometry
+    ngroupbanks = 4
+    ngroups     = 4
+    nbanks      = ngroups * ngroupbanks
+    nrows       = 131072
+    ncols       = 1024
+    # timings
+    trefi = {"1x": 64e6/8192,   "2x": (64e6/8192)/2, "4x": (64e6/8192)/4}
+    trfc  = {"1x": (None, 350), "2x": (None, 260),   "4x": (None, 160)}
+    technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 4.9), tZQCS=(128, 80))
+    speedgrade_timings = {
+        "2400": _SpeedgradeTimings(tRP=13.32, tRCD=13.32, tWR=15, tRFC=trfc, tFAW=(20, 25), tRAS=32),
+    }
+    speedgrade_timings["default"] = speedgrade_timings["2400"]


### PR DESCRIPTION
RDIMM-related configuration is currently missing, as more work is required for a format for this.