### PR TITLE
dfii: Really default to HW control

### DIFF
--- a/litedram/dfii.py
+++ b/litedram/dfii.py
@@ -53,7 +53,7 @@ class DFIInjector(Module, AutoCSR):
             CSRField("sel",     size=1, values=[
                 ("``0b0``", "Software (CPU) control."),
                 ("``0b1`",  "Hardware control (default)."),
-            ], reset=0b0), # Defaults to HW control.
+            ], reset=0b1), # Defaults to HW control.
             CSRField("cke",     size=1),
             CSRField("odt",     size=1),
             CSRField("reset_n", size=1),


### PR DESCRIPTION
Looks like there was a typo in commit
a595fe07f25ab9c8dac3e9707aae9cca9ede0019
"dfii: simplify control using CSRFields"

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>