### PR TITLE
WIP: Implement cmd_latency calibration 

### DIFF
--- a/litedram/core/multiplexer.py
+++ b/litedram/core/multiplexer.py
@@ -324,10 +324,11 @@ class Multiplexer(Module, AutoCSR):
                     elif i == settings.phy.rdcmdphase:
                         s = steerer.sel[i].eq(STEER_CMD)
                 elif r_w_n == "write":
-                    if i == settings.phy.wrphase:
-                        s = steerer.sel[i].eq(STEER_REQ)
-                    elif i == settings.phy.wrcmdphase:
-                        s = steerer.sel[i].eq(STEER_CMD)
+                    s = If(i == settings.phy.wrphase,
+                            steerer.sel[i].eq(STEER_REQ)
+                        ).Elif(i == settings.phy.wrcmdphase,
+                            steerer.sel[i].eq(STEER_CMD)
+                        ).Else(s)
                 else:
                     raise ValueError
                 r.append(s)

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -449,7 +449,7 @@ __attribute__((unused)) static void command_p{n}(int cmd)
 
 
     # wr access functions
-    if phytype in ["USDDRPHY", "USPDDRPHY"]:
+    if phytype in ["USDDRPHY", "USPDDRPHY", "A7DDRPHY", "K7DDRPHY", "V7DDRPHY"]:
         def wrphase_access(declaration, call_fmt):
             case_fmt = "        case {phase}: {call}; break;"
             cases = [case_fmt.format(phase=i, call=call_fmt.format(phase=i))

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -445,35 +445,44 @@ __attribute__((unused)) static void command_p{n}(int cmd)
 #define sdram_dfii_pird_address_write(X) sdram_dfii_pi{rdphase}_address_write(X)
 #define sdram_dfii_pird_baddress_write(X) sdram_dfii_pi{rdphase}_baddress_write(X)
 #define command_prd(X) command_p{rdphase}(X)
-    """.format(rdphase=str(phy_settings.rdphase))
+    """.rstrip().format(rdphase=str(phy_settings.rdphase))
+
 
     # wr access functions
-    def wrphase_access(declaration, call_fmt):
-        case_fmt = "        case {phase}: {call}; break;"
-        cases = [case_fmt.format(phase=i, call=call_fmt.format(phase=i))
-                 for i in range(phy_settings.nphases)]
-        return """
+    if phytype in ["USDDRPHY", "USPDDRPHY"]:
+        def wrphase_access(declaration, call_fmt):
+            case_fmt = "        case {phase}: {call}; break;"
+            cases = [case_fmt.format(phase=i, call=call_fmt.format(phase=i))
+                     for i in range(phy_settings.nphases)]
+            return """
 {declaration} {{
     switch (ddrphy_wrphase_read()) {{
 {phase_cases}
         default: break;
     }}
 }}
-        """.rstrip().format(declaration=declaration, phase_cases="\n".join(cases))
+            """.rstrip().format(declaration=declaration, phase_cases="\n".join(cases))
 
-    r += wrphase_access(
-        declaration="static inline void sdram_dfii_piwr_address_write(int address)",
-        call_fmt="sdram_dfii_pi{phase}_address_write(address)",
-    )
-    r += wrphase_access(
-        declaration="static inline void sdram_dfii_piwr_baddress_write(int address)",
-        call_fmt="sdram_dfii_pi{phase}_baddress_write(address)",
-    )
-    r += wrphase_access(
-        declaration="static inline void command_pwr(int cmd)",
-        call_fmt="command_p{phase}(cmd)",
-    )
-    r += "\n\n"
+        r += wrphase_access(
+            declaration="static inline void sdram_dfii_piwr_address_write(int address)",
+            call_fmt="sdram_dfii_pi{phase}_address_write(address)",
+        )
+        r += wrphase_access(
+            declaration="static inline void sdram_dfii_piwr_baddress_write(int address)",
+            call_fmt="sdram_dfii_pi{phase}_baddress_write(address)",
+        )
+        r += wrphase_access(
+            declaration="static inline void command_pwr(int cmd)",
+            call_fmt="command_p{phase}(cmd)",
+        )
+        r += "\n\n"
+    else:
+        r += """
+#define sdram_dfii_piwr_address_write(X) sdram_dfii_pi{wrphase}_address_write(X)
+#define sdram_dfii_piwr_baddress_write(X) sdram_dfii_pi{wrphase}_baddress_write(X)
+#define command_pwr(X) command_p{wrphase}(X)
+        """.rstrip().format(wrphase=str(phy_settings.wrphase.value))
+        r += "\n\n"
 
     #
     # sdrrd/sdrwr functions utilities

--- a/litedram/phy/ecp5ddrphy.py
+++ b/litedram/phy/ecp5ddrphy.py
@@ -125,13 +125,13 @@ class ECP5DDRPHY(Module, AutoCSR):
             nranks        = nranks,
             nphases       = nphases,
             rdphase       = rdphase,
-            wrphase       = wrphase,
+            wrphase       = Constant(wrphase),
             rdcmdphase    = rdcmdphase,
-            wrcmdphase    = wrcmdphase,
+            wrcmdphase    = Constant(wrcmdphase),
             cl            = cl,
             cwl           = cwl,
             read_latency  = 2 + cl_sys_latency + 2 + log2_int(4//nphases) + 4,
-            write_latency = cwl_sys_latency
+            write_latency = Constant(cwl_sys_latency)
         )
 
         # DFI Interface ----------------------------------------------------------------------------
@@ -460,7 +460,7 @@ class ECP5DDRPHY(Module, AutoCSR):
         # FIXME: understand +2
         wrdata_en = Signal(cwl_sys_latency + 5)
         wrdata_en_last = Signal.like(wrdata_en)
-        self.comb += wrdata_en.eq(Cat(dfi.phases[self.settings.wrphase].wrdata_en, wrdata_en_last))
+        self.comb += wrdata_en.eq(Cat(Array(dfi.phases)[self.settings.wrphase].wrdata_en, wrdata_en_last))
         self.sync += wrdata_en_last.eq(wrdata_en)
         self.comb += dq_oe.eq(wrdata_en[cwl_sys_latency + 2] | wrdata_en[cwl_sys_latency + 3])
         self.comb += bl8_chunk.eq(wrdata_en[cwl_sys_latency + 1])

--- a/litedram/phy/gensdrphy.py
+++ b/litedram/phy/gensdrphy.py
@@ -31,12 +31,12 @@ class GENSDRPHY(Module):
             nranks        = nranks,
             nphases       = 1,
             rdphase       = 0,
-            wrphase       = 0,
+            wrphase       = Constant(0),
             rdcmdphase    = 0,
-            wrcmdphase    = 0,
+            wrcmdphase    = Constant(0),
             cl            = cl,
             read_latency  = cl + cmd_latency,
-            write_latency = 0
+            write_latency = Constant(0)
         )
 
         # DFI Interface ----------------------------------------------------------------------------

