### PR TITLE
Integrate micron memory model simulation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/xil-models"]
 	path = thirdparty/xil-models
-	url = git@github.com:dirjud/Nitro-Parts-lib-Xilinx.git
+	url = https://github.com/dirjud/Nitro-Parts-lib-Xilinx.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/xil-models"]
+	path = thirdparty/xil-models
+	url = git@github.com:dirjud/Nitro-Parts-lib-Xilinx.git

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -19,7 +19,7 @@ burst_lengths = {
     "DDR":   4,
     "LPDDR": 4,
     "DDR2":  4,
-    "DDR3":  8,
+    "DDR3":  4,
     "DDR4":  8
 }
 

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -114,7 +114,7 @@ def get_ddr2_phy_init_sequence(phy_settings, timing_settings):
 
 def get_ddr3_phy_init_sequence(phy_settings, timing_settings):
     cl  = phy_settings.cl
-    bl  = 8
+    bl  = 4
     cwl = phy_settings.cwl
 
     def format_mr0(bl, cl, wr, dll_reset):

--- a/litedram/modulemodel.py
+++ b/litedram/modulemodel.py
@@ -1,0 +1,66 @@
+import math
+
+from migen import *
+
+from litex.soc.interconnect.csr import *
+
+from litedram.common import *
+from litedram.phy.dfi import *
+
+# RAM module model ---------------------------------------------------------------------------------
+
+class SDRAMModuleModel(Module):
+
+    def __init__(self, platform):
+        vname = "ddr3"
+
+        from os import path
+        vdir = path.abspath(path.join(path.dirname(__file__), "../thirdparty/micron"))
+        platform.verilog_include_paths.append(vdir)
+        platform.add_source(path.join(vdir, f"{vname}.v"))
+
+        DM_BITS     =  2
+        ADDR_BITS   = 13
+        DQ_BITS     = 16
+        DQS_BITS    =  2
+        BA_BITS     =  3
+
+        self.reset_n = Signal()
+        self.clk_p   = Signal()
+        self.clk_n   = Signal()
+        self.a       = Signal(ADDR_BITS)
+        self.ba      = Signal(BA_BITS)
+        self.ras_n   = Signal()
+        self.cas_n   = Signal()
+        self.we_n    = Signal()
+        self.cs_n    = Signal()
+        self.dm      = Signal(DM_BITS)
+        self._dm     = Signal(DM_BITS)
+        self.dq      = Signal(DQ_BITS)
+        self.dqs     = Signal(DQS_BITS)
+        self._dqs_n  = Signal(DQS_BITS)
+        self.cke     = Signal()
+        self.odt     = Signal()
+        self.tdqs_n  = Signal(DQS_BITS)
+
+        self.comb += self._dm.eq(self.dm)
+        self.comb += self._dqs_n.eq(~self.dqs)
+
+        self.specials.module = Instance(vname,
+            i_rst_n    = self.reset_n,
+            i_ck       = self.clk_p,
+            i_ck_n     = self.clk_n,
+            i_cke      = self.cke,
+            i_cs_n     = self.cs_n,
+            i_ras_n    = self.ras_n,
+            i_cas_n    = self.cas_n,
+            i_we_n     = self.we_n,
+            io_dm_tdqs = self._dm,
+            i_ba       = self.ba,
+            i_addr     = self.a,
+            io_dq      = self.dq,
+            io_dqs     = self.dqs,
+            io_dqs_n   = self._dqs_n,
+            i_odt      = self.odt,
+            o_tdqs_n   = self.tdqs_n
+        )

