### PR TITLE
[WIP] Add LPDDR4 PHY

### DIFF
--- a/litedram/phy/lpddr4phy.py
+++ b/litedram/phy/lpddr4phy.py
@@ -167,17 +167,15 @@ class LPDDR4PHY(Module, AutoCSR):
         self.comb += self.ck_clk.eq(bitpattern("-_-_-_-_" * 2))
 
         # Simple commands --------------------------------------------------------------------------
-        def delayed(sig, cycles):
-            for _ in range(cycles):
-                new = Signal.like(sig)
-                self.sync += new.eq(sig)
-                sig = new
-            return sig
+        def delayed(sig, cycles=1):
+            delay = TappedDelayLine(signal=sig, ntaps=cycles)
+            self.submodules += delay
+            return delay.output
 
         self.comb += [
-            self.ck_cke.eq(Cat(delayed(phase.cke, 1) for phase in self.dfi.phases)),
-            self.ck_odt.eq(Cat(delayed(phase.odt, 1) for phase in self.dfi.phases)),
-            self.ck_reset_n.eq(Cat(delayed(phase.reset_n, 1) for phase in self.dfi.phases)),
+            self.ck_cke.eq(Cat(delayed(phase.cke) for phase in self.dfi.phases)),
+            self.ck_odt.eq(Cat(delayed(phase.odt) for phase in self.dfi.phases)),
+            self.ck_reset_n.eq(Cat(delayed(phase.reset_n) for phase in self.dfi.phases)),
         ]
 
         # LPDDR4 Commands --------------------------------------------------------------------------