--- a/litedram/phy/s6ddrphy.py
+++ b/litedram/phy/s6ddrphy.py
@@ -53,13 +53,13 @@ class S6HalfRateDDRPHY(Module):
                 nranks        = nranks,
                 nphases       = nphases,
                 rdphase       = 0,
-                wrphase       = 1,
+                wrphase       = Constant(1),
                 rdcmdphase    = 1,
-                wrcmdphase    = 0,
+                wrcmdphase    = Constant(0),
                 cl            = 5,
                 cwl           = 6,
                 read_latency  = 6,
-                write_latency = 2
+                write_latency = Constant(2)
             )
         else:
             self.settings = PhySettings(
@@ -70,12 +70,12 @@ class S6HalfRateDDRPHY(Module):
                 nranks        = nranks,
                 nphases       = nphases,
                 rdphase       = 0,
-                wrphase       = 1,
+                wrphase       = Constant(1),
                 rdcmdphase    = 1,
-                wrcmdphase    = 0,
+                wrcmdphase    = Constant(0),
                 cl            = 3,
                 read_latency  = 5,
-                write_latency = 0
+                write_latency = Constant(0)
             )
 
         # DFI Interface ----------------------------------------------------------------------------
@@ -433,13 +433,13 @@ class S6QuarterRateDDRPHY(Module):
             nranks        = nranks,
             nphases       = nphases,
             rdphase       = 0,
