### PR TITLE
Add customizable standalone user port data widths

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -504,7 +504,8 @@ class LiteDRAMCore(SoCCore):
         for name, port in core_config["user_ports"].items():
             # Native -------------------------------------------------------------------------------
             if port["type"] == "native":
-                user_port = self.sdram.crossbar.get_port()
+                user_port = self.sdram.crossbar.get_port(
+                    data_width=port.get("data_width", None))
                 platform.add_extension(get_native_user_port_ios(name,
                     user_port.address_width,
                     user_port.data_width))
@@ -529,7 +530,8 @@ class LiteDRAMCore(SoCCore):
                 ]
             # Wishbone -----------------------------------------------------------------------------
             elif port["type"] == "wishbone":
-                user_port = self.sdram.crossbar.get_port()
+                user_port = self.sdram.crossbar.get_port(
+                    data_width=port.get("data_width", None))
                 wb_port = wishbone.Interface(
                     user_port.data_width,
                     user_port.address_width)
@@ -552,7 +554,8 @@ class LiteDRAMCore(SoCCore):
                 ]
             # AXI ----------------------------------------------------------------------------------
             elif port["type"] == "axi":
-                user_port = self.sdram.crossbar.get_port()
+                user_port = self.sdram.crossbar.get_port(
+                    data_width=port.get("data_width", None))
                 axi_port  = LiteDRAMAXIPort(
                     user_port.data_width,
                     user_port.address_width + log2_int(user_port.data_width//8),


### PR DESCRIPTION
Adds `data_width` parameter in the yml configuration for user ports of types native, AXI, and Wishbone. The parameter is optional, defaulting to previous behavior.

Generation of data width converters is handled by existing functionality in crossbar.py

```
    "user_ports": {
        "native" : {
            "type": "native",
            "data_width": 32,
        },
        "axi" : {
            "type": "axi",
            "id_width": 3,
            "data_width": 32,
        },
        "wishbone" : {
            "type": "wishbone",
            "data_width": 32,
        }
    },
```