### PR TITLE
Add support for DDR4 RDIMMs

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -173,6 +173,7 @@ class PhySettings(Settings):
                  cl, read_latency, write_latency, nranks=1, cwl=None):
         self.set_attributes(locals())
         self.cwl = cl if cwl is None else cwl
+        self.is_rdimm = False
 
     # Optional DDR3/DDR4 electrical settings:
     # rtt_nom: Non-Writes on-die termination impedance
@@ -182,6 +183,11 @@ class PhySettings(Settings):
         assert self.memtype in ["DDR3", "DDR4"]
         self.set_attributes(locals())
 
+    # Optional RDIMM configuration
+    def set_rdimm(self, tck, rcd_pll_bypass, rcd_ca_cs_drive, rcd_odt_cke_drive, rcd_clk_drive):
+        assert self.memtype == "DDR4"
+        self.is_rdimm = True
+        self.set_attributes(locals())
 
 class GeomSettings(Settings):
     def __init__(self, bankbits, rowbits, colbits):

--- a/litedram/phy/usddrphy.py
+++ b/litedram/phy/usddrphy.py
@@ -22,7 +22,8 @@ class USDDRPHY(Module, AutoCSR):
         memtype          = "DDR3",
         sys_clk_freq     = 100e6,
         iodelay_clk_freq = 200e6,
-        cmd_latency      = 0):
+        cmd_latency      = 0,
+        is_rdimm         = False):
         phytype     = self.__class__.__name__
         device      = {"USDDRPHY": "ULTRASCALE", "USPDDRPHY": "ULTRASCALE_PLUS"}[phytype]
         pads        = PHYPadsCombiner(pads)
@@ -89,6 +90,16 @@ class USDDRPHY(Module, AutoCSR):
             read_latency  = 2 + cl_sys_latency + 1 + 2,
             write_latency = cwl_sys_latency
         )
+
+        if is_rdimm:
+            # All drive settings for an 8-chip load
+            self.settings.set_rdimm(
+                tck               = tck,
+                rcd_pll_bypass    = False,
+                rcd_ca_cs_drive   = 0x5,
+                rcd_odt_cke_drive = 0x5,
+                rcd_clk_drive     = 0x5
+            )
 
         # DFI Interface ----------------------------------------------------------------------------
         self.dfi = dfi = Interface(addressbits, bankbits, nranks, 2*databits, nphases)


### PR DESCRIPTION
I would appreciate some feedback on the structure, it seems like perhaps is_rdimm and drive strengths should be a module property, but I can't find a nice way of glueing that in.

This also still needs regression testing on a non-RDIMM platform too, I can do that if you want.