-            wrphase       = 1,
+            wrphase       = Constant(1),
             rdcmdphase    = 1,
-            wrcmdphase    = 0,
+            wrcmdphase    = Constant(0),
             cl            = 5,
             cwl           = 6,
             read_latency  = 6//2+1,
-            write_latency = 2//2
+            write_latency = Constant(2//2)
         )
 
         # DFI Interface ----------------------------------------------------------------------------
@@ -482,10 +482,10 @@ class S6QuarterRateDDRPHY(Module):
                 dfi.phases[3].connect(half_rate_phy.dfi.phases[1], omit=dfi_omit),
             ),
         ]
-        wr_data_en = dfi.phases[self.settings.wrphase].wrdata_en & ~phase_sel
+        wr_data_en = Array(dfi.phases)[self.settings.wrphase].wrdata_en & ~phase_sel
         wr_data_en_d = Signal()
         sd_sys2x += wr_data_en_d.eq(wr_data_en)
-        self.comb += half_rate_phy.dfi.phases[half_rate_phy.settings.wrphase].wrdata_en.eq(wr_data_en | wr_data_en_d)
+        self.comb += Array(half_rate_phy.dfi.phases)[half_rate_phy.settings.wrphase].wrdata_en.eq(wr_data_en | wr_data_en_d)
 
         # Reads
         rddata = Array(Signal(2*databits) for i in range(2))

--- a/litedram/phy/s7ddrphy.py
+++ b/litedram/phy/s7ddrphy.py
@@ -89,13 +89,13 @@ class S7DDRPHY(Module, AutoCSR):
             nranks        = nranks,
             nphases       = nphases,
             rdphase       = rdphase,
-            wrphase       = wrphase,
+            wrphase       = Constant(wrphase),
             rdcmdphase    = rdcmdphase,
-            wrcmdphase    = wrcmdphase,
+            wrcmdphase    = Constant(wrcmdphase),
             cl            = cl,
             cwl           = cwl - cmd_latency,
             read_latency  = 2 + cl_sys_latency + iserdese2_latency[interface_type] + 2,
-            write_latency = cwl_sys_latency,
+            write_latency = Constant(cwl_sys_latency),
         )
 
         # DFI Interface ----------------------------------------------------------------------------
@@ -573,7 +573,7 @@ class S7DDRPHY(Module, AutoCSR):
         # is used to control DQ/DQS tristates.
         wrdata_en = Signal(cwl_sys_latency + 2)
         wrdata_en_last = Signal.like(wrdata_en)
-        self.comb += wrdata_en.eq(Cat(dfi.phases[self.settings.wrphase].wrdata_en, wrdata_en_last))
+        self.comb += wrdata_en.eq(Cat(Array(dfi.phases)[self.settings.wrphase].wrdata_en, wrdata_en_last))
         self.sync += wrdata_en_last.eq(wrdata_en)
         self.comb += dq_oe.eq(wrdata_en[cwl_sys_latency])
         self.comb += If(self._wlevel_en.storage, dqs_oe.eq(1)).Else(dqs_oe.eq(dq_oe))

--- a/litedram/phy/usddrphy.py
+++ b/litedram/phy/usddrphy.py
@@ -22,7 +22,8 @@ class USDDRPHY(Module, AutoCSR):
         memtype          = "DDR3",
         sys_clk_freq     = 100e6,
         iodelay_clk_freq = 200e6,
