### PR TITLE
Only update UpConverter sel when input valid

### DIFF
--- a/litedram/frontend/adapter.py
+++ b/litedram/frontend/adapter.py
@@ -204,7 +204,9 @@ class LiteDRAMNativePortUpConverter(Module):
             ).Else(  # Acknowledge incomming commands, while filling `sel`.
                 port_from.cmd.ready.eq(port_from.cmd.valid),
                 NextValue(cmd_last, port_from.cmd.last),
-                NextValue(sel, sel | 1 << port_from.cmd.addr[:log2_int(ratio)]),
+                If(port_from.cmd.valid,
+                    NextValue(sel, sel | 1 << port_from.cmd.addr[:log2_int(ratio)])
+                )
             )
         )
         fsm.act("COMMIT",


### PR DESCRIPTION
In the case where the input port valid signal goes low while the UpConverter is in the FILL stage, sel would continue to update. This would cause the fsm to prematurely leave the FILL stage.

Signed-off-by: Andrew Butt <andrewb1999@gmail.com>