### PR TITLE
Allow to pass all module timings in the format (ck, ns)

### DIFF
--- a/litedram/phy/model.py
+++ b/litedram/phy/model.py
@@ -212,10 +212,10 @@ class DFITimingsChecker(Module):
 
             if val is None:
                 val = 0
-            elif key in CK_NS:
-                val = self.ck_ns_to_ps(val, tck)
-            else:
+            elif key == "tCK":
                 val = self.ns_to_ps(val)
+            else:
+                val = self.ck_ns_to_ps(val, tck)
 
             new_timings[key] = val
 


### PR DESCRIPTION
This is a part of splitting https://github.com/enjoy-digital/litedram/pull/224 into smaller PRs.

This PR makes it possible to pass all timings as `(ck, ns)` tuples (here `ns` can be `None`) or just `ns` float. 