-        cmd_latency      = 0):
+        cmd_latency      = 0,
+        cmd_latency_max  = 8):
         phytype     = self.__class__.__name__
         device      = {"USDDRPHY": "ULTRASCALE", "USPDDRPHY": "ULTRASCALE_PLUS"}[phytype]
         pads        = PHYPadsCombiner(pads)
@@ -41,9 +42,7 @@ class USDDRPHY(Module, AutoCSR):
         if phytype == "USPDDRPHY": assert iodelay_clk_freq >= 300e6
 
         cl, cwl         = get_cl_cw(memtype, tck)
-        cwl             = cwl + cmd_latency
         cl_sys_latency  = get_sys_latency(nphases, cl)
-        cwl_sys_latency = get_sys_latency(nphases, cwl)
 
         # Registers --------------------------------------------------------------------------------
         self._en_vtc              = CSRStorage(reset=1)
@@ -69,9 +68,36 @@ class USDDRPHY(Module, AutoCSR):
         self._wdly_dqs_rst        = CSR()
         self._wdly_dqs_inc        = CSR()
 
+        self._cmd_latency         = CSRStorage(bits_for(cmd_latency_max - 1), reset=cmd_latency)
+        self._wrcmdphase          = CSRStatus(bits_for(nphases))
+        self._wrphase             = CSRStatus(bits_for(nphases))
+
+        # Dynamic latency --------------------------------------------------------------------------
+        # cwl_sys_latency = ceil((cwl + cmd_latency) / nphases)
+        # Division can be replaced with shift, as nphases is always a power of 2.
+        # To get the ceiling (instead of floor), we add (nphases - 1).
+        cwl_sys_latency  = Signal(max=cwl + cmd_latency_max)
+        _cwl_sys_latency = Signal(max=cwl + cmd_latency_max + nphases)
+        self.comb += _cwl_sys_latency.eq(cwl + self._cmd_latency.storage + (nphases - 1))
+        self.comb += cwl_sys_latency.eq(_cwl_sys_latency[log2_int(nphases):])
+
         # PHY settings -----------------------------------------------------------------------------
         rdcmdphase, rdphase = get_sys_phases(nphases, cl_sys_latency, cl)
-        wrcmdphase, wrphase = get_sys_phases(nphases, cwl_sys_latency, cwl)
+
+        # wrphase    = cwl_sys_latency * nphases - (cwl + cmd_latency)
+        # wrcmdphase = (wrphase - 1) % nphases
+        wrcmdphase = Signal(max=nphases)
+        wrphase    = Signal(max=nphases)
+        _wrphase   = Signal(cwl_sys_latency.nbits + log2_int(nphases))
+        self.comb += _wrphase.eq((cwl_sys_latency << log2_int(nphases)) - (cwl + self._cmd_latency.storage))
+        self.comb += wrphase.eq(_wrphase)
+        self.comb += wrcmdphase.eq(wrphase - 1)
+
+        self.comb += [
+            self._wrcmdphase.status.eq(wrcmdphase),
+            self._wrphase.status.eq(wrphase),
+        ]
+
         self.settings = PhySettings(
             phytype       = phytype,
             memtype       = memtype,
@@ -84,7 +110,7 @@ class USDDRPHY(Module, AutoCSR):
             rdcmdphase    = rdcmdphase,
             wrcmdphase    = wrcmdphase,
             cl            = cl,
-            cwl           = cwl - cmd_latency,
+            cwl           = cwl,
             read_latency  = 2 + cl_sys_latency + 1 + 2,
             write_latency = cwl_sys_latency
         )
@@ -501,19 +527,19 @@ class USDDRPHY(Module, AutoCSR):
         # Write Control Path -----------------------------------------------------------------------
         # Creates a shift register of write commands coming from the DFI interface. This shift register
         # is used to control DQ/DQS tristates.
