### PR TITLE
frontend/fifo: increase FIFO level only after data has actually been written

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -609,9 +609,7 @@ class LiteDRAMCore(SoCCore):
                     base            = port["base"],
                     depth           = port["depth"],
                     write_port      = self.sdram.crossbar.get_port("write"),
-                    write_threshold = port["depth"] - 32, # FIXME
                     read_port       = self.sdram.crossbar.get_port("read"),
-                    read_threshold  = 32 # FIXME
                 )
                 self.submodules += fifo
                 self.comb += [


### PR DESCRIPTION
Closes https://github.com/enjoy-digital/litedram/issues/203

This removes the need for `read_threshold` by using `port.wdata.ready` (or `port.w.ready` for `LiteDRAMAXIPort`) to increment FIFO level. This way data is available for read only after it has been actually written to memory. The tests have been updated and `write_threshold` has also been removed as now it is not needed. 