### PR TITLE
modules: add MT48LC32M8 SDR module

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -461,6 +461,15 @@ class MT48LC16M16(SDRModule):
     technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 15))
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=20, tRCD=20, tWR=15, tRFC=(None, 66), tFAW=None, tRAS=44)}
 
+class MT48LC32M8(SDRModule):
+    # geometry
+    nbanks = 4
+    nrows  = 8192
+    ncols  = 1024
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 15))
+    speedgrade_timings = {"default": _SpeedgradeTimings(tRP=20, tRCD=20, tWR=15, tRFC=(None, 66), tFAW=None, tRAS=44)}
+
 class AS4C16M16(SDRModule):
     # geometry
     nbanks = 4


### PR DESCRIPTION
The 8 meg x 8 x 4 bank variant of the existing MT48 series modules.

The chip is used in the SDRAM and HDMI add-on shields for the Alchitry MojoV3 hobbyist platform: https://alchitry.com/products/mojo-v3