-        wrdata_en = Signal(cwl_sys_latency + 2)
+        wrdata_en = Signal(2**cwl_sys_latency.nbits + 1)
         wrdata_en_last = Signal.like(wrdata_en)
-        self.comb += wrdata_en.eq(Cat(dfi.phases[self.settings.wrphase].wrdata_en, wrdata_en_last))
+        self.comb += wrdata_en.eq(Cat(Array(dfi.phases)[self.settings.wrphase].wrdata_en, wrdata_en_last))
         self.sync += wrdata_en_last.eq(wrdata_en)
-        self.comb += dq_oe.eq(wrdata_en[cwl_sys_latency])
+        self.comb += dq_oe.eq(Array(wrdata_en)[cwl_sys_latency])
         self.comb += If(self._wlevel_en.storage, dqs_oe.eq(1)).Else(dqs_oe.eq(dq_oe))
 
         # Write DQS Postamble/Preamble Control Path ------------------------------------------------
         # Generates DQS Preamble 1 cycle before the first write and Postamble 1 cycle after the last
         # write. During writes, DQS tristate is configured as output for at least 3 sys_clk cycles:
         # 1 for Preamble, 1 for the Write and 1 for the Postamble.
-        self.comb += dqs_pattern.preamble.eq( wrdata_en[cwl_sys_latency - 1]  & ~wrdata_en[cwl_sys_latency])
-        self.comb += dqs_pattern.postamble.eq(wrdata_en[cwl_sys_latency + 1]  & ~wrdata_en[cwl_sys_latency])
+        self.comb += dqs_pattern.preamble.eq( Array(wrdata_en)[cwl_sys_latency - 1]  & ~Array(wrdata_en)[cwl_sys_latency])
+        self.comb += dqs_pattern.postamble.eq(Array(wrdata_en)[cwl_sys_latency + 1]  & ~Array(wrdata_en)[cwl_sys_latency])
 
 # Xilinx Ultrascale Plus DDR3/DDR4 PHY -------------------------------------------------------------
 

--- a/test/reference/ddr3_init.h
+++ b/test/reference/ddr3_init.h
@@ -37,10 +37,10 @@ __attribute__((unused)) static void command_p3(int cmd)
 
 
 #define sdram_dfii_pird_address_write(X) sdram_dfii_pi1_address_write(X)
-#define sdram_dfii_piwr_address_write(X) sdram_dfii_pi1_address_write(X)
 #define sdram_dfii_pird_baddress_write(X) sdram_dfii_pi1_baddress_write(X)
-#define sdram_dfii_piwr_baddress_write(X) sdram_dfii_pi1_baddress_write(X)
 #define command_prd(X) command_p1(X)
+#define sdram_dfii_piwr_address_write(X) sdram_dfii_pi1_address_write(X)
+#define sdram_dfii_piwr_baddress_write(X) sdram_dfii_pi1_baddress_write(X)
 #define command_pwr(X) command_p1(X)
 
 #define DFII_PIX_DATA_SIZE CSR_SDRAM_DFII_PI0_WRDATA_SIZE

--- a/test/reference/ddr4_init.h
+++ b/test/reference/ddr4_init.h
@@ -38,11 +38,35 @@ __attribute__((unused)) static void command_p3(int cmd)
 
 
 #define sdram_dfii_pird_address_write(X) sdram_dfii_pi1_address_write(X)
-#define sdram_dfii_piwr_address_write(X) sdram_dfii_pi3_address_write(X)
 #define sdram_dfii_pird_baddress_write(X) sdram_dfii_pi1_baddress_write(X)
-#define sdram_dfii_piwr_baddress_write(X) sdram_dfii_pi3_baddress_write(X)
 #define command_prd(X) command_p1(X)
