### PR TITLE
Fix Python header generation for LPDDR4

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -827,12 +827,6 @@ def get_sdram_phy_py_header(phy_settings, timing_settings):
 
     r += "init_sequence = [\n"
     for comment, a, ba, cmd, delay in init_sequence:
-        r += "    "
-        r += "(\"" + comment + "\", "
-        r += str(a) + ", "
-        r += str(ba) + ", "
-        r += cmd.lower() + ", "
-        r += str(delay) + "),"
-        r += "\n"
+        r += f"    (\"{comment}\", {a}, {ba}, {cmd.lower()}, {delay}),\n"
     r += "]\n"
     return r


### PR DESCRIPTION
With the previous code generated lines included Python variable names instead of integers, e.g.
```python
("ZQ Calibration start", MPC.ZQC_START, SpecialCmd.MPC, dfii_command_we|dfii_command_cs, 200),
```
which failed as these names were not being imported.