### PR TITLE
Implement LiteDRAMNativePortUpConverter with mode="both"

### DIFF
--- a/litedram/frontend/adaptation.py
+++ b/litedram/frontend/adaptation.py
@@ -127,84 +127,9 @@ class LiteDRAMNativePortDownConverter(Module):
             self.submodules += stream.Pipeline(
                 port_to.rdata, rdata_converter, port_from.rdata)
 
-# LiteDRAMNativeWritePortUpConverter ---------------------------------------------------------------
+# LiteDRAMNativePortUpConverter --------------------------------------------------------------------
 
-class LiteDRAMNativeWritePortUpConverter(Module):
-    # TODO: finish and remove hack
-    """LiteDRAM write port UpConverter
-
-    This module increase user port data width to fit controller data width.
-    With N = port_to.data_width/port_from.data_width:
-    - Address is adapted (divided by N)
-    - N writes from user are regrouped in a single one to the controller
-    (when possible, ie when consecutive and bursting)
-    """
-    def __init__(self, port_from, port_to, reverse=False):
-        assert port_from.clock_domain == port_to.clock_domain
-        assert port_from.data_width    < port_to.data_width
-        assert port_from.mode         == port_to.mode
-        assert port_from.mode         == "write"
-        if port_to.data_width % port_from.data_width:
-            raise ValueError("Ratio must be an int")
-
-        # # #
-
-        ratio = port_to.data_width//port_from.data_width
-
-        we      = Signal()
-        address = Signal(port_to.address_width)
-
-        counter       = Signal(max=ratio)
-        counter_reset = Signal()
-        counter_ce    = Signal()
-        self.sync += \
-            If(counter_reset,
-                counter.eq(0)
-            ).Elif(counter_ce,
-                counter.eq(counter + 1)
-            )
-
-        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
-        fsm.act("IDLE",
-            port_from.cmd.ready.eq(1),
-            If(port_from.cmd.valid,
-                counter_ce.eq(1),
-                NextValue(we, port_from.cmd.we),
-                NextValue(address, port_from.cmd.addr),
-                NextState("RECEIVE")
-            )
-        )
-        fsm.act("RECEIVE",
-            port_from.cmd.ready.eq(1),
-            If(port_from.cmd.valid,
-                counter_ce.eq(1),
-                If(counter == ratio-1,
-                    NextState("GENERATE")
-                )
-            )
-        )
-        fsm.act("GENERATE",
-            port_to.cmd.valid.eq(1),
-            port_to.cmd.we.eq(we),
-            port_to.cmd.addr.eq(address[log2_int(ratio):]),
-            If(port_to.cmd.ready,
-                NextState("IDLE")
-            )
-        )
-
-        wdata_converter = stream.StrideConverter(
-            port_from.wdata.description,
-            port_to.wdata.description,
-            reverse=reverse)
-        self.submodules += wdata_converter
-        self.submodules += stream.Pipeline(
-            port_from.wdata,
-            wdata_converter,
-            port_to.wdata)
-
-# LiteDRAMNativeReadPortUpConverter ----------------------------------------------------------------
-
-class LiteDRAMNativeReadPortUpConverter(Module):
+class LiteDRAMNativePortUpConverter(Module):
     """LiteDRAM port UpConverter
 
     This module increase user port data width to fit controller data width.
@@ -212,87 +137,192 @@ class LiteDRAMNativeReadPortUpConverter(Module):
     - Address is adapted (divided by N)
     - N read from user are regrouped in a single one to the controller
     (when possible, ie when consecutive and bursting)
+    - N writes from user are regrouped in a single one to the controller
+    (when possible, ie when consecutive and bursting)
     """
     def __init__(self, port_from, port_to, reverse=False):
         assert port_from.clock_domain == port_to.clock_domain
         assert port_from.data_width    < port_to.data_width
         assert port_from.mode         == port_to.mode
-        assert port_from.mode         == "read"
         if port_to.data_width % port_from.data_width:
             raise ValueError("Ratio must be an int")
 
         # # #
 
         ratio = port_to.data_width//port_from.data_width
-
+        mode  = port_from.mode
 
         # Command ----------------------------------------------------------------------------------
 
-        cmd_buffer = stream.SyncFIFO([("sel", ratio)], 4)
+        # defines cmd type and the chunks that have been requested for the current port_to command
+        sel = Signal(ratio)
+        cmd_buffer = stream.SyncFIFO([("sel", ratio), ("we", 1)], 4)
         self.submodules += cmd_buffer
