### PR TITLE
Add module name CLI option

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -682,6 +682,7 @@ def main():
     parser.set_defaults(output_dir="build")
     parser.add_argument("config", help="YAML config file")
     parser.add_argument("--sim", action='store_true', help="Integrate SDRAMPHYModel in core for simulation")
+    parser.add_argument("--module-name", default="litedram_core", help="Set Verilog module name")
     args = parser.parse_args()
     core_config = yaml.load(open(args.config).read(), Loader=yaml.Loader)
 
@@ -715,7 +716,7 @@ def main():
 
     soc     = LiteDRAMCore(platform, core_config, integrated_rom_size=0x8000)
     builder = Builder(soc, **builder_arguments)
-    builder.build(build_name="litedram_core", regular_comb=False)
+    builder.build(build_name=args.module_name, regular_comb=False)
 
     if soc.cpu_type is not None:
         init_filename = "mem.init"


### PR DESCRIPTION
Adds ability to specify a custom build name (Verilog module name) on the CLI. When using litedram in standalone mode and generating multiple DRAM interfaces, each generated litedram module needs to have a unique name otherwise they will conflict in the Verilog namespace.