### PR TITLE
Allow generation of a standalone sim model

### DIFF
--- a/litedram/phy/model.py
+++ b/litedram/phy/model.py
@@ -492,7 +492,7 @@ class SDRAMPHYModel(Module):
             self.submodules += timing_checker
 
         # Bank init data ---------------------------------------------------------------------------
-        bank_init  = [[] for i in range(nbanks)]
+        bank_init  = [None for i in range(nbanks)]
 
         if init:
             bank_init = self.__prepare_bank_init_data(


### PR DESCRIPTION
(This depends on the corresponding branch in LiteX)

This allows litedram_gen --sim to be used to generate a simulated litedram model from
the same .yml file as a real synth model.