### PR TITLE
lpddr4: add missing copyright comments

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2016-2019 Florent Kermarrec <florent@enjoy-digital.fr>
 # Copyright (c) 2018 John Sully <john@csquare.ca>
 # Copyright (c) 2018 bunnie <bunnie@kosagi.com>
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import math

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -7,6 +7,7 @@
 # Copyright (c) 2014 Yann Sionneau <ys@m-labs.hk>
 # Copyright (c) 2018 bunnie <bunnie@kosagi.com>
 # Copyright (c) 2019 Gabriel L. Somlo <gsomlo@gmail.com>
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import math

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2018 Tim 'mithro' Ansell <me@mith.ro>
 # Copyright (c) 2018 Daniel Kucera <daniel.kucera@gmail.com>
 # Copyright (c) 2018 Mikołaj Sowiński <mikolaj.sowinski@gmail.com>
-# Copyright (c) 2020 Antmicro <www.antmicro.com>
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from math import ceil

--- a/litedram/phy/lpddr4/__init__.py
+++ b/litedram/phy/lpddr4/__init__.py
@@ -1,2 +1,8 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 from litedram.phy.lpddr4.s7phy import A7LPDDR4PHY, K7LPDDR4PHY, V7LPDDR4PHY
 from litedram.phy.lpddr4.simphy import LPDDR4SimPHY

--- a/litedram/phy/lpddr4/basephy.py
+++ b/litedram/phy/lpddr4/basephy.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 from operator import or_
 from functools import reduce
 from collections import defaultdict

--- a/litedram/phy/lpddr4/commands.py
+++ b/litedram/phy/lpddr4/commands.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 import re
 import enum
 

--- a/litedram/phy/lpddr4/s7phy.py
+++ b/litedram/phy/lpddr4/s7phy.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 from migen import *
 from migen.genlib.cdc import PulseSynchronizer
 

--- a/litedram/phy/lpddr4/sim.py
+++ b/litedram/phy/lpddr4/sim.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 import math
 from operator import or_
 from functools import reduce

--- a/litedram/phy/lpddr4/simphy.py
+++ b/litedram/phy/lpddr4/simphy.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 from migen import *
 
 from litedram.phy.lpddr4.utils import delayed, Serializer, Deserializer

--- a/litedram/phy/lpddr4/simsoc.py
+++ b/litedram/phy/lpddr4/simsoc.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 import os
 import argparse
 

--- a/litedram/phy/lpddr4/utils.py
+++ b/litedram/phy/lpddr4/utils.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 from functools import reduce
 from operator import or_
 

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -1,3 +1,9 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
 import re
 import copy
 import pprint


### PR DESCRIPTION
This adds the copyright comments, I forgot to include them in https://github.com/enjoy-digital/litedram/pull/224.