-#define command_pwr(X) command_p3(X)
+static inline void sdram_dfii_piwr_address_write(int address) {
+    switch (ddrphy_wrphase_read()) {
+        case 0: sdram_dfii_pi0_address_write(address); break;
+        case 1: sdram_dfii_pi1_address_write(address); break;
+        case 2: sdram_dfii_pi2_address_write(address); break;
+        case 3: sdram_dfii_pi3_address_write(address); break;
+        default: break;
+    }
+}
+static inline void sdram_dfii_piwr_baddress_write(int address) {
+    switch (ddrphy_wrphase_read()) {
+        case 0: sdram_dfii_pi0_baddress_write(address); break;
+        case 1: sdram_dfii_pi1_baddress_write(address); break;
+        case 2: sdram_dfii_pi2_baddress_write(address); break;
+        case 3: sdram_dfii_pi3_baddress_write(address); break;
+        default: break;
+    }
+}
+static inline void command_pwr(int cmd) {
+    switch (ddrphy_wrphase_read()) {
+        case 0: command_p0(cmd); break;
+        case 1: command_p1(cmd); break;
+        case 2: command_p2(cmd); break;
+        case 3: command_p3(cmd); break;
+        default: break;
+    }
+}
 
 #define DFII_PIX_DATA_SIZE CSR_SDRAM_DFII_PI0_WRDATA_SIZE
 

--- a/test/reference/sdr_init.h
+++ b/test/reference/sdr_init.h
@@ -17,10 +17,10 @@ __attribute__((unused)) static void command_p0(int cmd)
 
 
 #define sdram_dfii_pird_address_write(X) sdram_dfii_pi0_address_write(X)
-#define sdram_dfii_piwr_address_write(X) sdram_dfii_pi0_address_write(X)
 #define sdram_dfii_pird_baddress_write(X) sdram_dfii_pi0_baddress_write(X)
-#define sdram_dfii_piwr_baddress_write(X) sdram_dfii_pi0_baddress_write(X)
 #define command_prd(X) command_p0(X)
+#define sdram_dfii_piwr_address_write(X) sdram_dfii_pi0_address_write(X)
+#define sdram_dfii_piwr_baddress_write(X) sdram_dfii_pi0_baddress_write(X)
 #define command_pwr(X) command_p0(X)
 
 #define DFII_PIX_DATA_SIZE CSR_SDRAM_DFII_PI0_WRDATA_SIZE

--- a/test/test_crossbar.py
+++ b/test/test_crossbar.py
@@ -123,7 +123,7 @@ class ControllerStub:
                 # has been sent from the crossbar port.
                 wdata = self.W(bank=n, addr=cmd_addr,
                                data=None, we=None)  # to be filled in callback
-                self._waiting.append(self.WaitingData(data=wdata, delay=self.write_latency))
+                self._waiting.append(self.WaitingData(data=wdata, delay=self.write_latency.value))
             else:  # READ
                 yield bank.rdata_valid.eq(1)
                 yield
@@ -151,7 +151,7 @@ class CrossbarDUT(Module):
         memtype       = "DDR2",
         dfi_databits  = 2*16,
         read_latency  = 5,
-        write_latency = 1,
+        write_latency = Constant(1),
     )
     default_geom_settings = dict(
         bankbits = 3,


### PR DESCRIPTION
This PR would introduce possibility to change `cmd_latency` dynamically during SDRAM operation, which can be used to find the correct value in the controller software. 

At this moment the implementation is only for USDDRPHY and breaks other PHYs. This implementation introduces CSRs for `cmd_latency`, `wrphase` and `wrcmdphase`. These are used in `Multiplexer` (`steerer_sel`) and in `LiteDRAMCrossbar` (`write_latency`). Could you please take a look at this to check if this is a good direction? I am somewhat worried that I had to add `Signal`s to `PhySettings`, it seems wrong considered that those are meant to be constant.

I have some corresponding changes to Litex (https://github.com/enjoy-digital/litex/compare/master...antmicro:jboc/sdram-calibration), but will create a PR when this one is ready.
