### PR TITLE
init: make the write leveling MR bit configurable

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -220,7 +220,7 @@ def get_ddr3_phy_init_sequence(phy_settings, timing_settings):
         ("ZQ Calibration", 0x0400, 0, "DFII_COMMAND_WE|DFII_COMMAND_CS", 200),
     ]
 
-    return init_sequence, mr1
+    return init_sequence, {1: mr1}
 
 # DDR4 ---------------------------------------------------------------------------------------------
 
@@ -443,7 +443,7 @@ def get_ddr4_phy_init_sequence(phy_settings, timing_settings):
         ("ZQ Calibration", 0x0400, 0, "DFII_COMMAND_WE|DFII_COMMAND_CS", 200),
     ]
 
-    return init_sequence, mr1
+    return init_sequence, {1: mr1}
 
 # Init Sequence ------------------------------------------------------------------------------------
 
@@ -568,11 +568,13 @@ const unsigned long sdram_dfii_pix_rddata_addr[SDRAM_PHY_PHASES] = {{
 """.format(sdram_dfii_pix_rddata_addr=",\n\t".join(sdram_dfii_pix_rddata_addr))
     r += "\n"
 
-    init_sequence, mr1 = get_sdram_phy_init_sequence(phy_settings, timing_settings)
+    init_sequence, mr = get_sdram_phy_init_sequence(phy_settings, timing_settings)
 
     if phy_settings.memtype in ["DDR3", "DDR4"]:
-        # The value of MR1 needs to be modified during write leveling
-        r += "#define DDRX_MR1 {}\n\n".format(mr1)
+        # The value of MR1[7] needs to be modified during write leveling
+        r += "#define DDRX_MR_WRLVL_ADDRESS {}\n\n".format(1)
+        r += "#define DDRX_MR_WRLVL_RESET {}\n\n".format(mr[1])
+        r += "#define DDRX_MR_WRLVL_BIT {}\n\n".format(7)
 
     r += "static void init_sequence(void)\n{\n"
     for comment, a, ba, cmd, delay in init_sequence:

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -627,10 +627,10 @@ def get_sdram_phy_py_header(phy_settings, timing_settings):
     r += "dfii_command_rddata = 0x20\n"
     r += "\n"
 
-    init_sequence, mr1 = get_sdram_phy_init_sequence(phy_settings, timing_settings)
+    init_sequence, mr = get_sdram_phy_init_sequence(phy_settings, timing_settings)
 
-    if mr1 is not None:
-        r += "ddrx_mr1 = 0x{:x}\n".format(mr1)
+    if mr is not None and 1 in mr:
+        r += "ddrx_mr1 = 0x{:x}\n".format(mr[1])
         r += "\n"
 
     r += "init_sequence = [\n"

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -572,8 +572,8 @@ const unsigned long sdram_dfii_pix_rddata_addr[SDRAM_PHY_PHASES] = {{
 
     if phy_settings.memtype in ["DDR3", "DDR4"]:
         # The value of MR1[7] needs to be modified during write leveling
-        r += "#define DDRX_MR_WRLVL_ADDRESS {}\n\n".format(1)
-        r += "#define DDRX_MR_WRLVL_RESET {}\n\n".format(mr[1])
+        r += "#define DDRX_MR_WRLVL_ADDRESS {}\n".format(1)
+        r += "#define DDRX_MR_WRLVL_RESET {}\n".format(mr[1])
         r += "#define DDRX_MR_WRLVL_BIT {}\n\n".format(7)
 
     r += "static void init_sequence(void)\n{\n"

--- a/test/reference/ddr3_init.h
+++ b/test/reference/ddr3_init.h
@@ -70,7 +70,9 @@ const unsigned long sdram_dfii_pix_rddata_addr[SDRAM_PHY_PHASES] = {
 	CSR_SDRAM_DFII_PI3_RDDATA_ADDR
 };
 
-#define DDRX_MR1 6
+#define DDRX_MR_WRLVL_ADDRESS 1
+#define DDRX_MR_WRLVL_RESET 6
+#define DDRX_MR_WRLVL_BIT 7
 
 static void init_sequence(void)
 {

--- a/test/reference/ddr4_init.h
+++ b/test/reference/ddr4_init.h
@@ -71,7 +71,9 @@ const unsigned long sdram_dfii_pix_rddata_addr[SDRAM_PHY_PHASES] = {
 	CSR_SDRAM_DFII_PI3_RDDATA_ADDR
 };
 
-#define DDRX_MR1 769
+#define DDRX_MR_WRLVL_ADDRESS 1
+#define DDRX_MR_WRLVL_RESET 769
+#define DDRX_MR_WRLVL_BIT 7
 
 static void init_sequence(void)
 {


### PR DESCRIPTION
This is a part of splitting https://github.com/enjoy-digital/litedram/pull/224 into smaller PRs.
Requires corresponding PR in litex: https://github.com/enjoy-digital/litex/pull/791.

In LPDDR4 the write leveling mode is configured with MR2[7] instead of MR1[7]. This PR changes the way `get_sdram_phy_init_sequence` returns mode register values. Now it should return a dictionary `{mr_num: mr_value, ...}`. Instead of generating `DDRX_MR1` define we now have 3 `DDRX_MR_WRLVL_*` defines that specify the mode register changes required to enter/leave write leveling mode.

Note that `DDRX_MR_WRLVL_BIT` is the bit that gets flipped (with xor), so `DDRX_MR_WRLVL_RESET` is the state when write leveling is disabled and software just filps given bit when entering write leveling mode and writes the original `DDRX_MR_WRLVL_RESET` value when leaving.