### PR TITLE
core/refresher: use A10=1 for an all-banks REF

### DIFF
--- a/litedram/core/refresher.py
+++ b/litedram/core/refresher.py
@@ -50,7 +50,7 @@ class RefreshExecuter(Module):
                 ]),
                 # Auto Refresh after tRP
                 (trp, [
-                    cmd.a.eq(  0),
+                    cmd.a.eq(  2**10),  # all banks in LPDDR4/DDR5, ignored in other memories
                     cmd.ba.eq( 0),
                     cmd.cas.eq(1),
                     cmd.ras.eq(1),


### PR DESCRIPTION
Related to https://github.com/enjoy-digital/litedram/pull/224.

In LPDDR2+ and DDR5 the refresh command has two variants: per-bank and all-banks. This PR changes Refresher to always issue the all-banks variant. This should not affect other memory types, as they always refresh all banks, ignoring the address (it just must be a defined voltage level).