### PR TITLE
Add HalfRate GENSDRPHY

### DIFF
--- a/litedram/core/controller.py
+++ b/litedram/core/controller.py
@@ -45,7 +45,8 @@ class ControllerSettings(Settings):
 class LiteDRAMController(Module):
     def __init__(self, phy_settings, geom_settings, timing_settings, clk_freq,
         controller_settings=ControllerSettings()):
-        address_align = log2_int(burst_lengths[phy_settings.memtype])
+        burst_length = phy_settings.nphases * (1 if phy_settings.memtype == "SDR" else 2)
+        address_align = log2_int(burst_length)
 
         # Settings ---------------------------------------------------------------------------------
         self.settings        = controller_settings

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -20,7 +20,7 @@ cmds = {
 
 def get_sdr_phy_init_sequence(phy_settings, timing_settings):
     cl = phy_settings.cl
-    bl = 1
+    bl = phy_settings.nphases
     mr = log2_int(bl) + (cl << 4)
     reset_dll = 1 << 8
 

--- a/litedram/phy/__init__.py
+++ b/litedram/phy/__init__.py
@@ -1,4 +1,4 @@
-from litedram.phy.gensdrphy import GENSDRPHY
+from litedram.phy.gensdrphy import GENSDRPHY, HalfRateGENSDRPHY
 
 from litedram.phy.s6ddrphy import S6HalfRateDDRPHY, S6QuarterRateDDRPHY
 from litedram.phy.s7ddrphy import V7DDRPHY, K7DDRPHY, A7DDRPHY


### PR DESCRIPTION
Corresponding issue: https://github.com/enjoy-digital/litedram/issues/183

This adds a wrapper over GENSDRPHY and option to use it on ULX3S (with https://github.com/enjoy-digital/litex/pull/563 PR).

But this does not yet work correctly, I've been trying to find an error, but with no success. 
@enjoy-digital could you please take a look if I'm missing something?