### PR TITLE
fix gcc warning: function used but not defined

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -730,7 +730,7 @@ def get_sdram_phy_c_header(phy_settings, timing_settings):
 
     r += "\n"
 
-    r += "static void cdelay(int i);\n"
+    r += "void cdelay(int i);\n"
 
     # Commands functions
     for n in range(nphases):

--- a/test/reference/ddr3_init.h
+++ b/test/reference/ddr3_init.h
@@ -32,7 +32,7 @@
 #define SDRAM_PHY_DELAYS 32
 #define SDRAM_PHY_BITSLIPS 8
 
-static void cdelay(int i);
+void cdelay(int i);
 
 __attribute__((unused)) static inline void command_p0(int cmd)
 {

--- a/test/reference/ddr4_init.h
+++ b/test/reference/ddr4_init.h
@@ -31,7 +31,7 @@
 #define SDRAM_PHY_DELAYS 512
 #define SDRAM_PHY_BITSLIPS 8
 
-static void cdelay(int i);
+void cdelay(int i);
 
 __attribute__((unused)) static inline void command_p0(int cmd)
 {

--- a/test/reference/sdr_init.h
+++ b/test/reference/sdr_init.h
@@ -25,7 +25,7 @@
 #define SDRAM_PHY_WRPHASE 0
 #define SDRAM_PHY_MODULES SDRAM_PHY_DATABITS/8
 
-static void cdelay(int i);
+void cdelay(int i);
 
 __attribute__((unused)) static inline void command_p0(int cmd)
 {


### PR DESCRIPTION
The 'cdelay()' function is defined in LiteX 'liblitedram', so we
should not be using 'static' to declare it before calling it from
other C source files.