### PR TITLE
Add DQ-DQS training for LPDDR4 PHY

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -456,6 +456,7 @@ def get_lpddr4_phy_init_sequence(phy_settings, timing_settings):
     bl = 16
     dq_odt = "RZQ/2"
     ca_odt = "RZQ/2"
+    pull_down_drive_strength = "RZQ/3"
 
     def get_nwr():
         frequency_ranges = [  # Table 28. Frequency Ranges for RL, WL, nWR, and nRTP Settings
@@ -575,7 +576,7 @@ def get_lpddr4_phy_init_sequence(phy_settings, timing_settings):
         (0, 1, 1),
         (1, 1, 0),
         (2, 1, 0),
-        (3, 3, odt_map["RZQ/6"]),
+        (3, 3, odt_map[pull_down_drive_strength]),
         (6, 1, 0),
         (7, 1, 0),
     ])

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -690,6 +690,8 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
             'K7LPDDR4PHY', 'V7LPDDR4PHY']:
         r += "#define SDRAM_PHY_WRITE_LATENCY_CALIBRATION_CAPABLE\n"
         r += "#define SDRAM_PHY_READ_LEVELING_CAPABLE\n"
+    if phytype in ['K7LPDDR4PHY', 'V7LPDDR4PHY']:
+        r += "#define SDRAM_PHY_WRITE_DQ_DQS_TRAINING_CAPABLE\n"
     if phytype in ["ECP5DDRPHY"]:
         r += "#define SDRAM_PHY_READ_LEVELING_CAPABLE\n"
     if phytype in ["LPDDR4SIMPHY"]:


### PR DESCRIPTION
This adds DQ-DQS training for LPDDR4 PHY. Requires https://github.com/enjoy-digital/litex/pull/884.

This PR also includes a modification in LPDDR4PHY settings that improves signal quality during reading.