--- a/litedram/phy/genericddr3phy.py
+++ b/litedram/phy/genericddr3phy.py
@@ -1,0 +1,488 @@
+# This file is Copyright (c) 2012 Sebastien Bourdeauducq <sb@m-labs.hk>
+# This file is Copyright (c) 2012-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# This file is Copyright (c) 2020 Antmicro <www.antmicro.com>
+# License: BSD
+
+from functools import reduce
+from operator import or_
+
+from migen import *
+from migen.genlib.record import *
+from migen.fhdl.decorators import ClockDomainsRenamer
+
+from litedram.common import *
+from litedram.phy.dfi import *
+
+
+class Serializer(Module):
+    def __init__(self, sd, strb, inputs):
+        assert(len(inputs) > 0)
+        assert(len(s) == len(inputs[0]) for s in inputs)
+
+        data_width = len(inputs)
+        signal_width = len(inputs[0])
+
+        if not isinstance(inputs, Array):
+            inputs = Array(inputs)
+
+        self.o = Signal(signal_width)
+        data_cntr = Signal(log2_int(data_width), reset=strb)
+        sd += data_cntr.eq(data_cntr+1)
+        self.comb += self.o.eq(inputs[data_cntr])
+
+class Deserializer(Module):
+    def __init__(self, sd, strb, input, outputs):
+        assert(len(outputs) > 0)
+        assert(len(s) == len(outputs[0]) for s in outputs)
+        assert(len(outputs[0]) == len(input))
+
+        data_width = len(outputs)
+        signal_width = len(outputs[0])
+
+        if not isinstance(outputs, Array):
+            outputs = Array(outputs)
+
+        data_cntr = Signal(log2_int(data_width), reset=strb)
+        sd += data_cntr.eq(data_cntr+1)
+        sd += outputs[data_cntr].eq(input)
+
+class GenericDDR3PHY(Module):
+    def __init__(self, pads, memtype, rd_bitslip, wr_bitslip, platform=None):
+        pads        = PHYPadsCombiner(pads)
+        if memtype not in ["DDR", "LPDDR", "DDR2", "DDR3"]:
+            raise NotImplementedError("GenericDDR3PHY only supports DDR, LPDDR, DDR2 and DDR3")
+        addressbits = len(pads.a)
+        bankbits    = len(pads.ba)
+        nranks      = 1 if not hasattr(pads, "cs_n") else len(pads.cs_n)
+        databits    = len(pads.dq)
+        nphases     = 2
+        assert databits%8 == 0
+
+        # Load verilog models
+        if platform is not None:
+            from os import path
+            this_file_dir = path.dirname(__file__)
+            thirdparty_dir = path.abspath(path.join(this_file_dir, "../../thirdparty"))
+
+            platform.verilog_include_paths.append(f"{thirdparty_dir}/xil-models")
+            platform.add_source(f"{thirdparty_dir}/xil-models/ISERDES2.v")
+            platform.add_source(f"{thirdparty_dir}/xil-models/ODDR2.v")
+            platform.add_source(f"{thirdparty_dir}/xil-models/IOBUF.v")
+            # platform.verilog_include_paths.append(f"{thirdparty_dir}/pll_sim")
+            # platform.add_source(f"{thirdparty_dir}/pll_sim/PLL_sim.v")
+
+
+        # PHY settings -----------------------------------------------------------------------------
+        if memtype == "DDR3":
+            self.settings = PhySettings(
+                phytype       = "GenericDDR3PHY",
+                memtype       = "DDR3",
+                databits      = databits,
+                dfi_databits  = 2*databits,
+                nranks        = nranks,
+                nphases       = nphases,
+                rdphase       = 0,
+                wrphase       = 1,
+                rdcmdphase    = 1,
+                wrcmdphase    = 0,
+                cl            = 6,
+                cwl           = 5,
+                read_latency  = 6,
+                write_latency = 1
+            )
+        else:
+            self.settings = PhySettings(
+                phytype       = "GenericDDR3PHY",
+                memtype       = memtype,
+                databits      = databits,
+                dfi_databits  = 2*databits,
+                nranks        = nranks,
+                nphases       = nphases,
+                rdphase       = 0,
+                wrphase       = 1,
+                rdcmdphase    = 1,
+                wrcmdphase    = 0,
+                cl            = 3,
+                read_latency  = 5,
+                write_latency = 0
+            )
+
+        # DFI Interface ----------------------------------------------------------------------------
+        self.dfi = dfi = Interface(addressbits, bankbits, nranks, 2*databits, nphases)
+        self.clk4x_wr_strb = Signal()
+        self.clk4x_rd_strb = Signal()
+
+        # # #
+
+        # Clock ------------------------------------------------------------------------------------
+        # sys_clk           : system clk, used for dfi interface
+        # sdram_half_clk    : half rate sdram clk
+        # sdram_full_wr_clk : full rate sdram write clk
+        # sdram_full_rd_clk : full rate sdram read clk
+        sd_sys = getattr(self.sync, "sys")
+        sd_sdram_half = getattr(self.sync, "sdram_half")
+        sd_full_wr = getattr(self.sync, "sdram_full_wr")
+        sd_full_rd = getattr(self.sync, "sdram_full_rd")
+
+        sys_clk = ClockSignal("sys")
+        sdram_half_clk = ClockSignal("sdram_half")
+        sdram_full_wr_clk = ClockSignal("sdram_full_wr")
+        sdram_full_rd_clk = ClockSignal("sdram_full_rd")
+
+        # Addresses and Commands -------------------------------------------------------------------
+
+        # select active phase
+        #             sys_clk   ----____----____
+        #  phase_sel(nphases=2) 0   1   0   1     Half Rate
+        phase_sel = Signal(log2_int(nphases))
+        phase_half = Signal.like(phase_sel)
+        phase_sys = Signal.like(phase_half)
+
+        sd_sys += phase_sys.eq(phase_half)
+
+        sd_sdram_half += [
+            If(phase_half == phase_sys,
+                phase_sel.eq(0),
+            ).Else(
+                phase_sel.eq(phase_sel+1)
+            ),
+            phase_half.eq(phase_half+1),
+        ]
+
+        # register dfi cmds on half_rate clk
+        r_dfi = Array(Record(phase_cmd_description(addressbits, bankbits, nranks=nranks)) for i in range(nphases))
+        for n, phase in enumerate(dfi.phases):
+            sd_sdram_half += [
+                r_dfi[n].reset_n.eq(phase.reset_n),
+                r_dfi[n].odt.eq(phase.odt),
+                r_dfi[n].address.eq(phase.address),
+                r_dfi[n].bank.eq(phase.bank),
+                r_dfi[n].cs_n.eq(phase.cs_n),
+                r_dfi[n].cke.eq(phase.cke),
+                r_dfi[n].cas_n.eq(phase.cas_n),
+                r_dfi[n].ras_n.eq(phase.ras_n),
+                r_dfi[n].we_n.eq(phase.we_n)
+            ]
+
+        # Iterate on pads groups -------------------------------------------------------------------
+        for pads_group in range(len(pads.groups)):
+            pads.sel_group(pads_group)
+
+            # output cmds
+            sd_sdram_half += [
+                pads.a.eq(r_dfi[phase_sel].address),
+                pads.ba.eq(r_dfi[phase_sel].bank),
+                pads.cke.eq(r_dfi[phase_sel].cke),
+                pads.ras_n.eq(r_dfi[phase_sel].ras_n),
+                pads.cas_n.eq(r_dfi[phase_sel].cas_n),
+                pads.we_n.eq(r_dfi[phase_sel].we_n)
+            ]
+            # optional pads
+            for name in "reset_n", "cs_n", "odt":
+              if hasattr(pads, name):
+                  sd_sdram_half += getattr(pads, name).eq(getattr(r_dfi[phase_sel], name))
+
+        # Bitslip ----------------------------------------------------------------------------------
+        bitslip_cnt = Signal(4)
+        bitslip_inc = Signal()
+
+        sd_sys += [
+            If(bitslip_cnt == rd_bitslip,
+                bitslip_inc.eq(0)
+            ).Else(
+                bitslip_cnt.eq(bitslip_cnt+1),
+                bitslip_inc.eq(1)
+            )
+        ]
+
+        # DQ/DQS/DM data ---------------------------------------------------------------------------
+        sdram_half_clk_n = Signal()
+        self.comb += sdram_half_clk_n.eq(~sdram_half_clk)
+
+        postamble = Signal()
+        drive_dqs = Signal()
+        dqs_t_d0 = Signal()
+        dqs_t_d1 = Signal()
+
+        dqs_o = Signal(databits//8)
+        dqs_t = Signal(databits//8)
+
+        self.comb += [
+            dqs_t_d0.eq(~(drive_dqs | postamble)),
+            dqs_t_d1.eq(~drive_dqs),
+        ]
+
+        for i in range(databits//8):
+            # DQS output
+            self.specials += Instance("ODDR2",
+                # p_DDR_ALIGNMENT=dqs_ddr_alignment,
+                # p_INIT=0,
+                # p_SRTYPE="ASYNC",
+
+                i_C0=sdram_half_clk,
+                i_C1=sdram_half_clk_n,
+
+                i_CE=1,
+                i_D0=0,
+                i_D1=1,
+                i_R=0,
+                i_S=0,
+
+                o_Q=dqs_o[i]
+            )
+
+            # DQS tristate cmd
+            self.specials += Instance("ODDR2",
+                # p_DDR_ALIGNMENT=dqs_ddr_alignment,
+                # p_INIT=0,
+                # p_SRTYPE="ASYNC",
+
+                i_C0=sdram_half_clk,
+                i_C1=sdram_half_clk_n,
+
+                i_CE=1,
+                i_D0=dqs_t_d0,
+                i_D1=dqs_t_d1,
+                i_R=0,
+                i_S=0,
+
+                o_Q=dqs_t[i]
+            )
+
+            # DQS tristate buffer
+            if hasattr(pads, "dqs_n"):
+                self.specials += Instance("IOBUFDS",
+                    i_T    = dqs_t[i],
+                    i_I    = dqs_o[i],
+                    io_IO  = pads.dqs[i],
+                    io_IOB = pads.dqs_n[i],
+                )
+            else:
+                self.specials += Instance("IOBUF",
+                    i_T   = dqs_t[i],
+                    i_I   = dqs_o[i],
+                    io_IO = pads.dqs[i],
+                )
+
+        sd_sdram_half += postamble.eq(drive_dqs)
+
+        d_dfi = [Record(phase_wrdata_description(nphases*databits)+phase_rddata_description(nphases*databits))
+            for i in range(2*nphases)]
+
+        for n, phase in enumerate(dfi.phases):
+            self.comb += [
+                d_dfi[n].wrdata.eq(phase.wrdata),
+                d_dfi[n].wrdata_mask.eq(phase.wrdata_mask),
+                d_dfi[n].wrdata_en.eq(phase.wrdata_en),
+                d_dfi[n].rddata_en.eq(phase.rddata_en),
+            ]
+            sd_sys += [
+                d_dfi[nphases+n].wrdata.eq(phase.wrdata),
+                d_dfi[nphases+n].wrdata_mask.eq(phase.wrdata_mask)
+            ]
+
+
+        drive_dq = Signal()
+        drive_dq_n = [Signal() for i in range(2)]
+        self.comb += drive_dq_n[0].eq(~drive_dq)
+        sd_sys += drive_dq_n[1].eq(drive_dq_n[0])
+
+        dq_t = Signal(databits)
+        dq_o = Signal(databits)
+        dq_i = Signal(databits)
+
+        dq_wrdata = []
+
+        for i in range(2):
+            for j in reversed(range(nphases)):
+                dq_wrdata.append(d_dfi[i*nphases+j].wrdata[:databits])
+                dq_wrdata.append(d_dfi[i*nphases+j].wrdata[databits:])
+
+
+        self.oserdes_d1 = Signal.like(dq_wrdata[wr_bitslip+3])
+        self.oserdes_d2 = Signal.like(dq_wrdata[wr_bitslip+2])
+        self.oserdes_d3 = Signal.like(dq_wrdata[wr_bitslip+1])
+        self.oserdes_d4 = Signal.like(dq_wrdata[wr_bitslip+0])
+
+        self.comb += self.oserdes_d1.eq(dq_wrdata[wr_bitslip+3])
+        self.comb += self.oserdes_d2.eq(dq_wrdata[wr_bitslip+2])
+        self.comb += self.oserdes_d3.eq(dq_wrdata[wr_bitslip+1])
+        self.comb += self.oserdes_d4.eq(dq_wrdata[wr_bitslip+0])
+
+        self.test_dq = Signal(len(pads.dq))
+
+        self.submodules.dq_serializer = Serializer(sd_full_wr, self.clk4x_wr_strb,
+                [self.oserdes_d1, self.oserdes_d2, self.oserdes_d3, self.oserdes_d4])
+
+        self.comb += self.test_dq.eq(self.dq_serializer.o)
+        # self.comb += dq_o.eq(self.dq_serializer.o)
+
+
+
+        self.iserdes_q1 = Signal.like(d_dfi[0].rddata)
+        self.iserdes_q2 = Signal.like(d_dfi[1].rddata)
+        # self.iserdes_q3 = Signal.like(d_dfi[1].rddata[:databits])
+        # self.iserdes_q4 = Signal.like(d_dfi[1].rddata[databits:])
+
+        self.submodules.dq_deserializer = Deserializer(sd_full_rd, self.clk4x_rd_strb, dq_i,
+                [self.iserdes_q1[databits:], self.iserdes_q1[:databits], self.iserdes_q2[databits:], self.iserdes_q2[:databits]])
+
+        for i in range(databits):
+            # Data serializer
+            self.specials += Instance("OSERDES2",
+                p_DATA_WIDTH=4,
+                p_DATA_RATE_OQ="SDR",
+                p_DATA_RATE_OT="SDR",
+                p_SERDES_MODE="NONE",
+                p_OUTPUT_MODE="SINGLE_ENDED",
+
+                o_OQ=dq_o[i],
+                i_OCE=1,
+                i_CLK0=sdram_full_wr_clk,
+                i_CLK1=0,
+                i_IOCE=self.clk4x_wr_strb,
+                i_RST=0,
+                i_CLKDIV=sys_clk,
+
+                i_D1=dq_wrdata[wr_bitslip+3][i],
+                i_D2=dq_wrdata[wr_bitslip+2][i],
+                i_D3=dq_wrdata[wr_bitslip+1][i],
+                i_D4=dq_wrdata[wr_bitslip+0][i],
+
+                o_TQ=dq_t[i],
+                i_T1=drive_dq_n[(wr_bitslip+3)//4],
+                i_T2=drive_dq_n[(wr_bitslip+2)//4],
+                i_T3=drive_dq_n[(wr_bitslip+1)//4],
+                i_T4=drive_dq_n[(wr_bitslip+0)//4],
+                i_TRAIN=0,
+                i_TCE=1,
+                i_SHIFTIN1=0,
+                i_SHIFTIN2=0,
+                i_SHIFTIN3=0,
+                i_SHIFTIN4=0,
+            )
+
+            # Data deserializer
+            self.specials += Instance("ISERDES2",
+                p_DATA_WIDTH=4,
+                p_DATA_RATE="SDR",
+                p_BITSLIP_ENABLE="TRUE",
+                p_SERDES_MODE="NONE",
+                p_INTERFACE_TYPE="RETIMED",
+
+                i_D=dq_i[i],
+                i_CE0=1,
+                i_CLK0=sdram_full_rd_clk,
+                i_CLK1=0,
+                i_IOCE=self.clk4x_rd_strb,
+                i_RST=ResetSignal(),
+                i_CLKDIV=sys_clk,
+                i_BITSLIP=bitslip_inc,
+
+                o_Q1=d_dfi[0*nphases+0].rddata[i],
+                o_Q2=d_dfi[0*nphases+0].rddata[i+databits],
+                o_Q3=d_dfi[0*nphases+1].rddata[i],
+                o_Q4=d_dfi[0*nphases+1].rddata[i+databits],
+            )
+
+            # Data buffer
+            self.specials += Instance("IOBUF",
+                i_I=dq_o[i],
+                o_O=dq_i[i],
+                i_T=dq_t[i],
+                io_IO=pads.dq[i]
+            )
+
+        dq_wrdata_mask = []
+        for i in range(2):
+            for j in reversed(range(nphases)):
+                dq_wrdata_mask.append(d_dfi[i*nphases+j].wrdata_mask[:databits//8])
+                dq_wrdata_mask.append(d_dfi[i*nphases+j].wrdata_mask[databits//8:])
+
+        self.dm_oserdes_d1 = Signal.like(dq_wrdata_mask[wr_bitslip+3])
+        self.dm_oserdes_d2 = Signal.like(dq_wrdata_mask[wr_bitslip+2])
+        self.dm_oserdes_d3 = Signal.like(dq_wrdata_mask[wr_bitslip+1])
+        self.dm_oserdes_d4 = Signal.like(dq_wrdata_mask[wr_bitslip+0])
+
+        self.comb += self.dm_oserdes_d1.eq(dq_wrdata_mask[wr_bitslip+3])
+        self.comb += self.dm_oserdes_d2.eq(dq_wrdata_mask[wr_bitslip+2])
+        self.comb += self.dm_oserdes_d3.eq(dq_wrdata_mask[wr_bitslip+1])
+        self.comb += self.dm_oserdes_d4.eq(dq_wrdata_mask[wr_bitslip+0])
+
+        self.test_dm = Signal(len(pads.dm))
+
+        self.submodules.dm_serializer = Serializer(sd_full_wr, self.clk4x_wr_strb,
+                [self.dm_oserdes_d1, self.dm_oserdes_d2, self.dm_oserdes_d3, self.dm_oserdes_d4])
+
+        self.comb += self.test_dm.eq(self.dm_serializer.o)
+
+        # dm = Signal(len(pads.dm))
+        # self.comb += [pads.dm[i].eq(dm[i]) for i in range(len(pads.dm))]
+        # self.comb += dm.eq(self.dm_serializer.o)
+
+        for i in range(databits//8):
+            # Mask serializer
+            self.specials += Instance("OSERDES2",
+                p_DATA_WIDTH=4,
+                p_DATA_RATE_OQ="SDR",
+                p_DATA_RATE_OT="SDR",
+                p_SERDES_MODE="NONE",
+                p_OUTPUT_MODE="SINGLE_ENDED",
+                o_OQ=pads.dm[i],
+                i_OCE=1,
+                i_CLK0=sdram_full_wr_clk,
+                i_CLK1=0,
+                i_IOCE=self.clk4x_wr_strb,
+                i_RST=0,
+                i_CLKDIV=sys_clk,
+                i_D1=dq_wrdata_mask[wr_bitslip+3][i],
+                i_D2=dq_wrdata_mask[wr_bitslip+2][i],
+                i_D3=dq_wrdata_mask[wr_bitslip+1][i],
+                i_D4=dq_wrdata_mask[wr_bitslip+0][i],
+                i_TRAIN=0,
+                i_TCE=0,
+                i_SHIFTIN1=0,
+                i_SHIFTIN2=0,
+                i_SHIFTIN3=0,
+                i_SHIFTIN4=0,
+            )
+
+        # DQ/DQS/DM control ------------------------------------------------------------------------
+
+        # write
+        wrdata_en = Signal()
+        self.comb += wrdata_en.eq(reduce(or_, [d_dfi[p].wrdata_en for p in range(nphases)]))
+
+        if memtype == "DDR3":
+            r_drive_dq = Signal(self.settings.cwl-1)
+            sd_sdram_half += r_drive_dq.eq(Cat(wrdata_en, r_drive_dq))
+            self.comb += drive_dq.eq(r_drive_dq[self.settings.cwl-2])
+        else:
+            self.comb += drive_dq.eq(wrdata_en)
+
+        wrdata_en_d = Signal()
+        sd_sys += wrdata_en_d.eq(wrdata_en)
+
+        if memtype == "DDR3":
+            r_dfi_wrdata_en = Signal(max(self.settings.cwl, self.settings.cl))
+        else:
+            r_dfi_wrdata_en = Signal(self.settings.cl)
+        sd_sdram_half += r_dfi_wrdata_en.eq(Cat(wrdata_en_d, r_dfi_wrdata_en))
+
+        if memtype == "DDR3":
+            self.comb += drive_dqs.eq(r_dfi_wrdata_en[self.settings.cwl-1])
+        else:
+            self.comb += drive_dqs.eq(r_dfi_wrdata_en[1])
+
+        # read
+        rddata_en = Signal()
+        self.comb += rddata_en.eq(reduce(or_, [d_dfi[p].rddata_en for p in range(nphases)]))
+
+        rddata_sr = Signal(self.settings.read_latency)
+        sd_sys += rddata_sr.eq(Cat(rddata_sr[1:self.settings.read_latency], rddata_en))
+
+        for n, phase in enumerate(dfi.phases):
+            self.comb += [
+                phase.rddata.eq(d_dfi[n].rddata),
+                phase.rddata_valid.eq(rddata_sr[0]),
+            ]

--- a/thirdparty/patch-micron.sh
+++ b/thirdparty/patch-micron.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+shopt -s nullglob
+shopt -s extglob
+
+SELF_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
+cd $SELF_DIR
+
+SRC="$SELF_DIR/micron"
+PATCHES="$SELF_DIR/patches/micron"
+
+
+if [[ ! -e "$SRC/ddr3.v" ]]; then
+	cat <<-EOF
+Micron memory model not found. Please download "DDR3 SDRAM Verilog Model" from:
+
+  https://www.micron.com/products/dram/ddr3-sdram/part-catalog/mt41k512m16ha-125
+
+and unpack it in the following directory:
+
+  $SRC
+
+EOF
+	mkdir -p $SRC
+	exit 1
+fi
+
+cd $SRC
+git init .
+git add \
+	1024Mb_ddr3_parameters.vh \
+	2048Mb_ddr3_parameters.vh \
+	4096Mb_ddr3_parameters.vh \
+	8192Mb_ddr3_parameters.vh \
+	ddr3.v \
+	ddr3_dimm.v \
+	ddr3_mcp.v \
+	ddr3_module.v \
+	readme.txt \
+	subtest.vh \
+	tb.v
+git commit -m 'Initial commit'
+
+if [[ -n "$(ls $PATCHES/)" ]]; then
+	git am $PATCHES/*
+fi

--- a/thirdparty/patch-xil-models.sh
+++ b/thirdparty/patch-xil-models.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+shopt -s nullglob
+shopt -s extglob
+
+SELF_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
+cd $SELF_DIR
+
+SRC="$SELF_DIR/xil-models"
+PATCHES="$SELF_DIR/patches/xil-models"
+
+git submodule update --init --recursive
+cd $SRC
+
+if [[ -n "$(ls $PATCHES/)" ]]; then
+	git am $PATCHES/*
+fi

--- a/thirdparty/patches/micron/0001-Add-configuration-defines.patch
+++ b/thirdparty/patches/micron/0001-Add-configuration-defines.patch
@@ -1,0 +1,27 @@
+From 6ce2e9ee5441f686bb0af7e7c64f1a19f2c275cf Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 08:30:05 +0200
+Subject: [PATCH 1/7] Add configuration defines
+
+---
+ ddr3.v | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/ddr3.v b/ddr3.v
+index 0b1970c..dd20747 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -115,6 +115,10 @@ module ddr3 (
+     odt
+ );
+ 
++`define den1024Mb
++`define x16
++`define sg25
++
+ `ifdef den1024Mb
+     `include "1024Mb_ddr3_parameters.vh"
+ `elsif den2048Mb
+-- 
+2.20.1
+

--- a/thirdparty/patches/micron/0002-Do-not-use-timeformat-under-Verilator.patch
+++ b/thirdparty/patches/micron/0002-Do-not-use-timeformat-under-Verilator.patch
@@ -1,0 +1,30 @@
+From 7ffdfe343e5795977edde3b7bc43988a5564a8b7 Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 08:33:51 +0200
+Subject: [PATCH 2/7] Do not use $timeformat under Verilator
+
+---
+ ddr3.v | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/ddr3.v b/ddr3.v
+index dd20747..3ee6885 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -553,8 +553,11 @@ module ddr3 (
+         if ((1<<BO_BITS) > BL_MAX) 
+             $display("%m ERROR: 2^BO_BITS cannot be greater than BL_MAX parameter.");
+ 
+-        $timeformat (-12, 1, " ps", 1);
+-        seed = RANDOM_SEED;
++        `ifdef VERILATOR
++        `else
++            $timeformat (-12, 1, " ps", 1);
++            seed = RANDOM_SEED;
++        `endif
+ 
+         ck_cntr = 0;
+     end
+-- 
+2.20.1
+

--- a/thirdparty/patches/micron/0003-Prevent-file-I-O.patch
+++ b/thirdparty/patches/micron/0003-Prevent-file-I-O.patch
@@ -1,0 +1,22 @@
+From 6ec70787e0ab14ba03111bf033c051ae054a8ea3 Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 08:37:54 +0200
+Subject: [PATCH 3/7] Prevent file I/O
+
+---
+ ddr3.v | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ddr3.v b/ddr3.v
+index 3ee6885..e74ad92 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -1,4 +1,4 @@
+-`define MAX_MEM
++// `define MAX_MEM
+ /****************************************************************************************
+ *
+ *    File Name:  ddr3.v
+-- 
+2.20.1
+

--- a/thirdparty/patches/micron/0004-Do-not-use-dist_uniform.patch
+++ b/thirdparty/patches/micron/0004-Do-not-use-dist_uniform.patch
@@ -1,0 +1,34 @@
+From 304b645093cfcb937b6e58092a90a123564023cb Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 08:45:11 +0200
+Subject: [PATCH 4/7] Do not use $dist_uniform
+
+---
+ ddr3.v | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ddr3.v b/ddr3.v
+index e74ad92..50c1ec2 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -1949,7 +1949,7 @@ module ddr3 (
+                     if (dqsck_min == dqsck_max) begin
+                         dqsck[i] = dqsck_min;
+                     end else begin
+-                        dqsck[i] = $dist_uniform(seed, dqsck_min, dqsck_max);
++                        dqsck[i] = (dqsck_min + dqsck_max) / 2;
+                     end
+                     dqsq_max = TDQSQ + dqsck[i];
+ 
+@@ -1961,7 +1961,7 @@ module ddr3 (
+                             if (dqsq_min == dqsq_max) begin
+                                 dq_out_dly   [i*`DQ_PER_DQS + j] <= #(tck_avg/2 + dqsq_min) dq_out[i*`DQ_PER_DQS + j];
+                             end else begin
+-                                dq_out_dly   [i*`DQ_PER_DQS + j] <= #(tck_avg/2 + $dist_uniform(seed, dqsq_min, dqsq_max)) dq_out[i*`DQ_PER_DQS + j];
++                                dq_out_dly   [i*`DQ_PER_DQS + j] <= #(tck_avg/2 + (dqsq_min + dqsq_max)/2) dq_out[i*`DQ_PER_DQS + j];
+                             end
+                         end
+                     end
+-- 
+2.20.1
+

--- a/thirdparty/patches/micron/0005-Replace-unsupported-assignment.patch
+++ b/thirdparty/patches/micron/0005-Replace-unsupported-assignment.patch
@@ -1,0 +1,25 @@
+From 38417a4c58d967659ba4a3de7ee1802ef130d461 Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 08:45:21 +0200
+Subject: [PATCH 5/7] Replace unsupported assignment
+
+---
+ ddr3.v | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ddr3.v b/ddr3.v
+index 50c1ec2..fb9a2d5 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -1401,7 +1401,7 @@ module ddr3 (
+                                             end else begin
+                                                 if (DEBUG) $display ("%m: at time %t INFO: %s bank %d", $time, cmd_string[cmd], i);
+                                                 active_bank[i] = 1'b0;
+-                                                tm_bank_precharge[i] <= $time;
++                                                tm_bank_precharge[i] = $time;
+                                                 tm_precharge <= $time;
+                                                 ck_precharge <= ck_cntr;
+                                             end
+-- 
+2.20.1
+

--- a/thirdparty/patches/micron/0006-Replace-non-working-assignment.patch
+++ b/thirdparty/patches/micron/0006-Replace-non-working-assignment.patch
@@ -1,0 +1,25 @@
+From 6f3d44bc66e3a4c14a34dc54969065a98a8df4b4 Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 09:10:43 +0200
+Subject: [PATCH 6/7] Replace non-working assignment
+
+---
+ ddr3.v | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ddr3.v b/ddr3.v
+index fb9a2d5..92a0c37 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -2125,7 +2125,7 @@ module ddr3 (
+                                 // the internal precharge happens (not at the next rising clock edge after this event).
+                                 if ($time - tm_bank_read_end[i] < TRTP) begin
+                                     if (DEBUG) $display ("%m: at time %t INFO: Auto Precharge bank %d", tm_bank_read_end[i] + TRTP, i);
+-                                    active_bank[i] <= #(tm_bank_read_end[i] + TRTP - $time) 0;
++                                    active_bank[i] = 0;
+                                     auto_precharge_bank[i] <= #(tm_bank_read_end[i] + TRTP - $time) 0;
+                                     tm_bank_precharge[i] <= #(tm_bank_read_end[i] + TRTP - $time) tm_bank_read_end[i] + TRTP;
+                                     tm_precharge <= #(tm_bank_read_end[i] + TRTP - $time) tm_bank_read_end[i] + TRTP;
+-- 
+2.20.1
+

--- a/thirdparty/patches/micron/0007-REVERT-LATER-Comment-out-too-verbose-init-errors.patch
+++ b/thirdparty/patches/micron/0007-REVERT-LATER-Comment-out-too-verbose-init-errors.patch
@@ -1,0 +1,99 @@
+From ff560c42b49c854439f9a9b1c07cbc6d64be09b5 Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 08:59:21 +0200
+Subject: [PATCH 7/7] [REVERT LATER] Comment out too verbose init errors
+
+---
+ ddr3.v | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/ddr3.v b/ddr3.v
+index 92a0c37..8a5a531 100644
+--- a/ddr3.v
++++ b/ddr3.v
+@@ -2048,17 +2048,17 @@ module ddr3 (
+                 // check setup of command signals
+                 if ($time > TIS) begin
+                     if ($time - tm_cke < TIS) 
+-                        $display ("%m: at time %t ERROR:   tIS violation on CKE by %t", $time, tm_cke + TIS - $time);
++                        ; // $display ("%m: at time %t ERROR:   tIS violation on CKE by %t", $time, tm_cke + TIS - $time);
+                     if (cke_in) begin
+                         for (i=0; i<3; i=i+1) begin
+                             if ($time - tm_cmd_addr[i] < TIS) 
+-                                $display ("%m: at time %t ERROR:   tIS violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIS - $time);
++                                ; // $display ("%m: at time %t ERROR:   tIS violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIS - $time);
+                         end
+                     end
+                     if (cke_in & !(cs_n_in | (ras_n_in & cas_n_in & we_n_in))) begin // Bank and Address are don't care when DES or NOP
+                         for (i=4; i<23; i=i+1) begin
+                             if ($time - tm_cmd_addr[i] < TIS)
+-                                $display ("%m: at time %t ERROR:   tIS violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIS - $time);
++                                ; // $display ("%m: at time %t ERROR:   tIS violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIS - $time);
+                         end
+                     end
+                 end
+@@ -2227,15 +2227,15 @@ module ddr3 (
+                         if (TCK_MIN - tck_avg >= 1.0)
+                             $display ("%m: at time %t ERROR: tCK(avg) minimum violation by %f ps.", $time, TCK_MIN - tck_avg);
+                         if (tck_avg - TCK_MAX >= 1.0) 
+-                            $display ("%m: at time %t ERROR: tCK(avg) maximum violation by %f ps.", $time, tck_avg - TCK_MAX);
++                            ; // $display ("%m: at time %t ERROR: tCK(avg) maximum violation by %f ps.", $time, tck_avg - TCK_MAX);
+ 
+                         // check tCL
+                         if (tm_ck_neg - $time < TCL_ABS_MIN*tck_avg) 
+-                            $display ("%m: at time %t ERROR: tCL(abs) minimum violation on CLK by %t", $time, TCL_ABS_MIN*tck_avg - tm_ck_neg + $time);
++                            ; // $display ("%m: at time %t ERROR: tCL(abs) minimum violation on CLK by %t", $time, TCL_ABS_MIN*tck_avg - tm_ck_neg + $time);
+                         if (tcl_avg < TCL_AVG_MIN*tck_avg) 
+-                            $display ("%m: at time %t ERROR: tCL(avg) minimum violation on CLK by %t", $time, TCL_AVG_MIN*tck_avg - tcl_avg);
++                            ; // $display ("%m: at time %t ERROR: tCL(avg) minimum violation on CLK by %t", $time, TCL_AVG_MIN*tck_avg - tcl_avg);
+                         if (tcl_avg > TCL_AVG_MAX*tck_avg) 
+-                            $display ("%m: at time %t ERROR: tCL(avg) maximum violation on CLK by %t", $time, tcl_avg - TCL_AVG_MAX*tck_avg);
++                            ; // $display ("%m: at time %t ERROR: tCL(avg) maximum violation on CLK by %t", $time, tcl_avg - TCL_AVG_MAX*tck_avg);
+                     end
+ 
+                     // calculate the tch avg jitter
+@@ -2459,19 +2459,19 @@ module ddr3 (
+         if (rst_n_in) begin
+             if ($time > TIH) begin
+                 if ($time - tm_ck_pos < TIH) 
+-                    $display ("%m: at time %t ERROR:  tIH violation on CKE by %t", $time, tm_ck_pos + TIH - $time);
++                    ; // $display ("%m: at time %t ERROR:  tIH violation on CKE by %t", $time, tm_ck_pos + TIH - $time);
+             end
+             if ($time - tm_cke < TIPW)
+-                $display ("%m: at time %t ERROR: tIPW violation on CKE by %t", $time, tm_cke + TIPW - $time);
++                ; // $display ("%m: at time %t ERROR: tIPW violation on CKE by %t", $time, tm_cke + TIPW - $time);
+         end
+         tm_cke = $time;
+     end
+     always @(odt_in) begin
+         if (rst_n_in && odt_en && !in_self_refresh) begin
+             if ($time - tm_ck_pos < TIH) 
+-                $display ("%m: at time %t ERROR:  tIH violation on ODT by %t", $time, tm_ck_pos + TIH - $time);
++                ; // $display ("%m: at time %t ERROR:  tIH violation on ODT by %t", $time, tm_ck_pos + TIH - $time);
+             if ($time - tm_odt < TIPW)
+-                $display ("%m: at time %t ERROR: tIPW violation on ODT by %t", $time, tm_odt + TIPW - $time);
++                ; // $display ("%m: at time %t ERROR: tIPW violation on ODT by %t", $time, tm_odt + TIPW - $time);
+         end
+         tm_odt = $time;
+     end
+@@ -2482,13 +2482,13 @@ module ddr3 (
+     begin
+         if (rst_n_in && prev_cke) begin
+             if ((i == 0) && ($time - tm_ck_pos < TIH))	               // always check tIH for CS#
+-                $display ("%m: at time %t ERROR:  tIH violation on %s by %t", $time, cmd_addr_string[i], tm_ck_pos + TIH - $time);
++                ; // $display ("%m: at time %t ERROR:  tIH violation on %s by %t", $time, cmd_addr_string[i], tm_ck_pos + TIH - $time);
+             if ((i > 0) && (cs_n_in == 0) &&($time - tm_ck_pos < TIH)) // Only check tIH for cmd_addr if CS# is low
+-                $display ("%m: at time %t ERROR:  tIH violation on %s by %t", $time, cmd_addr_string[i], tm_ck_pos + TIH - $time);
++                ; // $display ("%m: at time %t ERROR:  tIH violation on %s by %t", $time, cmd_addr_string[i], tm_ck_pos + TIH - $time);
+             if ((i == 0) && ($time - tm_cmd_addr[i] < TIPW))           // always check tIPW for CS#
+-                $display ("%m: at time %t ERROR: tIPW violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIPW - $time);
++                ; // $display ("%m: at time %t ERROR: tIPW violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIPW - $time);
+             if ((i > 0) && (cs_n_in == 0) && ($time - tm_cmd_addr[i] < TIPW))
+-                $display ("%m: at time %t ERROR: tIPW violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIPW - $time);
++                ; // $display ("%m: at time %t ERROR: tIPW violation on %s by %t", $time, cmd_addr_string[i], tm_cmd_addr[i] + TIPW - $time);
+         end
+         tm_cmd_addr[i] = $time;
+     end
+-- 
+2.20.1
+

--- a/thirdparty/patches/xil-models/0001-iserdes2-oserdes2-hardcode-SDR-rate-do-not-use-PLL_s.patch
+++ b/thirdparty/patches/xil-models/0001-iserdes2-oserdes2-hardcode-SDR-rate-do-not-use-PLL_s.patch
@@ -1,0 +1,71 @@
+From a70433f489ad2c1da9d58f6d327a5b477fa15fbc Mon Sep 17 00:00:00 2001
+From: Mariusz Glebocki <mglebocki@antmicro.com>
+Date: Wed, 20 May 2020 07:33:55 +0200
+Subject: [PATCH] iserdes2, oserdes2: hardcode SDR rate; do not use PLL_sim
+
+---
+ ISERDES2.v | 18 +++++++++---------
+ OSERDES2.v | 18 +++++++++---------
+ 2 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/ISERDES2.v b/ISERDES2.v
+index d9d0dd0..4d67b1c 100644
+--- a/ISERDES2.v
++++ b/ISERDES2.v
+@@ -295,15 +295,15 @@ module ISERDES2 (
+     end  // initial begin
+ 
+ //-----------------------------------------------------------------------------------
+-   parameter PLL_MULT = DATA_RATE == "DDR" ? 2 : 1;
+-   PLL_sim PLL_sim(.input_clk(CLK0_IN),
+-		   .output_clk(clk_int),
+-		   .pll_mult(PLL_MULT),
+-		   .pll_div(1),
+-		   .locked(),
+-		   .debug(0));
+-   
+-   //assign clk_int = clk0_int | clk1_int;
++   // parameter PLL_MULT = DATA_RATE == "DDR" ? 2 : 1;
++   // PLL_sim PLL_sim(.input_clk(CLK0_IN),
++			 // .output_clk(clk_int),
++			 // .pll_mult(PLL_MULT),
++			 // .pll_div(1),
++			 // .locked(),
++			 // .debug(0));
++
++    assign clk_int = CLK0_IN;
+ 
+     assign CFB0_OUT = CLK0_IN;
+     assign CFB1_OUT = CLK1_IN;
+diff --git a/OSERDES2.v b/OSERDES2.v
+index 5ffe996..99b43e2 100644
+--- a/OSERDES2.v
++++ b/OSERDES2.v
+@@ -464,15 +464,15 @@ module OSERDES2 (
+ //           #100  clk1_int = 0;
+ //        end
+ //    endgenerate
+-//    assign clk_int = clk0_int | clk1_int;
+-   parameter PLL_MULT = DATA_RATE_OQ == "DDR" ? 2 : 1;
+-   PLL_sim PLL_sim(.input_clk(CLK0_INDELAY),
+-		   .output_clk(clk_int),
+-		   .pll_mult(PLL_MULT),
+-		   .pll_div(1),
+-		   .locked(),
+-		   .debug(0));
+-   
++   assign clk_int = CLK0_INDELAY;
++   // parameter PLL_MULT = DATA_RATE_OQ == "DDR" ? 2 : 1;
++   // PLL_sim PLL_sim(.input_clk(CLK0_INDELAY),
++					// .output_clk(clk_int),
++					// .pll_mult(PLL_MULT),
++					// .pll_div(1),
++					// .locked(),
++					// .debug(0));
++
+ //
+ // =====================
+ // IOCE sample
+-- 
+2.20.1
+


### PR DESCRIPTION
Issues:
* PHY needs 4 phases to use BL=8. BL for DDR3 is changed to 4 for now.
* Invalid DQS during writing
* Xilinx primitives (especially OSERDES/ISERDES) used in the PHY must be replaced

Before use:
* Download verilog model from https://www.micron.com/products/dram/ddr3-sdram/part-catalog/mt41k512m16ha-125
* Unpack it to ./thirdparty/micron
* Run `./patch-micron.sh && ./patch-xil-models.sh` in thirdparty directory

Use with https://github.com/enjoy-digital/litex/pull/536