-
-        counter = Signal(max=ratio)
-        counter_ce = Signal()
-        self.sync += \
-            If(counter_ce,
-                counter.eq(counter + 1)
-            )
-
-        self.comb += \
-            If(port_from.cmd.valid,
-                If(counter == 0,
-                    port_to.cmd.valid.eq(1),
-                    port_to.cmd.addr.eq(port_from.cmd.addr[log2_int(ratio):]),
-                    port_from.cmd.ready.eq(port_to.cmd.ready),
-                    counter_ce.eq(port_to.cmd.ready)
-                ).Else(
-                    port_from.cmd.ready.eq(1),
-                    counter_ce.eq(1)
-                )
-            )
-
-        # TODO: fix sel
-        self.comb += \
-            If(port_to.cmd.valid & port_to.cmd.ready,
-                cmd_buffer.sink.valid.eq(1),
-                cmd_buffer.sink.sel.eq(2**ratio-1)
-            )
-
-        # Datapath ---------------------------------------------------------------------------------
-
-        rdata_buffer    = stream.Buffer(port_to.rdata.description)
-        rdata_converter = stream.StrideConverter(
-            port_to.rdata.description,
-            port_from.rdata.description,
-            reverse=reverse)
-        self.submodules +=  rdata_buffer, rdata_converter
-
-        rdata_chunk       = Signal(ratio, reset=1)
-        rdata_chunk_valid = Signal()
-        self.sync += \
-            If(rdata_converter.source.valid &
-               rdata_converter.source.ready,
-                rdata_chunk.eq(Cat(rdata_chunk[ratio-1], rdata_chunk[:ratio-1]))
-            )
+        # store last command info
+        cmd_addr = Signal.like(port_from.cmd.addr)
+        cmd_we = Signal()
+        # indicates that we need to proceed to the next port_to command
+        next_cmd = Signal()
+        # signals that indicate that write/read convertion has finished
+        wdata_finished = Signal()
+        rdata_finished = Signal()
+        # register that user requested a flush
+        flush_r = Signal()
 
         self.comb += [
-            port_to.rdata.connect(rdata_buffer.sink),
-            rdata_buffer.source.connect(rdata_converter.sink),
-            rdata_chunk_valid.eq((cmd_buffer.source.sel & rdata_chunk) != 0),
-            If(port_from.flush,
-                rdata_converter.source.ready.eq(1)
-            ).Elif(cmd_buffer.source.valid,
-                If(rdata_chunk_valid,
-                    port_from.rdata.valid.eq(rdata_converter.source.valid),
-                    port_from.rdata.data.eq(rdata_converter.source.data),
-                    rdata_converter.source.ready.eq(port_from.rdata.ready)
+            # go to the next command if one of the following happens:
+            #  * port_to address changes
+            #  * cmd type changes
+            #  * we received all the `ratio` commands
+            #  * this is last command (flush)
+            next_cmd.eq(
+                (cmd_addr[log2_int(ratio):] != port_from.cmd.addr[log2_int(ratio):]) |
+                (cmd_we != port_from.cmd.we) |
+                (sel == 2**ratio - 1) |
+                port_from.flush | flush_r
+            ),
+            # when the first command is received, send it immediatelly
+            If(sel == 0,
+                If(port_from.cmd.valid,
+                    port_to.cmd.valid.eq(1),
+                    port_to.cmd.we.eq(port_from.cmd.we),
+                    port_to.cmd.addr.eq(port_from.cmd.addr[log2_int(ratio):]),
+                    port_from.cmd.ready.eq(port_to.cmd.ready),
+                )
+            ).Else(
+                # we have already sent the initial command, now either continue sending cmd.ready
+                # to the master or send the current command if we have to go to next command
+                If(next_cmd,
+                    cmd_buffer.sink.valid.eq(1),
+                    cmd_buffer.sink.sel.eq(sel),
+                    cmd_buffer.sink.we.eq(cmd_we),
                 ).Else(
-                    rdata_converter.source.ready.eq(1)
+                    port_from.cmd.ready.eq(port_from.cmd.valid),
                 )
             ),
-            cmd_buffer.source.ready.eq(
-                rdata_converter.source.ready & rdata_chunk[ratio-1])
+            cmd_buffer.source.ready.eq(wdata_finished | rdata_finished)
         ]
+
+        self.sync += [
+            # whenever a command gets accepted, update `sel` bitmask and store the command info
+            If(port_from.cmd.valid & port_from.cmd.ready,
+                cmd_addr.eq(port_from.cmd.addr),
+                cmd_we.eq(port_from.cmd.we),
+                sel.eq(sel | (1 << port_from.cmd.addr[:log2_int(ratio)])),
+            ),
+            # clear `sel` after the command has been sent for data procesing
+            If(cmd_buffer.sink.valid & cmd_buffer.sink.ready,
+                sel.eq(0),
+                flush_r.eq(0),
+            ),
+            # store flush info until we register the current command
+            If(port_from.flush,
+               flush_r.eq(1)
+            ),
+        ]
+
+        # Read Datapath ----------------------------------------------------------------------------
+
+        if mode == "read" or mode == "both":
+            # buffers output from port_to
+            rdata_fifo = stream.SyncFIFO(port_to.rdata.description, ratio)
+            # connected to the buffered output
+            rdata_converter = stream.StrideConverter(
+                port_to.rdata.description,
+                port_from.rdata.description,
+                reverse=reverse)
+            self.submodules +=  rdata_fifo, rdata_converter
+
+            # bitmask shift register with single 1 bit and all other 0s
+            rdata_chunk       = Signal(ratio, reset=1)
+            rdata_chunk_valid = Signal()
+            # whenever the converter spits data chunk we shift the chunk bitmask
+            self.sync += \
+                If(rdata_converter.source.valid &
+                   rdata_converter.source.ready,
+                    rdata_chunk.eq(Cat(rdata_chunk[ratio-1], rdata_chunk[:ratio-1]))
+                )
+
+            self.comb += [
+                # port_to -> rdata_fifo -> rdata_converter
+                port_to.rdata.connect(rdata_fifo.sink),
+                rdata_fifo.source.connect(rdata_converter.sink),
+                # chunk is valid if it's bit is in `sel` sent previously to the FIFO
+                rdata_chunk_valid.eq((cmd_buffer.source.sel & rdata_chunk) != 0),
+                # whenever `sel` from FIFO is valid
+                If(cmd_buffer.source.valid & ~cmd_buffer.source.we,
+                    # if that chunk is valid we send it to the user port and wait for ready from user
+                    If(rdata_chunk_valid,
+                        port_from.rdata.valid.eq(rdata_converter.source.valid),
+                        port_from.rdata.data.eq(rdata_converter.source.data),
+                        rdata_converter.source.ready.eq(port_from.rdata.ready)
+                    # if this was not requested by `sel` then we just ack it
+                    ).Else(
+                        rdata_converter.source.ready.eq(1)
+                    ),
+                    rdata_finished.eq(rdata_converter.source.valid & rdata_converter.source.ready & rdata_chunk[ratio - 1])
+                ),
+            ]
+
+        # Write Datapath ---------------------------------------------------------------------------
+
+        if mode == "write" or mode == "both":
+            wdata_fifo    = stream.SyncFIFO(port_from.wdata.description, ratio)
+            wdata_converter = stream.StrideConverter(
+                port_from.wdata.description,
+                port_to.wdata.description,
+                reverse=reverse)
+            self.submodules += wdata_converter, wdata_fifo
+
+            # bitmask shift register with single 1 bit and all other 0s
+            wdata_chunk       = Signal(ratio, reset=1)
+            wdata_chunk_valid = Signal()
+            # whenever the converter spits data chunk we shift the chunk bitmask
+            self.sync += \
+                If(wdata_converter.sink.valid & wdata_converter.sink.ready,
+                    wdata_chunk.eq(Cat(wdata_chunk[ratio-1], wdata_chunk[:ratio-1]))
+                )
+
+            # replicate sel so that each bit covers according part of we bitmask (1 sel bit may cover
+            # multiple bytes)
+            wdata_sel = Signal.like(port_to.wdata.we)
+            #  self.comb += wdata_sel.eq(
+            #      Cat([Replicate(cmd_buffer.source.sel[i], port_to.wdata.we.nbits // sel.nbits) for i in range(ratio)])
+            #  )
+
+            self.sync += [
+                If(cmd_buffer.source.valid & cmd_buffer.source.we & wdata_chunk[ratio - 1],
+                    wdata_sel.eq(Cat([Replicate(cmd_buffer.source.sel[i], port_to.wdata.we.nbits // sel.nbits)
+                                      for i in range(ratio)]))
+                )
+            ]
+
+            self.comb += [
+                port_from.wdata.connect(wdata_fifo.sink),
+
+                wdata_chunk_valid.eq((cmd_buffer.source.sel & wdata_chunk) != 0),
+
+                If(cmd_buffer.source.valid & cmd_buffer.source.we,
+                    If(wdata_chunk_valid,
+                        wdata_converter.sink.valid.eq(wdata_fifo.source.valid),
+                        wdata_converter.sink.data.eq(wdata_fifo.source.data),
+                        wdata_converter.sink.we.eq(wdata_fifo.source.we),
+                        wdata_fifo.source.ready.eq(1),
+                    ).Else(
+                        wdata_converter.sink.valid.eq(1),
+                        wdata_converter.sink.data.eq(0),
+                        wdata_converter.sink.we.eq(0),
+                        wdata_fifo.source.ready.eq(0),
+                    ),
+                ),
+
+                port_to.wdata.valid.eq(wdata_converter.source.valid),
+                port_to.wdata.data.eq(wdata_converter.source.data),
+                port_to.wdata.we.eq(wdata_converter.source.we & wdata_sel),
+                wdata_converter.source.ready.eq(port_to.wdata.ready),
+                #  wdata_finished.eq(wdata_converter.source.valid & wdata_converter.source.ready),
+                wdata_finished.eq(wdata_converter.sink.valid & wdata_converter.sink.ready & wdata_chunk[ratio-1]),
+            ]
 
 # LiteDRAMNativePortConverter ----------------------------------------------------------------------
 
@@ -309,12 +339,7 @@ class LiteDRAMNativePortConverter(Module):
             converter = LiteDRAMNativePortDownConverter(port_from, port_to, reverse)
             self.submodules += converter
         elif port_from.data_width < port_to.data_width:
-            if mode == "write":
-                converter = LiteDRAMNativeWritePortUpConverter(port_from, port_to, reverse)
-            elif mode == "read":
-                converter = LiteDRAMNativeReadPortUpConverter(port_from, port_to, reverse)
-            else:
-                raise NotImplementedError
+            converter = LiteDRAMNativePortUpConverter(port_from, port_to, reverse)
             self.submodules += converter
         else:
             self.comb += [

--- a/litedram/frontend/wishbone.py
+++ b/litedram/frontend/wishbone.py
@@ -8,6 +8,8 @@ from math import log2
 from migen import *
 
 from litex.soc.interconnect import stream
+from litedram.common import LiteDRAMNativePort
+from litedram.frontend.adaptation import LiteDRAMNativePortConverter
 
 
 # LiteDRAMWishbone2Native --------------------------------------------------------------------------
@@ -16,74 +18,55 @@ class LiteDRAMWishbone2Native(Module):
     def __init__(self, wishbone, port, base_address=0x00000000):
         wishbone_data_width = len(wishbone.dat_w)
         port_data_width     = 2**int(log2(len(port.wdata.data))) # Round to lowest power 2
-        assert wishbone_data_width >= port_data_width
+
+        if wishbone_data_width != port_data_width:
+            if wishbone_data_width > port_data_width:
+                addr_shift = -log2_int(wishbone_data_width//port_data_width)
+            else:
+                addr_shift = log2_int(port_data_width//wishbone_data_width)
+            new_port = LiteDRAMNativePort(
+                mode          = port.mode,
+                address_width = port.address_width + addr_shift,
+                data_width    = wishbone_data_width
+            )
+            self.submodules += LiteDRAMNativePortConverter(new_port, port)
+            port = new_port
 
         # # #
 
         adr_offset = base_address >> log2_int(port.data_width//8)
 
-        # Write Datapath ---------------------------------------------------------------------------
-        wdata_converter = stream.StrideConverter(
-            [("data", wishbone_data_width), ("we", wishbone_data_width//8)],
-            [("data", port_data_width),     ("we", port_data_width//8)],
-        )
-        self.submodules += wdata_converter
-        wdata_complete = Signal()
-        self.comb += [
-            wdata_converter.sink.valid.eq(wishbone.cyc & wishbone.stb & wishbone.we & ~wdata_complete),
-            wdata_converter.sink.data.eq(wishbone.dat_w),
-            wdata_converter.sink.we.eq(wishbone.sel),
-            wdata_converter.source.connect(port.wdata)
-        ]
+        # latch ready signals of cmd/wdata and then wait until all are ready
+        cmd_consumed   = Signal()
+        wdata_consumed = Signal()
         self.sync += [
-            If(wdata_converter.sink.valid & wdata_converter.sink.ready,
-               wdata_complete.eq(1)
-            )
+            If(wishbone.ack,
+                cmd_consumed.eq(0),
+                wdata_consumed.eq(0),
+            ).Else(
+                If(port.cmd.valid   & port.cmd.ready,   cmd_consumed.eq(1)),
+                If(port.wdata.valid & port.wdata.ready, wdata_consumed.eq(1)),
+            ),
         ]
 
-        # Read Datapath ----------------------------------------------------------------------------
-        rdata_converter = stream.StrideConverter(
-            [("data", port_data_width)],
-            [("data", wishbone_data_width)],
-        )
-        self.submodules += rdata_converter
+        ack_cmd   = Signal()
+        ack_wdata = Signal()
+        ack_rdata = Signal()
         self.comb += [
-            port.rdata.connect(rdata_converter.sink),
-            rdata_converter.source.ready.eq(1),
-            wishbone.dat_r.eq(rdata_converter.source.data),
-        ]
-
-        # Control ----------------------------------------------------------------------------------
-        ratio = wishbone_data_width//port_data_width
-        count = Signal(max=max(ratio, 2))
-        self.submodules.fsm = fsm = FSM(reset_state="CMD")
-        fsm.act("CMD",
-            port.cmd.valid.eq(wishbone.cyc & wishbone.stb),
+            port.cmd.addr.eq(wishbone.adr - adr_offset),
             port.cmd.we.eq(wishbone.we),
-            port.cmd.addr.eq(wishbone.adr*ratio + count - adr_offset),
-            port.cmd.last.eq(1),
-            If(port.cmd.valid & port.cmd.ready,
-                NextValue(count, count + 1),
-                If(count == (ratio - 1),
-                    NextValue(count, 0),
-                    If(wishbone.we,
-                        NextState("WAIT-WRITE")
-                    ).Else(
-                        NextState("WAIT-READ")
-                    )
-                )
-            )
-        )
-        fsm.act("WAIT-WRITE",
-            If(wdata_complete,
-               wishbone.ack.eq(1),
-                NextValue(wdata_complete, 0),
-                NextState("CMD")
-            )
-        )
-        fsm.act("WAIT-READ",
-            If(rdata_converter.source.valid,
-               wishbone.ack.eq(1),
-               NextState("CMD")
-            )
-        )
+            port.wdata.data.eq(wishbone.dat_w),
+            port.wdata.we.eq(wishbone.sel),
+            wishbone.dat_r.eq(port.rdata.data),
+            # always wait for reads, flush write when transaction ends
+            port.flush.eq(~wishbone.cyc),
+            port.cmd.last.eq(~wishbone.we),
+            # make sure cmd/wdata won't stay valid after it is consumed
+            port.cmd.valid.eq(wishbone.cyc & wishbone.stb & ~cmd_consumed),
+            port.wdata.valid.eq((port.cmd.valid | cmd_consumed) & port.cmd.we & ~wdata_consumed),
+            port.rdata.ready.eq((port.cmd.valid | cmd_consumed) & ~port.cmd.we),
+            wishbone.ack.eq(ack_cmd & ((wishbone.we & ack_wdata) | (~wishbone.we & ack_rdata))),
+            ack_cmd.eq((port.cmd.valid & port.cmd.ready) | cmd_consumed),
+            ack_wdata.eq((port.wdata.valid & port.wdata.ready) | wdata_consumed),
+            ack_rdata.eq(port.rdata.valid & port.rdata.ready),
+        ]

--- a/litedram/frontend/wishbone.py
+++ b/litedram/frontend/wishbone.py
@@ -28,16 +28,16 @@ class LiteDRAMWishbone2Native(Module):
             [("data", port_data_width),     ("we", port_data_width//8)],
         )
         self.submodules += wdata_converter
-        wdata_lock = Signal()
+        wdata_complete = Signal()
         self.comb += [
-            wdata_converter.sink.valid.eq(wishbone.cyc & wishbone.stb & wishbone.we & ~wdata_lock),
+            wdata_converter.sink.valid.eq(wishbone.cyc & wishbone.stb & wishbone.we & ~wdata_complete),
             wdata_converter.sink.data.eq(wishbone.dat_w),
             wdata_converter.sink.we.eq(wishbone.sel),
             wdata_converter.source.connect(port.wdata)
         ]
         self.sync += [
             If(wdata_converter.sink.valid & wdata_converter.sink.ready,
-               wdata_lock.eq(1)
+               wdata_complete.eq(1)
             )
         ]
 
@@ -75,9 +75,9 @@ class LiteDRAMWishbone2Native(Module):
             )
         )
         fsm.act("WAIT-WRITE",
-            If(wdata_converter.sink.ready,
-                NextValue(wdata_lock, 0),
-                wishbone.ack.eq(1),
+            If(wdata_complete,
+               wishbone.ack.eq(1),
+                NextValue(wdata_complete, 0),
                 NextState("CMD")
             )
         )

--- a/test/common.py
+++ b/test/common.py
@@ -217,7 +217,7 @@ class DRAMMemory:
         mask = reduce(or_, [0xff << (8 * bit) for bit in range(self.width//8)
                             if (we & (1 << bit)) != 0], 0)
         data = data & mask
-        self.mem[address%self.depth] = data
+        self.mem[address%self.depth] = data | (self.mem[address%self.depth] & ~mask)
         if self._debug in ["1", "W"]:
             print("W 0x{:08x}: 0x{:0{dwidth}x}".format(address, self.mem[address%self.depth],
                                                        dwidth=self.width//4))

--- a/test/common.py
+++ b/test/common.py
@@ -94,8 +94,10 @@ class NativePortDriver:
                 for _ in range(latency):
                     yield
 
-    def read(self, address, wait_data=True):
+    def read(self, address, first=0, last=0, wait_data=True):
         yield self.port.cmd.valid.eq(1)
+        yield self.port.cmd.first.eq(first)
+        yield self.port.cmd.last.eq(last)
         yield self.port.cmd.we.eq(0)
         yield self.port.cmd.addr.eq(address)
         yield
@@ -108,10 +110,12 @@ class NativePortDriver:
                 yield
             return self.rdata[-1]
 
-    def write(self, address, data, we=None, wait_data=True, data_with_cmd=False):
+    def write(self, address, data, we=None, first=0, last=0, wait_data=True, data_with_cmd=False):
         if we is None:
             we = 2**self.port.wdata.we.nbits - 1
         yield self.port.cmd.valid.eq(1)
+        yield self.port.cmd.first.eq(first)
+        yield self.port.cmd.last.eq(last)
         yield self.port.cmd.we.eq(1)
         yield self.port.cmd.addr.eq(address)
         if data_with_cmd:

--- a/test/common.py
+++ b/test/common.py
@@ -500,7 +500,7 @@ class MemoryTestDataMixin:
                     (0x05, 0x11),
                     (0x0a, 0x22),
                     (0x0f, 0x33),
-                    (0x1d, 0x44),
+                    (0x1e, 0x44),
                     (0x15, 0x55),
                     (0x13, 0x66),
                     (0x18, 0x77),

--- a/test/test_adaptation.py
+++ b/test/test_adaptation.py
@@ -77,13 +77,13 @@ class CDCDUT(ConverterDUT):
 
 
 class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
-    def test_converter_down_ratio_must_be_integer(self):
+    def test_down_converter_ratio_must_be_integer(self):
         with self.assertRaises(ValueError) as cm:
             dut = ConverterDUT(user_data_width=64, native_data_width=24, mem_depth=128)
             dut.finalize()
         self.assertIn("ratio must be an int", str(cm.exception).lower())
 
-    def test_converter_up_ratio_must_be_integer(self):
+    def test_up_converter_ratio_must_be_integer(self):
         with self.assertRaises(ValueError) as cm:
             dut = ConverterDUT(user_data_width=32, native_data_width=48, mem_depth=128)
             dut.finalize()
@@ -155,7 +155,7 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
         # Verify 32-bit to 256-bit up-conversion.
         self.converter_test(test_data="32bit_to_256bit", user_data_width=32, native_data_width=256)
 
-    def test_converter_up_read_latencies(self):
+    def test_up_converter_read_latencies(self):
         # Verify that up-conversion works with different port reader latencies
         cases = {
             "1to2": dict(test_data="8bit_to_16bit",   user_data_width=8,  native_data_width=16),
@@ -168,7 +168,7 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
                     with self.subTest(conversion=conversion):
                         self.converter_test(**kwargs, read_latency=latency)
 
-    def test_converter_down_read_latencies(self):
+    def test_down_converter_read_latencies(self):
         # Verify that down-conversion works with different port reader latencies
         cases = {
             "2to1": dict(test_data="64bit_to_32bit", user_data_width=64, native_data_width=32),
@@ -330,7 +330,7 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
                 self.converter_readback_test(dut, pattern=[], mem_expected=mem_expected,
                                              main_generator=main_generator)
 
-    def test_converter_up_not_aligned(self):
+    def test_up_converter_not_aligned(self):
         data = self.pattern_test_data["8bit_to_32bit_not_aligned"]
         dut  = ConverterDUT(user_data_width=8, native_data_width=32,
                             mem_depth=len(data["expected"]), separate_rw=False)

--- a/test/test_adaptation.py
+++ b/test/test_adaptation.py
@@ -17,18 +17,25 @@ from litex.gen.sim import *
 
 
 class ConverterDUT(Module):
-    def __init__(self, user_data_width, native_data_width, mem_depth, separate_rw=True):
+    def __init__(self, user_data_width, native_data_width, mem_depth, separate_rw=True, read_latency=0):
         self.separate_rw = separate_rw
         if separate_rw:
             self.write_user_port     = LiteDRAMNativeWritePort(address_width=32, data_width=user_data_width)
             self.write_crossbar_port = LiteDRAMNativeWritePort(address_width=32, data_width=native_data_width)
             self.read_user_port      = LiteDRAMNativeReadPort( address_width=32, data_width=user_data_width)
             self.read_crossbar_port  = LiteDRAMNativeReadPort( address_width=32, data_width=native_data_width)
+            self.write_driver        = NativePortDriver(self.write_user_port)
+            self.read_driver         = NativePortDriver(self.read_user_port)
         else:
             self.write_user_port     = LiteDRAMNativePort(mode="both", address_width=32, data_width=user_data_width)
             self.write_crossbar_port = LiteDRAMNativePort(mode="both", address_width=32, data_width=native_data_width)
+            self.write_driver        = NativePortDriver(self.write_user_port)
             self.read_user_port      = self.write_user_port
             self.read_crossbar_port  = self.write_crossbar_port
+            self.read_driver         = self.write_driver
+
+        self.driver_generators   = [self.write_driver.write_data_handler(),
+                                    self.read_driver.read_data_handler(latency=read_latency)]
 
         # Memory
         self.memory = DRAMMemory(native_data_width, mem_depth)
@@ -43,73 +50,15 @@ class ConverterDUT(Module):
             self.submodules.converter = LiteDRAMNativePortConverter(
                 self.write_user_port, self.write_crossbar_port)
 
-    def read(self, address, read_data=True):
-        port = self.read_user_port
-        yield port.cmd.valid.eq(1)
-        yield port.cmd.we.eq(0)
-        yield port.cmd.addr.eq(address)
-        yield
-        while (yield port.cmd.ready) == 0:
-            yield
-        yield port.cmd.valid.eq(0)
-        yield
-        if read_data:
-            while (yield port.rdata.valid) == 0:
-                yield
-            data = (yield port.rdata.data)
-            yield port.rdata.ready.eq(1)
-            yield
-            yield port.rdata.ready.eq(0)
-            yield
-            return data
+    def read(self, address, wait_data=True):
+        return (yield from self.read_driver.read(address, wait_data=wait_data))
 
-    def write(self, address, data, we=None):
-        if we is None:
-            we = 2**self.write_user_port.wdata.we.nbits - 1
+    def write(self, address, data, wait_data=True, we=None):
+        data_with_cmd = False
         if self.write_user_port.data_width > self.write_crossbar_port.data_width:
-            yield from self._write_down(address, data, we)
-        else:
-            yield from self._write_up(address, data, we)
-
-    def _write_up(self, address, data, we):
-        port = self.write_user_port
-        yield port.cmd.valid.eq(1)
-        yield port.cmd.we.eq(1)
-        yield port.cmd.addr.eq(address)
-        yield
-        while (yield port.cmd.ready) == 0:
-            yield
-        yield port.cmd.valid.eq(0)
-        yield
-        yield port.wdata.valid.eq(1)
-        yield port.wdata.data.eq(data)
-        yield port.wdata.we.eq(we)
-        yield
-        while (yield port.wdata.ready) == 0:
-            yield
-        yield port.wdata.valid.eq(0)
-        yield
-
-    def _write_down(self, address, data, we):
-        # Down converter must have all the data available along with cmd, it will set
-        # user_port.cmd.ready only when it sends all input words.
-        port = self.write_user_port
-        yield port.cmd.valid.eq(1)
-        yield port.cmd.we.eq(1)
-        yield port.cmd.addr.eq(address)
-        yield port.wdata.valid.eq(1)
-        yield port.wdata.data.eq(data)
-        yield port.wdata.we.eq(we)
-        yield
-        # Ready goes up only after StrideConverter copied all words
-        while (yield port.cmd.ready) == 0:
-            yield
-        yield port.cmd.valid.eq(0)
-        yield
-        while (yield port.wdata.ready) == 0:
-            yield
-        yield port.wdata.valid.eq(0)
-        yield
+            data_with_cmd = True
+        return (yield from self.write_driver.write(address, data, we, wait_data=wait_data,
+                                                   data_with_cmd=data_with_cmd))
 
 
 class CDCDUT(ConverterDUT):
@@ -142,48 +91,44 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
             dut.finalize()
         self.assertIn("ratio must be an int", str(cm.exception).lower())
 
-    def converter_readback_test(self, dut, pattern, mem_expected):
+    def converter_readback_test(self, dut, pattern, mem_expected, main_generator=None):
         assert len(set(adr for adr, _ in pattern)) == len(pattern), "Pattern has duplicates!"
-        read_data = []
 
-        @passive
-        def read_handler(read_port):
-            yield read_port.rdata.ready.eq(1)
-            while True:
-                if (yield read_port.rdata.valid):
-                    read_data.append((yield read_port.rdata.data))
+        if main_generator is None:
+            def main_generator(dut):
+                for adr, data in pattern:
+                    yield from dut.write(adr, data)
+
+                for adr, _ in pattern:
+                    yield from dut.read(adr, wait_data=False)
+
+                # we need to flush after last command in the up-converter case, if the last
+                # command does not fill whole `sel`
+                yield dut.write_user_port.flush.eq(1)
                 yield
+                yield dut.write_user_port.flush.eq(0)
 
-        def main_generator(dut, pattern):
-            for adr, data in pattern:
-                yield from dut.write(adr, data)
-
-            for adr, _ in pattern:
-                yield from dut.read(adr, read_data=False)
-
-            # Latency delay
-            for _ in range(32):
-                yield
+                yield from dut.write_driver.wait_all()
+                yield from dut.read_driver.wait_all()
 
         generators = [
-            main_generator(dut, pattern),
-            read_handler(dut.read_user_port),
+            main_generator(dut),
+            *dut.driver_generators,
             dut.memory.write_handler(dut.write_crossbar_port),
             dut.memory.read_handler(dut.read_crossbar_port),
-            timeout_generator(5000),
+            timeout_generator(1000),
         ]
         run_simulation(dut, generators, vcd_name='sim.vcd')
         self.assertEqual(dut.memory.mem, mem_expected)
-        self.assertEqual(read_data, [data for adr, data in pattern])
+        self.assertEqual(dut.read_driver.rdata, [data for adr, data in pattern])
 
-    # TODO: test port.flush!
-
-    def converter_test(self, test_data, user_data_width, native_data_width):
-        for separate_rw in [True, False]:
+    def converter_test(self, test_data, user_data_width, native_data_width, **kwargs):
+        #  for separate_rw in [True, False]:
+        for separate_rw in [False]:
             with self.subTest(separate_rw=separate_rw):
                 data = self.pattern_test_data[test_data]
                 dut  = ConverterDUT(user_data_width=user_data_width, native_data_width=native_data_width,
-                                    mem_depth=len(data["expected"]), separate_rw=separate_rw)
+                                    mem_depth=len(data["expected"]), separate_rw=separate_rw, **kwargs)
                 self.converter_readback_test(dut, data["pattern"], data["expected"])
 
     def test_converter_1to1(self):
@@ -214,10 +159,200 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
         # Verify 32-bit to 256-bit up-conversion.
         self.converter_test(test_data="32bit_to_256bit", user_data_width=32, native_data_width=256)
 
-    # TODO: implement case when user does not write all words (LiteDRAMNativeWritePortUpConverter)
-    @unittest.skip("Only full-burst writes currently supported")
+    def test_converter_up_read_latencies(self):
+        # Verify that up-conversion works with different port reader latencies
+        cases = {
+            "1to2": dict(test_data="8bit_to_16bit",   user_data_width=8,  native_data_width=16),
+            "1to4": dict(test_data="32bit_to_128bit", user_data_width=32, native_data_width=128),
+            "1to8": dict(test_data="32bit_to_256bit", user_data_width=32, native_data_width=256),
+        }
+        for latency in [0, 1]:
+            with self.subTest(latency=latency):
+                for conversion, kwargs in cases.items():
+                    with self.subTest(conversion=conversion):
+                        self.converter_test(**kwargs, read_latency=latency)
+
+    def test_converter_down_read_latencies(self):
+        # Verify that down-conversion works with different port reader latencies
+        cases = {
+            "2to1": dict(test_data="64bit_to_32bit", user_data_width=64, native_data_width=32),
+            "4to1": dict(test_data="32bit_to_8bit",  user_data_width=32, native_data_width=8),
+            "8to1": dict(test_data="64bit_to_8bit",  user_data_width=64, native_data_width=8),
+        }
+        for latency in [0, 1]:
+            with self.subTest(latency=latency):
+                for conversion, kwargs in cases.items():
+                    with self.subTest(conversion=conversion):
+                        self.converter_test(**kwargs, read_latency=latency)
+
+    def test_up_converter_write_complete_sequence(self):
+        # Verify up-conversion when master sends full sequences (of `ratio` length)
+        def main_generator(dut):
+            yield from dut.write(0x00, 0x11)  # first
+            yield from dut.write(0x01, 0x22)
+            yield from dut.write(0x02, 0x33)
+            yield from dut.write(0x03, 0x44)
+            yield from dut.write(0x04, 0x55)  # second
+            yield from dut.write(0x05, 0x66)
+            yield from dut.write(0x06, 0x77)
+            yield from dut.write(0x07, 0x88)
+
+            yield from dut.write_driver.wait_all()
+            for _ in range(8):  # wait for memory
+                yield
+
+        mem_expected = [
+            #     data  address
+            0x44332211,  # 0x00
+            0x88776655,  # 0x04
+            0x00000000,  # 0x08
+            0x00000000,  # 0x0c
+        ]
+
+        for separate_rw in [False, True]:
+            with self.subTest(separate_rw=separate_rw):
+                dut  = ConverterDUT(user_data_width=8, native_data_width=32,
+                                    mem_depth=len(mem_expected), separate_rw=separate_rw)
+                self.converter_readback_test(dut, pattern=[], mem_expected=mem_expected,
+                                             main_generator=main_generator)
+
+    def test_up_converter_write_with_manual_flush(self):
+        # Verify that up-conversion writes incomplete data when flushed
+        def main_generator(dut):
+            yield from dut.write(0x00, 0x11, wait_data=False)
+            yield from dut.write(0x01, 0x22, wait_data=False)
+            yield from dut.write(0x02, 0x33, wait_data=False)
+            yield dut.write_user_port.flush.eq(1)
+            yield
+            yield dut.write_user_port.flush.eq(0)
+
+            yield from dut.write_driver.wait_all()
+            for _ in range(8):  # wait for memory
+                yield
+
+        mem_expected = [
+            #     data  address
+            0x00332211,  # 0x00
+            0x00000000,  # 0x04
+            0x00000000,  # 0x08
+            0x00000000,  # 0x0c
+        ]
+
+        for separate_rw in [False, True]:
+            with self.subTest(separate_rw=separate_rw):
+                dut  = ConverterDUT(user_data_width=8, native_data_width=32,
+                                    mem_depth=len(mem_expected), separate_rw=separate_rw)
+                self.converter_readback_test(dut, pattern=[], mem_expected=mem_expected,
+                                             main_generator=main_generator)
+
+    def test_up_converter_auto_flush_on_address_change(self):
+        # Verify that up-conversion automatically flushes the cmd if the (shifted) address changes
+        def main_generator(dut):
+            yield from dut.write(0x00, 0x11, wait_data=False)  # -> 0x00
+            yield from dut.write(0x01, 0x22, wait_data=False)  # -> 0x00
+            yield from dut.write(0x02, 0x33, wait_data=False)  # -> 0x00
+            yield from dut.write(0x04, 0x55, wait_data=False)  # -> 0x01
+            yield from dut.write(0x05, 0x66, wait_data=False)  # -> 0x01
+            yield from dut.write(0x06, 0x77, wait_data=False)  # -> 0x01
+            yield from dut.write(0x07, 0x88, wait_data=False)  # -> 0x01
+
+            yield from dut.write_driver.wait_all()
+            for _ in range(8):  # wait for memory
+                yield
+
+        mem_expected = [
+            #     data  address
+            0x00332211,  # 0x00
+            0x88776655,  # 0x04
+            0x00000000,  # 0x08
+            0x00000000,  # 0x0c
+        ]
+
+
+        for separate_rw in [False, True]:
+            with self.subTest(separate_rw=separate_rw):
+                dut  = ConverterDUT(user_data_width=8, native_data_width=32,
+                                    mem_depth=len(mem_expected), separate_rw=separate_rw)
+                self.converter_readback_test(dut, pattern=[], mem_expected=mem_expected,
+                                             main_generator=main_generator)
+
+    @unittest.skip("Read after write not yet synchronised enough")
+    def test_up_converter_auto_flush_on_cmd_we_change(self):
+        # Verify that up-conversion automatically flushes the cmd when command type (write/read) changes
+        def main_generator(dut):
+            yield from dut.write(0x00, 0x11, wait_data=False)
+            yield from dut.write(0x01, 0x22, wait_data=False)
+            yield from dut.write(0x02, 0x33, wait_data=False)
+            yield from dut.write(0x03, 0x44, wait_data=False)
+            yield from dut.write(0x04, 0x55, wait_data=False)
+            yield from dut.write(0x05, 0x66, wait_data=False)
+            yield from dut.read (0x00)
+            yield from dut.read (0x01)
+            yield from dut.read (0x02)
+            yield from dut.read (0x03)
+            yield from dut.read (0x04)
+            yield from dut.read (0x05)
+            yield from dut.read (0x06)
+            yield from dut.read (0x07)
+
+            yield from dut.write_driver.wait_all()
+            yield from dut.read_driver.wait_all()
+            for _ in range(8):  # wait for memory
+                yield
+
+        mem_expected = [
+            #     data  address
+            0x44332211,  # 0x00
+            0x00006655,  # 0x04
+            0x00000000,  # 0x08
+            0x00000000,  # 0x0c
+        ]
+        pattern = [
+            (0x00, mem_expected[0]),
+            (0x01, mem_expected[1]),
+        ]
+
+        for separate_rw in [False, True]:
+            with self.subTest(separate_rw=separate_rw):
+                dut  = ConverterDUT(user_data_width=8, native_data_width=32,
+                                    mem_depth=len(mem_expected), separate_rw=separate_rw)
+                self.converter_readback_test(dut, pattern=pattern, mem_expected=mem_expected,
+                                             main_generator=main_generator)
+
+    def test_up_converter_write_with_gap(self):
+        # Verify that the up-converter can mask data properly when sending non-sequential writes
+        def main_generator(dut):
+            yield from dut.write(0x00, 0x11, wait_data=False)
+            yield from dut.write(0x02, 0x22, wait_data=False)
+            yield from dut.write(0x03, 0x33, wait_data=False)
+            yield dut.write_user_port.flush.eq(1)
+            yield
+            yield dut.write_user_port.flush.eq(0)
+
+            yield from dut.write_driver.wait_all()
+            for _ in range(8):  # wait for memory
+                yield
+
+        mem_expected = [
+            # data, address
+            0x33220011,  # 0x00
+            0x00000000,  # 0x04
+            0x00000000,  # 0x08
+            0x00000000,  # 0x0c
+        ]
+
+        for separate_rw in [True, False]:
+            with self.subTest(separate_rw=separate_rw):
+                dut  = ConverterDUT(user_data_width=8, native_data_width=32,
+                                    mem_depth=len(mem_expected), separate_rw=separate_rw)
+                self.converter_readback_test(dut, pattern=[], mem_expected=mem_expected,
+                                             main_generator=main_generator)
+
     def test_converter_up_not_aligned(self):
-        self.converter_test(test_data="8bit_to_32bit_not_aligned", user_data_width=8, native_data_width=32)
+        data = self.pattern_test_data["8bit_to_32bit_not_aligned"]
+        dut  = ConverterDUT(user_data_width=8, native_data_width=32,
+                            mem_depth=len(data["expected"]), separate_rw=False)
+        self.converter_readback_test(dut, data["pattern"], data["expected"])
 
     def cdc_readback_test(self, dut, pattern, mem_expected, clocks):
         assert len(set(adr for adr, _ in pattern)) == len(pattern), "Pattern has duplicates!"
@@ -236,16 +371,16 @@ class TestAdaptation(MemoryTestDataMixin, unittest.TestCase):
                 yield from dut.write(adr, data)
 
             for adr, _ in pattern:
-                yield from dut.read(adr, read_data=False)
+                yield from dut.read(adr, wait_data=False)
 
-            # Latency delay
-            for _ in range(32):
-                yield
+            yield from dut.write_driver.wait_all()
+            yield from dut.read_driver.wait_all()
 
         generators = {
             "user": [
                 main_generator(dut, pattern),
                 read_handler(dut.read_user_port),
+                *dut.driver_generators,
                 timeout_generator(5000),
             ],
             "native": [

--- a/test/test_crossbar.py
+++ b/test/test_crossbar.py
@@ -510,10 +510,5 @@ class TestCrossbar(unittest.TestCase):
         modes       = ["both", "write", "read"]
         for mode, data_width in itertools.product(modes, data_widths):
             with self.subTest(mode=mode, data_width=data_width):
-                # Up conversion is supported only for single direction ports
-                if mode == "both" and data_width < dut.interface.data_width:
-                    with self.assertRaises(NotImplementedError):
-                        dut.crossbar.get_port(mode=mode, data_width=data_width)
-                else:
-                    port = dut.crossbar.get_port(mode=mode, data_width=data_width)
-                    self.assertEqual(port.data_width, data_width)
+                port = dut.crossbar.get_port(mode=mode, data_width=data_width)
+                self.assertEqual(port.data_width, data_width)

--- a/test/test_crossbar.py
+++ b/test/test_crossbar.py
@@ -285,21 +285,24 @@ class TestCrossbar(unittest.TestCase):
                 kwargs = dict(data=next(read_data))
             expected.append(cls(bank=t["bank"], addr=addr, **kwargs))
 
-        data = self.crossbar_test(dut, producer(dut, driver))
+        data = self.crossbar_test(dut, [producer(dut, driver)] + driver.generators())
         self.assertEqual(data, expected)
 
     def test_arbitration(self):
         # Create multiple masters that write to the same bank at the same time and verify that all
         # the requests have been sent correctly.
-        def producer(dut, port, num):
-            driver = NativePortDriver(port)
+        def producer(dut, driver, num):
             addr = dut.addr_port(bank=3, row=0x10 + num, col=0x20 + num)
             yield from driver.write(addr, data=0x30 + num)
 
         dut      = CrossbarDUT()
         ports    = [dut.crossbar.get_port() for _ in range(4)]
-        masters  = [producer(dut, port, i) for i, port in enumerate(ports)]
-        data     = self.crossbar_test(dut, masters)
+        drivers  = [NativePortDriver(port) for port in ports]
+        masters  = [producer(dut, driver, i) for i, driver in enumerate(drivers)]
+        generators = masters
+        for driver in drivers:
+            generators.extend(driver.generators())
+        data     = self.crossbar_test(dut, generators)
         expected = {
             self.W(bank=3, addr=dut.addr_iface(row=0x10, col=0x20), data=0x30, we=0xff),
             self.W(bank=3, addr=dut.addr_iface(row=0x11, col=0x21), data=0x31, we=0xff),
@@ -314,16 +317,14 @@ class TestCrossbar(unittest.TestCase):
         # continuously writing to bank 1 (bank is locked) so that master A is blocked. We use
         # wait_data=False because we are only concerned about sending commands fast enough for
         # the lock to be held continuously.
-        def master_a(dut, port):
-            driver = NativePortDriver(port)
+        def master_a(dut, driver):
             adr    = functools.partial(dut.addr_port, row=1, col=1)
             write  = functools.partial(driver.write, wait_data=False)
             yield from write(adr(bank=0), data=0x10)
             yield from write(adr(bank=1), data=0x11)
             yield from write(adr(bank=0), data=0x12, wait_data=True)
 
-        def master_b(dut, port):
-            driver = NativePortDriver(port)
+        def master_b(dut, driver):
             adr    = functools.partial(dut.addr_port, row=2, col=2)
             write  = functools.partial(driver.write, wait_data=False)
             yield from write(adr(bank=1), data=0x20)
@@ -332,9 +333,11 @@ class TestCrossbar(unittest.TestCase):
             yield from write(adr(bank=1), data=0x23)
             yield from write(adr(bank=1), data=0x24)
 
-        dut   = CrossbarDUT()
-        ports = [dut.crossbar.get_port() for _ in range(2)]
-        data  = self.crossbar_test(dut, [master_a(dut, ports[0]), master_b(dut, ports[1])])
+        dut     = CrossbarDUT()
+        ports   = [dut.crossbar.get_port() for _ in range(2)]
+        drivers = [NativePortDriver(port) for port in ports]
+        masters = [master_a(dut, drivers[0]), master_b(dut, drivers[1])]
+        data    = self.crossbar_test(dut, masters + drivers[0].generators() + drivers[1].generators())
         expected = [
             self.W(bank=0, addr=dut.addr_iface(row=1, col=1), data=0x10, we=0xff),  # A
             self.W(bank=1, addr=dut.addr_iface(row=2, col=2), data=0x20, we=0xff),  #  B
@@ -394,14 +397,13 @@ class TestCrossbar(unittest.TestCase):
         produced = defaultdict(list)
         prng = random.Random(42)
 
-        def master(dut, port, num):
+        def master(dut, driver, num):
             # Choose operation types based on port mode
             ops_choice = {
                 "both":  ["w", "r"],
                 "write": ["w"],
                 "read":  ["r"],
-            }[port.mode]
-            driver = NativePortDriver(port)
+            }[driver.port.mode]
 
             for i in range(n_ops):
                 bank = prng.randrange(n_banks)
@@ -417,12 +419,13 @@ class TestCrossbar(unittest.TestCase):
                     yield from driver.read(addr)
                     produced[num].append(self.R(bank, addr_iface, data=None))
 
-            for _ in range(8):
-                yield
+            yield from driver.wait_all()
 
         generators = defaultdict(list)
         for i, port in enumerate(ports):
-            generators[port.clock_domain].append(master(dut, port, i))
+            driver = NativePortDriver(port)
+            generators[port.clock_domain].append(master(dut, driver, i))
+            generators[port.clock_domain].extend(driver.generators())
         generators["sys"] += controller.generators()
         generators["sys"].append(timeout_generator(80 * n_ops))
 

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -15,12 +15,6 @@ from test.common import DRAMMemory, MemoryTestDataMixin
 
 
 class TestWishbone(MemoryTestDataMixin, unittest.TestCase):
-    def test_wishbone_data_width_not_smaller(self):
-        with self.assertRaises(AssertionError):
-            wb   = wishbone.Interface(data_width=32)
-            port = LiteDRAMNativePort("both", address_width=32, data_width=wb.data_width * 2)
-            LiteDRAMWishbone2Native(wb, port)
-
     def wishbone_readback_test(self, pattern, mem_expected, wishbone, port, base_address=0):
         class DUT(Module):
             def __init__(self):
@@ -80,6 +74,20 @@ class TestWishbone(MemoryTestDataMixin, unittest.TestCase):
         data = self.pattern_test_data["32bit_to_8bit"]
         wb   = wishbone.Interface(adr_width=30, data_width=32)
         port = LiteDRAMNativePort("both", address_width=30, data_width=8)
+        self.wishbone_readback_test(data["pattern"], data["expected"], wb, port)
+
+    def test_wishbone_8bit_to_32bit(self):
+        # Verify Wishbone with 8-bit data width up-converted to 32-bit data width.
+        data = self.pattern_test_data["8bit_to_32bit"]
+        wb   = wishbone.Interface(adr_width=30, data_width=8)
+        port = LiteDRAMNativePort("both", address_width=30, data_width=32)
+        self.wishbone_readback_test(data["pattern"], data["expected"], wb, port)
+
+    def test_wishbone_32bit_to_64bit(self):
+        # Verify Wishbone with 32-bit data width up-converted to 64-bit data width.
+        data = self.pattern_test_data["32bit_to_64bit"]
+        wb   = wishbone.Interface(adr_width=30, data_width=32)
+        port = LiteDRAMNativePort("both", address_width=30, data_width=64)
         self.wishbone_readback_test(data["pattern"], data["expected"], wb, port)
 
     def test_wishbone_32bit_base_address(self):

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -44,7 +44,7 @@ class TestWishbone(MemoryTestDataMixin, unittest.TestCase):
             dut.mem.write_handler(dut.port),
             dut.mem.read_handler(dut.port),
         ]
-        run_simulation(dut, generators)
+        run_simulation(dut, generators, vcd_name='sim.vcd')
         self.assertEqual(dut.mem.mem, mem_expected)
 
     def test_wishbone_8bit(self):


### PR DESCRIPTION
Closes https://github.com/enjoy-digital/litedram/issues/191

This PR implements the up-converter as described in https://github.com/enjoy-digital/litedram/issues/191. It combines subsequent `port_from` commands to lower the number of `port_to` commands. It allows incomplete transfers and automatically advances to next `port_to` command when command address or type (r/w) changes. It is also possible to have gaps, e.g. for 1:4 conversion we can write/read `[0x00, 0x02, 0x03], ...`. As you suggested, I used `port_from.cmd.last` instead of `port_from.flush` to indicate the end of a burst. `cmd.last` must be 1 if the last command does not form a "complete" `port_to` command.

I added unit tests for the mentioned cases and they all pass, but I seem to have some problem during `memtest` when running in `litex_sim`. I will further investigate if this is caused by the up-converter or there is some incompatibility with wishbone2native, so we may yet wait with merging this PR.

If you have any suggestions I can modify the implementation. To be able to handle all the cases I had to insert FIFOs on write and read data paths not to loose data during transfers with gaps.