--- a/litedram/phy/lpddr4phy.py
+++ b/litedram/phy/lpddr4phy.py
@@ -1,0 +1,230 @@
+import re
+from functools import reduce
+from operator import or_
+
+import math
+
+from migen import *
+
+from litex.soc.interconnect.csr import *
+
+from litedram.common import *
+from litedram.phy.dfi import *
+
+
+class LPDDR4PHY(Module, AutoCSR):
+    def __init__(self, pads, *,
+                 sys_clk_freq, write_ser_latency, read_des_latency, phytype
+                 cmd_latency=1):
+        self.pads        = pads
+        self.memtype     = memtype     = "LPDDR4"
+        self.nranks      = nranks      = 1 if not hasattr(pads, "cs_n") else len(pads.cs_n)
+        self.databits    = databits    = len(pads.dq)
+        self.addressbits = addressbits = 16  # for activate row address
+        self.bankbits    = bankbits    = 3
+        self.nphases     = nphases     = 8
+        self.tck         = tck         = 1 / (nphases*sys_clk_freq)
+        assert databits % 8 == 0
+
+        # Parameters -------------------------------------------------------------------------------
+        iodelay_tap_average = {
+            200e6: 78e-12,
+            300e6: 52e-12,
+            400e6: 39e-12,  # Only valid for -3 and -2/2E speed grades
+        }
+        half_sys8x_taps = math.floor(tck/(4*iodelay_tap_average[iodelay_clk_freq]))
+
+        def get_cl_cw(memtype, tck):
+            # MT53E256M16D1, No DBI, Set A
+            f_to_cl_cwl = OrderedDict()
+            f_to_cl_cwl[ 532e6] = ( 6,  4)
+            f_to_cl_cwl[1066e6] = (10,  6)
+            f_to_cl_cwl[1600e6] = (14,  8)
+            f_to_cl_cwl[2132e6] = (20, 10)
+            f_to_cl_cwl[2666e6] = (24, 12)
+            f_to_cl_cwl[3200e6] = (28, 14)
+            f_to_cl_cwl[3732e6] = (32, 16)
+            f_to_cl_cwl[4266e6] = (36, 18)
+            for f, (cl, cwl) in f_to_cl_cwl.items():
+                if tck >= 2/f:
+                    return cl, cwl
+            raise ValueError
+
+        cl, cwl         = get_cl_cw(memtype, tck)
+        cl_sys_latency  = get_sys_latency(nphases, cl)
+        cwl_sys_latency = get_sys_latency(nphases, cwl)
+        rdphase         = get_sys_phase(nphases, cl_sys_latency,   cl + cmd_latency)
+        wrphase         = get_sys_phase(nphases, cwl_sys_latency, cwl + cmd_latency)
+
+        # Registers --------------------------------------------------------------------------------
+        self._rst             = CSRStorage()
+
+        self._dly_sel         = CSRStorage(databits//8)
+        self._half_sys8x_taps = CSRStorage(5, reset=half_sys8x_taps)
+
+        self._wlevel_en     = CSRStorage()
+        self._wlevel_strobe = CSR()
+
+        if with_odelay:
+            self._cdly_rst = CSR()
+            self._cdly_inc = CSR()
+
+        self._dly_sel = CSRStorage(databits//8)
+
+        self._rdly_dq_rst         = CSR()
+        self._rdly_dq_inc         = CSR()
+        self._rdly_dq_bitslip_rst = CSR()
+        self._rdly_dq_bitslip     = CSR()
+
+        if with_odelay:
+            self._wdly_dq_rst   = CSR()
+            self._wdly_dq_inc   = CSR()
+            self._wdly_dqs_rst  = CSR()
+            self._wdly_dqs_inc  = CSR()
+
+        self._wdly_dq_bitslip_rst = CSR()
+        self._wdly_dq_bitslip     = CSR()
+
+        self._rdphase = CSRStorage(int(math.log2(nphases)), reset=rdphase)
+        self._wrphase = CSRStorage(int(math.log2(nphases)), reset=wrphase)
+
+        # PHY settings -----------------------------------------------------------------------------
+        self.settings = PhySettings(
+            phytype       = phytype,
+            memtype       = memtype,
+            databits      = databits,
+            dfi_databits  = 2*databits,
+            nranks        = nranks,
+            nphases       = nphases,
+            rdphase       = self._rdphase.storage,
+            wrphase       = self._wrphase.storage,
+            cl            = cl,
+            cwl           = cwl,
+            read_latency  = cl_sys_latency + 6,
+            write_latency = cwl_sys_latency - 1,
+            cmd_latency   = cmd_latency,
+            cmd_delay     = cmd_delay,
+        )
+
+        # DFI Interface ----------------------------------------------------------------------------
+        self.dfi = dfi = Interface(addressbits, bankbits, nranks, 2*databits, nphases=8)
+
+        # # #
+
+        adapters = [DFIPhaseAdapter(phase) for phase in self.dfi.phases]
+        self.submodules += adapters
+
+
+class DFIPhaseAdapter(Module):
+    # We must perform mapping of DFI commands to the LPDDR4 commands set on CA bus
+    # LPDDR4 "small command" consists of 2 words CA[5:0] sent on the bus in 2 subsequent
+    # cycles. First cycle is marked with CS high, second with CS low.
+    # Then most "big commands" consists of 2 "small commands".
+    # If a command uses 1 "small command", then it shall go as cmd2 so that all command
+    # timings can be counted from the same moment (cycle of cmd2 CS low).
+    def __init__(self, dfi_phase):
+        # CS/CA values for 4 SDR cycles
+        self.cs = Signal(4)
+        self.ca = Array([Signal(6) for _ in range(4)])
+
+        # # #
+
+        self.submodules.cmd1 = Command(dfi_phase)
+        self.submodules.cmd2 = Command(dfi_phase)
+        self.comb += [
+            self.cs[:2].eq(self.cmd1.cs),
+            self.cs[2:].eq(self.cmd2.cs),
+            self.ca[0].eq(self.cmd1.ca[0])
+            self.ca[1].eq(self.cmd1.ca[1])
+            self.ca[2].eq(self.cmd2.ca[0])
+            self.ca[3].eq(self.cmd2.ca[1])
+        ]
+
+        dfi_cmd = Signal(3)
+        self.comb += dfi_cmd.eq(Cat(~dfi_phase.we_n, ~dfi_phase.ras_n, ~dfi_phase.cas_n)),
+        _cmd = {  # cas, ras, we
+            "NOP": 0b000,
+            "ACT": 0b010,
+            "RD":  0b100,
+            "WR":  0b101,
+            "PRE": 0b011,
+            "REF": 0b110,
+            "ZQC": 0b001,
+            "MRS": 0b111,
+        }
+
+        def cmds(cmd1, cmd2):
+            return self.cmd1.set(cmd1) + self.cmd2.set(cmd2)
+
+        self.comb += Case(dfi_cmd, {
+            _cmd["ACT"]: cmds("ACTIVATE-1", "ACTIVATE-2"),
+            _cmd["RD"]:  cmds("READ-1",     "CAS-2"),
+            _cmd["WR"]:  cmds("WRITE-1",    "CAS-2"),
+            _cmd["PRE"]: cmds("DESELECT",   "PRECHARGE"),
+            _cmd["REF"]: cmds("DESELECT",   "REFRESH"),
+            # TODO: ZQC init/short/long? start/latch?
+            # _cmd["ZQC"]: [
+            #     *cmds("DESELECT", "MPC"),
+            #     self.cmd2.mpc.eq(0b1001111),
+            # ],
+            _cmd["MRS"]: cmds("MRW-1",      "MRW-2"),
+            "default":   cmds("DESELECT",   "DESELECT"),
+        })
+
+class Command(Module):
+    # String description of 1st and 2nd edge of each command, later parsed to construct
+    # the value. CS is assumed to be H for 1st edge and L for 2nd edge.
+    TRUTH_TABLE = {
+        "MRW-1":        ["L H H L L OP7",       "MA0 MA1 MA2 MA3 MA4 MA5"],
+        "MRW-2":        ["L H H L H OP6",       "OP0 OP1 OP2 OP3 OP4 OP5"],
+        "MRR-1":        ["L H H H L V",         "MA0 MA1 MA2 MA3 MA4 MA5"],
+        "REFRESH":      ["L L L H L AB",        "BA0 BA1 BA2 V V V"],
+        "ACTIVATE-1":   ["H L R12 R13 R14 R15", "BA0 BA1 BA2 R16 R10 R11"],
+        "ACTIVATE-2":   ["H H R6 R7 R8 R9",     "R0 R1 R2 R3 R4 R5"],
+        "WRITE-1":      ["L H L L BL",          "BA0 BA1 BA2 V C9 AP"],
+        "MASK WRITE-1": ["L L H H L BL",        "BA0 BA1 BA2 V C9 AP"],
+        "READ-1":       ["L H L L L BL",        "BA0 BA1 BA2 V C9 AP"],
+        "CAS-2":        ["L H L L H C8",        "C2 C3 C4 C5 C6 C7"],
+        "PRECHARGE":    ["L L L L H AB",        "BA0 BA1 BA2 V V V"],
+        "MPC":          ["L L L L L OP6",       "OP0 OP1 OP2 OP3 OP4 OP5"],
+        "DESELECT":     ["X X X X X X",         "X X X X X X"],
+    }
+
+    def __init__(self, dfi_phase):
+        self.cs = Signal(2)
+        self.ca = Array([Signal(6), Signal(6)])  # CS high, CS low
+        self.mpc = Signal(7)  # special OP values for multipurpose command
+        self.dfi = dfi_phase
+
+    def set(self, cmd):
+        desc = self.TRUTH_TABLE[cmd]
+        ops = []
+        for i, description in enumerate(self.TRUTH_TABLE[cmd]):
+            for j, bit in enumerate(description.split()):
+                ops.append(self.ca[i][j].eq(self.parse_bit(bit, is_mpc=cmd == "MPC")))
+        if cmd != "DESELECT":
+            ops.append(self.cs[0].eq(1))
+        return ops
+
+    def parse_bit(self, bit, is_mpc=False):
+        rules = {
+            "H":       lambda: 1,  # high
+            "L":       lambda: 0,  # low
+            "V":       lambda: 0,  # defined logic
+            "X":       lambda: 0,  # don't care
+            "BL":      lambda: 0,  # on-the-fly burst length, not using
+            "AP":      lambda: self.dfi.address[10],  # auto precharge
+            "AB":      lambda: self.dfi.address[10],  # all banks
+            "BA(\d+)": lambda i: self.dfi.bank[i],
+            "R(\d+)":  lambda i: self.dfi.address[i],  # row
+            "C(\d+)":  lambda i: self.dfi.address[i],  # column
+            "MA(\d+)": lambda i: self.dfi.address[8+i],  # mode register address
+            # mode register value, or op code for MPC
+            "OP(\d+)": lambda i: self.mpc[i] if is_mpc else self.dfi.address[i],
+        }
+        for pattern, value in rules.items():
+            m = re.match(pattern, bit)
+            if m:
+                args = [int(g) for g in m.groups()]
+                return value(*args)
+        raise ValueError(bit)

--- a/litedram/phy/lpddr4phy.py
+++ b/litedram/phy/lpddr4phy.py
@@ -245,20 +245,22 @@ class DFIPhaseAdapter(Module):
         def cmds(cmd1, cmd2, valid=1):
             return self.cmd1.set(cmd1) + self.cmd2.set(cmd2) + [self.valid.eq(valid)]
 
-        self.comb += Case(dfi_cmd, {
-            _cmd["ACT"]: cmds("ACTIVATE-1", "ACTIVATE-2"),
-            _cmd["RD"]:  cmds("READ-1",     "CAS-2"),
-            _cmd["WR"]:  cmds("WRITE-1",    "CAS-2"),  # TODO: masked write
-            _cmd["PRE"]: cmds("DESELECT",   "PRECHARGE"),
-            _cmd["REF"]: cmds("DESELECT",   "REFRESH"),
-            # TODO: ZQC init/short/long? start/latch?
-            # _cmd["ZQC"]: [
-            #     *cmds("DESELECT", "MPC"),
-            #     self.cmd2.mpc.eq(0b1001111),
-            # ],
-            _cmd["MRS"]: cmds("MRW-1",      "MRW-2"),
-            "default":   cmds("DESELECT",   "DESELECT", valid=0),
-        })
+        self.comb += If(dfi_phase.cs_n == 0,  # require dfi.cs_n
+            Case(dfi_cmd, {
+                _cmd["ACT"]: cmds("ACTIVATE-1", "ACTIVATE-2"),
+                _cmd["RD"]:  cmds("READ-1",     "CAS-2"),
+                _cmd["WR"]:  cmds("WRITE-1",    "CAS-2"),  # TODO: masked write
+                _cmd["PRE"]: cmds("DESELECT",   "PRECHARGE"),
+                _cmd["REF"]: cmds("DESELECT",   "REFRESH"),
+                # TODO: ZQC init/short/long? start/latch?
+                # _cmd["ZQC"]: [
+                #     *cmds("DESELECT", "MPC"),
+                #     self.cmd2.mpc.eq(0b1001111),
+                # ],
+                _cmd["MRS"]: cmds("MRW-1",      "MRW-2"),
+                "default":   cmds("DESELECT",   "DESELECT", valid=0),
+            })
+        )
 
 class Command(Module):
     # String description of 1st and 2nd edge of each command, later parsed to construct

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -1,5 +1,7 @@
+import re
 import unittest
 from collections import defaultdict
+from typing import Mapping, Sequence
 
 from migen import *
 
@@ -13,6 +15,8 @@ def chunks(lst, n):
         yield lst[i:i + n]
 
 class TestLPDDR4(unittest.TestCase):
+    CMD_LATENCY = 2
+
     class PadsHistory(defaultdict):
         def __init__(self):
             super().__init__(str)
@@ -24,11 +28,12 @@ class TestLPDDR4(unittest.TestCase):
             lines = []
             for k in keys:
                 hist = ' '.join(chunk for chunk in chunks(self[k], 8))
-                line = '{:{n}} {}'.format(k + ':', hist, n=key_strw+1)
+                line = '{:{n}} {}'.format(k + ':' if k != 'E' else '', hist, n=key_strw+1)
                 lines.append(line)
             return '\n'.join(lines)
 
-    def pads_checker(self, pads, signals, fail_fast=False):
+    def pads_checker(self, pads, signals: Mapping[str, str], fail_fast=False):
+        # signals: {sig: values}, values: a string of '0'/'1'/'x'
         lengths = [len(vals) for vals in signals.values()]
         n = lengths[0]
         assert all(l == n for l in lengths)
@@ -37,7 +42,11 @@ class TestLPDDR4(unittest.TestCase):
         history = self.PadsHistory()
         for i in range(n):
             for sig, vals in signals.items():
-                pad = getattr(pads, sig)
+                m = re.match(r'(\S+)(\d+)', sig)
+                if m:
+                    pad = getattr(pads, m.group(1))[int(m.group(2))]
+                else:
+                    pad = getattr(pads, sig)
                 val = vals[i]
                 history[sig] += str((yield pad))
                 if val != 'x':
@@ -56,15 +65,26 @@ class TestLPDDR4(unittest.TestCase):
     def dfi_reset_value(self, sig):
         return 1 if sig.endswith('_n') else 0
 
-    def dfi_generator(self, dfi, sequence):
+    def dfi_reset_values(self):
+        return {sig: self.dfi_reset_value(sig) for sig, _, _ in dfi.phase_description(1, 1, 1, 1)}
+
+    DFIPhaseValues = Mapping[str, int]
+    DFIPhase = int
+
+    def dfi_generator(self, dfi, sequence: Sequence[Mapping[DFIPhase, DFIPhaseValues]]):
+        # sequence: [{phase: {sig: value}}]
         for per_phase in sequence:
+            # reset in case of any previous changes
+            for phase in dfi.phases:
+                for sig, val in self.dfi_reset_values().items():
+                    yield getattr(phase, sig).eq(val)
+            # set values
             for phase, values in per_phase.items():
                 for sig, val in values.items():
+                    # print(f'dfi.p{phase}.{sig} = {val}')
                     yield getattr(dfi.phases[phase], sig).eq(val)
+            # print()
             yield
-            for phase, values in per_phase.items():
-                for sig, val in values.items():
-                    yield getattr(dfi.phases[phase], sig).eq(self.dfi_reset_value(sig))
 
     def run_simulation(self, dut, generators, **kwargs):
         clocks = {  # sys and sys8x phase aligned
@@ -74,58 +94,99 @@ class TestLPDDR4(unittest.TestCase):
         }
         run_simulation(dut, generators, clocks, **kwargs)
 
-    def test_cs_phase_0(self):
-        dfi_reset = {sig: self.dfi_reset_value(sig) for sig, _, _ in dfi.phase_description(1, 1, 1, 1)}
-        dfi_seq = [
-            {p: dict(dfi_reset) for p in range(8)},
-            {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},  # p0: READ
-        ]
-
-        latency = 2
-        pads_signals = {
-            'cs': '00000000' * latency + '00000000' + '10100000' + '00000000',
-        }
-
+    def run_test(self, dfi_sequence, pad_signals):
         dut = SimulationPHY()
         generators = {
-            "sys":   [self.dfi_generator(dut.dfi, dfi_seq)],
-            "sys8x": [self.pads_checker(dut.pads, pads_signals)],
+            "sys":   [self.dfi_generator(dut.dfi, dfi_sequence)],
+            "sys8x": [self.pads_checker(dut.pads, pad_signals)],
         }
-        self.run_simulation(dut, generators, vcd_name='sim.vcd')
+        self.run_simulation(dut, generators)
+
+    def test_cs_phase_0(self):
+        latency = '00000000' * self.CMD_LATENCY
+        self.run_test(
+            dfi_sequence = [
+                {p: dict(self.dfi_reset_values()) for p in range(8)},
+                {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},  # p0: READ
+            ],
+            pad_signals = {
+                'cs': latency + '00000000' + '10100000',
+            }
+        )
 
     def test_cs_multiple_phases(self):
-        dfi_reset = {sig: self.dfi_reset_value(sig) for sig, _, _ in dfi.phase_description(1, 1, 1, 1)}
-        dfi_seq = [
-            {p: dict(dfi_reset) for p in range(8)},
-            {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
-            {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
-            {
-                1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
-                4: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should be ignored
-            },
-            {
-                1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
-                5: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should NOT be ignored
-            },
-            {6: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)}, # crosses cycle boundaries
-        ]
+        latency = '00000000' * self.CMD_LATENCY
+        self.run_test(
+            dfi_sequence = [
+                {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
+                {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
+                {
+                    1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
+                    4: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should be ignored
+                },
+                {
+                    1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
+                    5: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should NOT be ignored
+                },
+                {6: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)}, # crosses cycle boundaries
+                {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},  # should be ignored
+            ],
+            pad_signals = {
+                'cs': latency + ''.join([
+                    '10100000',  # p0
+                    '00010100',  # p3
+                    '01010000',  # p1, p4 ignored
+                    '01010101',  # p1, p5
+                    '00000010',  # p6 (cyc 0)
+                    '10000000',  # p6 (cyc 1), p0 ignored
+                ])
+            }
+        )
 
-        latency = 2
-        pads_signals = {
-            'cs': '00000000' * latency + ''.join([
-                '00000000',
-                '10100000',  # p0
-                '00010100',  # p3
-                '01010000',  # p1
-                '01010101',  # p1, p5
-                '00000010',  # p6 (cyc 0)
-                '10000000',  # p6 (cyc 1)
-            ])
-        }
+    def test_ca_sequencing(self):
+        latency = '00000000' * self.CMD_LATENCY
+        read = dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)
+        self.run_test(
+            dfi_sequence = [
+                {0: read, 3: read},  # p4 should be ignored
+                {0: read, 4: read},
+                {6: read},
+                {0: read}, # ignored
+            ],
+            pad_signals = {
+                'cs':  latency + '10100000' + '10101010' + '00000010' + '10000000',
+                'ca0': latency + '00000000' + '00000000' + '00000000' + '00000000',
+                'ca1': latency + '10100000' + '10101010' + '00000010' + '10000000',
+                'ca2': latency + '00000000' + '00000000' + '00000000' + '00000000',
+                'ca3': latency + '0x000000' + '0x000x00' + '0000000x' + '00000000',
+                'ca4': latency + '00100000' + '00100010' + '00000000' + '10000000',
+                'ca5': latency + '00000000' + '00000000' + '00000000' + '00000000',
+            }
+        )
 
-        dut = SimulationPHY()
-        generators = {
-            "sys":   [self.dfi_generator(dut.dfi, dfi_seq)],
-            "sys8x": [self.pads_checker(dut.pads, pads_signals)],
-        }
-        self.run_simulation(dut, generators, vcd_name='sim.vcd')
+    def test_ca_addressing(self):
+        latency = '00000000' * self.CMD_LATENCY
+        read       = dict(cs_n=0, cas_n=0, ras_n=1, we_n=1, bank=0b101, address=0b1100110011)  # actually invalid because CA[1:0] should always be 0
+        write_ap   = dict(cs_n=0, cas_n=0, ras_n=1, we_n=0, bank=0b111, address=0b10000000000)
+        activate   = dict(cs_n=0, cas_n=1, ras_n=0, we_n=1, bank=0b010, address=0b11110000111100001)
+        refresh_ab = dict(cs_n=0, cas_n=0, ras_n=0, we_n=1, bank=0b100, address=0b10000000000)
+        precharge  = dict(cs_n=0, cas_n=1, ras_n=0, we_n=0, bank=0b011, address=0)
+        mrw        = dict(cs_n=0, cas_n=0, ras_n=0, we_n=0, bank=0,     address=(0b110011 << 8) | 0b10101010)  # 6-bit address | 8-bit op code
+        self.run_test(
+            dfi_sequence = [
+                {0: read, 4: write_ap},
+                {0: activate, 4: refresh_ab},
+                {0: precharge, 4: mrw},
+            ],
+            pad_signals = {
+                # note that refresh and precharge have a single command so these go as cmd2
+                #                              rd     wr       act    ref      pre    mrw
+                'cs':  latency + '1010'+'1010' + '1010'+'0010' + '0010'+'1010',
+                'ca0': latency + '0100'+'0100' + '1011'+'0000' + '0001'+'0100',
+                'ca1': latency + '1010'+'0110' + '0110'+'0000' + '0001'+'1111',
+                'ca2': latency + '0101'+'1100' + '0010'+'0001' + '0000'+'1010',
+                'ca3': latency + '0x01'+'0x00' + '1110'+'001x' + '000x'+'0001',
+                'ca4': latency + '0110'+'0010' + '1010'+'000x' + '001x'+'0110',
+                'ca5': latency + '0010'+'0100' + '1001'+'001x' + '000x'+'1101',
+            }
+        )

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -97,29 +97,29 @@ class TestLPDDR4(unittest.TestCase):
         dfi_reset = {sig: self.dfi_reset_value(sig) for sig, _, _ in dfi.phase_description(1, 1, 1, 1)}
         dfi_seq = [
             {p: dict(dfi_reset) for p in range(8)},
-            {1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
+            {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
             {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
-            # {
-            #     1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
-            #     4: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should be ignored
-            # },
-            # {
-            #     1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
-            #     5: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should NOT be ignored
-            # },
-            # {6: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)}, # crosses cycle boundaries
+            {
+                1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
+                4: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should be ignored
+            },
+            {
+                1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
+                5: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should NOT be ignored
+            },
+            {6: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)}, # crosses cycle boundaries
         ]
 
         latency = 2
         pads_signals = {
             'cs': '00000000' * latency + ''.join([
                 '00000000',
-                '01010000',  # p1
+                '10100000',  # p0
                 '00010100',  # p3
-                # '01010000',  # p1
-                # '01010101',  # p1, p5
-                # '00000010',  # p6 (cyc 0)
-                # '10000000',  # p6 (cyc 1)
+                '01010000',  # p1
+                '01010101',  # p1, p5
+                '00000010',  # p6 (cyc 0)
+                '10000000',  # p6 (cyc 1)
             ])
         }
 

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -1,0 +1,131 @@
+import unittest
+from collections import defaultdict
+
+from migen import *
+
+from litedram.phy import dfi
+from litedram.phy.lpddr4phy import SimulationPHY
+
+from litex.gen.sim import run_simulation
+
+def chunks(lst, n):
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+class TestLPDDR4(unittest.TestCase):
+    class PadsHistory(defaultdict):
+        def __init__(self):
+            super().__init__(str)
+
+        def format(self):
+            keys = list(self.keys())
+            key_strw = max(len(k) for k in keys)
+            keys = sorted(keys, key=lambda k: 2 if k == 'E' else 1)
+            lines = []
+            for k in keys:
+                hist = ' '.join(chunk for chunk in chunks(self[k], 8))
+                line = '{:{n}} {}'.format(k + ':', hist, n=key_strw+1)
+                lines.append(line)
+            return '\n'.join(lines)
+
+    def pads_checker(self, pads, signals, fail_fast=False):
+        lengths = [len(vals) for vals in signals.values()]
+        n = lengths[0]
+        assert all(l == n for l in lengths)
+
+        errors = []
+        history = self.PadsHistory()
+        for i in range(n):
+            for sig, vals in signals.items():
+                pad = getattr(pads, sig)
+                val = vals[i]
+                history[sig] += str((yield pad))
+                if val != 'x':
+                    msg = f'Cycle {i} Signal {sig}: {(yield pad)} vs {vals[i]}'
+                    errors.append([i, (yield pad), int(vals[i]), msg])
+                    if fail_fast:
+                        msg += '\nHistory:\n{}'.format(history.format())
+                        self.assertEqual((yield pad), int(vals[i]), msg=msg)
+            yield
+
+        for i, pad_val, ref_val, msg in errors:
+            history['E'] = ''.join(['^' if j == i else ' ' for j in range(n)])
+            msg += '\nHistory:\n{}'.format(history.format())
+            self.assertEqual(pad_val, ref_val, msg=msg)
+
+    def dfi_reset_value(self, sig):
+        return 1 if sig.endswith('_n') else 0
+
+    def dfi_generator(self, dfi, sequence):
+        for per_phase in sequence:
+            for phase, values in per_phase.items():
+                for sig, val in values.items():
+                    yield getattr(dfi.phases[phase], sig).eq(val)
+            yield
+            for phase, values in per_phase.items():
+                for sig, val in values.items():
+                    yield getattr(dfi.phases[phase], sig).eq(self.dfi_reset_value(sig))
+
+    def run_simulation(self, dut, generators, **kwargs):
+        clocks = {  # sys and sys8x phase aligned
+            "sys":      (32, 16),
+            "sys8x":    ( 4,  2),
+            "sys8x_90": ( 4,  1),
+        }
+        run_simulation(dut, generators, clocks, **kwargs)
+
+    def test_cs_phase_0(self):
+        dfi_reset = {sig: self.dfi_reset_value(sig) for sig, _, _ in dfi.phase_description(1, 1, 1, 1)}
+        dfi_seq = [
+            {p: dict(dfi_reset) for p in range(8)},
+            {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},  # p0: READ
+        ]
+
+        latency = 2
+        pads_signals = {
+            'cs': '00000000' * latency + '00000000' + '10100000' + '00000000',
+        }
+
+        dut = SimulationPHY()
+        generators = {
+            "sys":   [self.dfi_generator(dut.dfi, dfi_seq)],
+            "sys8x": [self.pads_checker(dut.pads, pads_signals)],
+        }
+        self.run_simulation(dut, generators, vcd_name='sim.vcd')
+
+    def test_cs_multiple_phases(self):
+        dfi_reset = {sig: self.dfi_reset_value(sig) for sig, _, _ in dfi.phase_description(1, 1, 1, 1)}
+        dfi_seq = [
+            {p: dict(dfi_reset) for p in range(8)},
+            {1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
+            {3: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},
+            # {
+            #     1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
+            #     4: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should be ignored
+            # },
+            # {
+            #     1: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),
+            #     5: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1),  # should NOT be ignored
+            # },
+            # {6: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)}, # crosses cycle boundaries
+        ]
+
+        latency = 2
+        pads_signals = {
+            'cs': '00000000' * latency + ''.join([
+                '00000000',
+                '01010000',  # p1
+                '00010100',  # p3
+                # '01010000',  # p1
+                # '01010101',  # p1, p5
+                # '00000010',  # p6 (cyc 0)
+                # '10000000',  # p6 (cyc 1)
+            ])
+        }
+
+        dut = SimulationPHY()
+        generators = {
+            "sys":   [self.dfi_generator(dut.dfi, dfi_seq)],
+            "sys8x": [self.pads_checker(dut.pads, pads_signals)],
+        }
+        self.run_simulation(dut, generators, vcd_name='sim.vcd')

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -238,5 +238,5 @@ class TestLPDDR4(unittest.TestCase):
                 'odt':     latency + '10100100',
                 'reset_n': latency + '11001110',
             }},
-            vcd_name='sim.vcd',
+            # vcd_name='sim.vcd',
         )

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -144,6 +144,7 @@ class TestLPDDR4(unittest.TestCase):
                 },
                 {6: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)}, # crosses cycle boundaries
                 {0: dict(cs_n=0, cas_n=0, ras_n=1, we_n=1)},  # should be ignored
+                {2: dict(cs_n=1, cas_n=0, ras_n=1, we_n=1)},  # ignored due to cs_n=1
             ],
             pad_checkers = {"sys8x": {
                 'cs': latency + ''.join([
@@ -153,6 +154,7 @@ class TestLPDDR4(unittest.TestCase):
                     '01010101',  # p1, p5
                     '00000010',  # p6 (cyc 0)
                     '10000000',  # p6 (cyc 1), p0 ignored
+                    '00000000',  # p2 ignored
                 ])
             }},
         )


### PR DESCRIPTION
This would add support for LPDDR4 PHYs in LiteDRAM. It is still WIP but will be useful to track progress.

In the current implementation there is LPDDR4PHY which will be a base class for a PHY for series 7 which will yet have to be added. Base PHY's job is to convert DFI commands to LPDDR4 commands format and provide signals that are ready to be serialized using hardware blocks in a concrete PHY. 

LPDDR4 sends commands on an CA[5:0] SDR  lines. DRAM commands consist of 1 or 2 "subcommands" (e.g. ACT = ACT-1 + ACT-2) and each subcommand is sent over 2 clock cycles. Currently the translation has been implemented and there are tests in Migen simulator that verify serialization of CA. Due to 16n prefetch of LPDDR4 the PHY uses 8 DFI phases to avoid complications if the write/read bursts would have to be sent over more than 1 cycle of DRAM controller clock.