### PR TITLE
core: use wider DFI address/bank if PHY requires it

### DIFF
--- a/litedram/core/__init__.py
+++ b/litedram/core/__init__.py
@@ -17,8 +17,8 @@ from litedram.core.crossbar import LiteDRAMCrossbar
 class LiteDRAMCore(Module, AutoCSR):
     def __init__(self, phy, geom_settings, timing_settings, clk_freq, **kwargs):
         self.submodules.dfii = DFIInjector(
-            addressbits = geom_settings.addressbits,
-            bankbits    = geom_settings.bankbits,
+            addressbits = max(geom_settings.addressbits, getattr(phy, "addressbits", 0)),
+            bankbits    = max(geom_settings.bankbits, getattr(phy, "bankbits", 0)),
             nranks      = phy.settings.nranks,
             databits    = phy.settings.dfi_databits,
             nphases     = phy.settings.nphases)


### PR DESCRIPTION
This is a part of changes related to https://github.com/enjoy-digital/litedram/pull/224.

LiteDRAM normally encodes Mode Register Set command using `DFIInjector`, passing mode register address as `dfi.baddress` and value as `dfi.address`. In LPDDR4 there are more Mode Registers than in other DRAMs and we need 6 bits to store the address. So when a module has only 8 banks it is not possible to issue MRS via DFIInjector this way. 

Initially I tried encoding both the address and the value in `dfi.address`,  but then I had to modify the implementation of `sdram_write_leveling_on`/`sdram_write_leveling_off` in `sdram.c` for LPDDR4 specifically. To avoid it, now LPDDR4 PHY sets bankbits to 6: https://github.com/enjoy-digital/litedram/pull/224/commits/dfd7816567bf3b6c3f6b3c8f97cc22d512c99c47#diff-d84b2ae2991ef50d505ebd78f702957557f81bdfcd77f1aafbdd7bc66cc86ae5L97, and with this PR `DFIInjector` would use the higher value of `geom_settings.bankbits` and `phy.bankbits`, making sure that there are enough bits for Mode Register address.