### PR TITLE
litedram_gen: Fix error with --sim option

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -501,7 +501,7 @@ class LiteDRAMCore(SoCCore):
                 memtype    = sdram_module.memtype,
                 data_width = core_config["sdram_module_nb"]*8,
                 clk_freq   = sdram_clk_freq)
-            self.submodules.ddrphy = SDRAMPHYModel(
+            self.submodules.ddrphy = sdram_phy = SDRAMPHYModel(
                 module    = sdram_module,
                 settings  = phy_settings,
                 clk_freq  = sdram_clk_freq)


### PR DESCRIPTION
It looks like commit 317072a1982d ("litedram_gen: Add initial SDRAM
support (with ULX3S example)") broke building with the --sim option.