### PR TITLE
Add RPC DRAM support

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2016-2019 Florent Kermarrec <florent@enjoy-digital.fr>
 # Copyright (c) 2018 John Sully <john@csquare.ca>
 # Copyright (c) 2018 bunnie <bunnie@kosagi.com>
-# Copyright (c) 2021 Antmicro <www.antmicro.com>
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import math
@@ -25,6 +25,7 @@ burst_lengths = {
     "LPDDR":  4,
     "DDR2":   4,
     "DDR3":   8,
+    "RPC":    16,
     "DDR4":   8,
     "LPDDR4": 16,
 }

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -839,6 +839,35 @@ class MT16KTF1G64HZ(DDR3Module):
     }
     speedgrade_timings["default"] = speedgrade_timings["1866"]
 
+# RPC ----------------------------------------------------------------------------------------------
+
+class RPCModule(SDRAMModule): memtype = "RPC"
+
+class EM6GA16L(RPCModule):
+    # 64MBits per bank => 256Mb
+    # TODO: the timings may need further verification
+    # geometry
+    nbanks = 4     #
+    ncols = 1024
+    nrows = 4096  # 64M / 1024 / 16 = 4k
+    # timings
+    technology_timings = _TechnologyTimings(
+        tREFI=64e6/8192,
+        # It seems that we need to calculate tCCD from tBESL by assuming BC=1, then it is:
+        # RL=WL + burst_time + tBESL
+        tCCD=(13+1 + 8 + 7, None),
+        # CCD enforces tBESL for read commands, we use tWTR to ensure it for writes
+        tWTR=(11 + 2, None),  # 11 for tBESL + 2 for STB low before a command
+        tRRD=(None, 7.5),
+        tZQCS=(None, 90),
+    )
+    speedgrade_timings = {
+        # FIXME: we're increasing tWR by 1 sysclk to compensate for long write (assuming max sysclk 200 MHz)
+        # Should we use tRFQSd for tRFC?
+        "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=15 + 1e9/200e6, tRFC=(3*100, None), tFAW=None, tRAS=35),
+        "1866": _SpeedgradeTimings(tRP=13.91, tRCD=13.91, tWR=15 + 1e9/200e6, tRFC=(3*100, None), tFAW=None, tRAS=34),
+    }
+    speedgrade_timings["default"] = speedgrade_timings["1600"]
 
 # DDR4 (Chips) -------------------------------------------------------------------------------------
 

--- a/litedram/phy/model.py
+++ b/litedram/phy/model.py
@@ -523,6 +523,7 @@ class SDRAMPHYModel(Module):
             "LPDDR": 2,
             "DDR2":  2,
             "DDR3":  2,
+            "RPC":   4,
             "DDR4":  2,
             }[settings.memtype]
 

--- a/litedram/phy/rpc/README.md
+++ b/litedram/phy/rpc/README.md
@@ -1,0 +1,75 @@
+# RPC DRAM PHY
+
+[Reduced Pin Count DRAM from Etron](https://etronamerica.com/products/rpc-dram/) is a memory that can deliver DDR3/DDR3L-level
+bandwidth using a reduced number of pins (22 or 24). The pins used in RPC are:
+
+* `CLK/CLK#` - differential clock
+* `CS#` - chip select
+* `DQS/DQS#` - differential data strobe (with optional `DQS0/DQS0#`)
+* `DB[15:0]` - similar to `DQ` in DDR3, used for parallel commands, DDR
+* `STB` - single serial line, used for serial commands and held low before each transaction, DDR
+
+`DQS` is phase-aligned to `CLK` and other signals are center-aligned to `CLK`.
+
+Unlike in DDR3, RPC doesn't use command/address lines. The commands are encoded on DB/STB lines.
+There are 2 types of commands: serial (on STB) and parallel (on DB). Every first command in a
+sequence is a parallel command, and any subsequent ones are transmitted as serial commands.
+
+## Hardware tests
+
+Due to the lack of ready boards with RPC DRAM (at the time of development of this PHY) it has been
+tested on a modified Arty A7 board. The onboard DDR3 DRAM has been replaced with an [RPC DRAM in a
+pin-compatible package](https://store.nacsemi.com/products/detail?part=EM6GA16LBX-12H&stock=ETRN00000000019).
+The DDR3 DRAM on Arty A7 normally operates on 1.35V, but the RPC DRAM chip requires 1.5V to work.
+To adjust the DRAM voltage, the Power Management IC on Arty A7 was being reconfigured on board
+startup. This requires adding I2C pins to the design and connecting them to J11 (exposed pads near
+DC jack and user LEDs).
+
+Example code to configure PMIC to use 1.5V:
+
+```c
+#include <i2c.h>
+unsigned char vbuck2_15 = 0x78;
+i2c_write(0x58, 0xa3, &vbuck2_15, sizeof(vbuck2_15));  // Vbuck2A
+i2c_write(0x58, 0xb4, &vbuck2_15, sizeof(vbuck2_15));  // Vbuck2B
+```
+
+There were however hardware-related issues (possibly wrong CS/STB termination) that prevented
+reaching high frequency operation.
+
+## Implementation
+
+Important implementation notes:
+
+* Frequency ratio between the controller and DRAM is 1:4.
+* There is some additional command latency due to the need to insert DQS and STB preamble.
+* Not all RPC commands can be represented with DFI commands, so DFI.reset_n is used to modify the
+  encoding (as it is not used to reset the PHY due to the lack of reset pin in RPC).
+* DRAM module tWR has to be artificially increased by 1 because data is being serialized over 2
+  controller clock cycles (problem would go away after switching to 8 DFI phases).
+* A Finite State Machine is used to ensure only correct commands are being sent (during
+  initialization or in UTR mode).
+* Series 7 backend reqires two phase-shifted clocks: sys4x_90 and sys4x_180.
+
+The current code structure is the predecessor of the concepts used in LPDDR4/LPDDR5 PHYs.
+RPC-related code is contained in the `litedram/phy/rpc` directory (with some modifications in other
+files e.g. `litedram/init.py`). The PHY is split into core part (`basephy.py`) and
+platform-dependant backend (`s7phy.py`). The DFI commands from the controller are translated based
+on the encoding defined in `commands.py`. There is also a backend for simulation purpose
+(`simphy.py`) along with a simulation SoC (`simsoc.py`).
+
+Currently this PHY is functional however it has some limitations that need to be addressed. The code
+structure could also be refreshed basing on the LPDDR4 code. Potential improvements include the
+following:
+
+* Main flaw is the usage of 4 DFI phases. Switching to 8 phases (due to BL=16, DDR) would allow to
+  transmit a single data burst in a single controller clock cycle, greatly simplify the core logic.
+* Serial commands are not being used, which prevents pipelining. Implementing proper usage of serial
+  commands would allow to improve performance.
+* Some parts of the implementation could be replaced with common utilities from `phy/utils.py`.
+* `RPCPads` (which was also used to map DDR3 pads to RPC ones) should be replaced with similar
+  output structure like the one in LPDDR4 PHY.
+* All the `do_*_serialization` abstract methods could be removed, letting the platform backend
+  use `self.out` of the base class.
+* Command encoding could be modified not to depend on DFI.reset_n but use ZQC as in LPDDR4.
+* Series 7 PHY could avoid two phase-shifted clocks by using correct clock reset.

--- a/litedram/phy/rpc/basephy.py
+++ b/litedram/phy/rpc/basephy.py
@@ -1,0 +1,584 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from math import ceil
+from operator import and_
+
+from migen import *
+from migen.genlib.misc import WaitTimer
+
+from litex.soc.interconnect.csr import AutoCSR, CSR, CSRStatus, CSRStorage
+
+from litedram.common import *
+from litedram.phy.utils import chunks, bitpattern
+from litedram.phy.dfi import Interface as DFIInterface
+from litedram.phy.rpc.commands import DFIAdapter
+
+
+class ShiftRegister(Module):
+    def __init__(self, n, i=None):
+        if i is None:
+            i = Signal()
+        assert len(i) == 1
+
+        self.i = i
+        self.sr = sr = Signal(n)
+        last = Signal.like(sr)
+
+        self.comb += sr.eq(Cat(i, last))
+        self.sync += last.eq(sr)
+
+    def __getitem__(self, key):
+        return self.sr[key]
+
+
+class RPCPads:
+    _layout = [
+        ("clk_p",  1),
+        ("clk_n",  1),
+        ("cs_n",   1),
+        ("dqs_p",  1),  # may be 2 (hardware option; 2-bit DQS strobes DB by bytes: [0:7], [8:15])
+        ("dqs_n",  1),  # may be 2
+        ("stb",    1),
+        ("db",    16),
+    ]
+
+    def __init__(self, pads):
+        self.map(pads)
+        for pad, width in self._layout:
+            assert len(getattr(self, pad)) >= width, \
+                "Pad {} has width {} < {}".format(pad, len(getattr(self, pad)), width)
+
+    # reimplement if a specific mapping is needed
+    def map(self, pads):
+        for pad, _ in self._layout:
+            setattr(self, pad, getattr(pads, pad))
+
+
+class BasePHY(Module, AutoCSR):
+    def __init__(self, pads, sys_clk_freq, write_ser_latency, read_des_latency, phytype):
+        # TODO: pads groups for multiple chips
+        #  pads = PHYPadsCombiner(pads)
+        if not isinstance(pads, RPCPads):
+            pads = RPCPads(pads)
+        self.pads = pads
+
+        self.memtype     = memtype     = "RPC"
+        self.nranks      = nranks      = 1
+        self.databits    = databits    = 16
+        self.addressbits = addressbits = 12
+        self.bankbits    = bankbits    = 2
+        self.nphases     = nphases     = 4
+        self.tck         = tck         = 1 / (nphases*sys_clk_freq)
+
+        # CSRs -------------------------------------------------------------------------------------
+        bitslip_cycles = 1
+        self._rst                 = CSRStorage()
+        self._dly_sel             = CSRStorage(databits//8)
+        self._rdly_dq_bitslip_rst = CSR()
+        self._rdly_dq_bitslip     = CSR()
+
+        self._reset_done = CSRStatus()
+        self._init_done  = CSRStatus()
+        self._reset_fsm  = CSR()
+
+        self._burst_stop = CSRStorage(reset=1)
+
+        # PHY settings -----------------------------------------------------------------------------
+        def get_cl(tck):
+            # FIXME: for testing it's easier to use CL=8; read/write will be on phase 3; max sys_clk_freq=100e6
+            return 8
+            # tck is for DDR frequency
+            f_to_cl = OrderedDict()
+            f_to_cl[533e6]  =  3
+            f_to_cl[800e6]  =  8
+            f_to_cl[1200e6] =  8
+            f_to_cl[1333e6] = 10
+            f_to_cl[1600e6] = 11
+            f_to_cl[1866e6] = 13
+            for f, cl in f_to_cl.items():
+                if tck >= 2/f:
+                    return cl
+            raise ValueError(tck)
+
+        # RPC always has AL=1 and both read and write latencies are equal: RL=WL=AL+CL
+        al = 1
+        cwl = cl = get_cl(tck) + al
+
+        cl_sys_latency  = get_sys_latency(nphases, cl)
+        cwl_sys_latency = get_sys_latency(nphases, cwl)
+
+        rdphase = get_sys_phase(nphases, cl_sys_latency, cl)
+        wrphase = get_sys_phase(nphases, cwl_sys_latency, cwl)
+
+        # Read latency
+        db_cmd_dly   = 2  # (need 1 cycle to insert STB preamble + 1 more to always meet tCSS)
+        cmd_ser_dly  = write_ser_latency
+        read_mux_dly = 1
+        bitslip_dly  = bitslip_cycles
+        # Time until first data is available on DB
+        read_db_dly = db_cmd_dly + cmd_ser_dly + cl_sys_latency
+        # Time until data is deserialized (data present on 1ck signal)
+        read_db_des_dly = read_db_dly + read_des_latency
+        # Time until data is set on DFI (+1 because all data is present only on 2nd cycle)
+        read_dfi_dly = read_mux_dly + bitslip_dly + 1
+        # Final latency
+        read_latency = read_db_des_dly + read_dfi_dly
+
+        # Write latency for the controller. We must send 1 cycles of data mask before the
+        # data, and we serialize data over 2 sysclk cycles due to minimal BL=16, so we
+        # are writing in the 2 cycles following the cycle when we obtain data on DFI.
+        # Other PHYs can send everything in 1 sysclk. Because of this spcific delay, we
+        # have to increate tWR in the RPC SDRModule definition to meet tWR requirements.
+        # +1 cycle needed to insert CS before command
+        write_latency = cwl_sys_latency + 1
+
+        self.settings = PhySettings(
+            phytype       = phytype,
+            memtype       = memtype,
+            databits      = databits,
+            dfi_databits  = 4*databits,
+            nranks        = nranks,
+            nphases       = nphases,
+            rdphase       = rdphase,
+            wrphase       = wrphase,
+            cl            = cl,
+            cwl           = cwl,
+            read_latency  = read_latency,
+            write_latency = write_latency,
+            bitslips      = bitslip_cycles*2*2*nphases,
+        )
+
+        # DFI Interface ----------------------------------------------------------------------------
+        # minimal BL=16, which gives 16*16=256 bits; with 4 phases we need 16/4=4 data widths
+        dfi_params = dict(addressbits=addressbits, bankbits=bankbits, nranks=nranks,
+                          databits=4*databits, nphases=nphases)
+
+        # Register DFI history (from newest to oldest), as we need to operate on 3 subsequent cycles
+        # hist[0] = dfi[N], hist[1] = dfi[N-1], ...
+        self.dfi = dfi = DFIInterface(**dfi_params)
+        dfi_hist = [dfi, DFIInterface(**dfi_params), DFIInterface(**dfi_params)]
+        self.sync += dfi_hist[0].connect(dfi_hist[1], omit={"rddata", "rddata_valid"})
+        self.sync += dfi_hist[1].connect(dfi_hist[2], omit={"rddata", "rddata_valid"})
+
+        # Serialization ----------------------------------------------------------------------------
+        # We have the following signals that have to be serialized:
+        # - CLK (O)  - full-rate clock
+        # - CS  (O)  - chip select
+        # - STB (O)  - serial commands, serial preamble
+        # - DB  (IO) - transmits data in/out, data mask, parallel commands
+        # - DQS (IO) - strobe for commands/data/mask on DB pins
+        # DQS is edge-aligned to CLK, while DB and STB are center-aligned to CLK (phase = -90).
+        # Sending a parallel command (on DB pins):
+        #  CLK: ____----____----____----____----____----____
+        #  STB: ----------________________------------------
+        #  DQS: ....................----____----____........
+        #  DB:  ..........................PPPPnnnn..........
+        # The signals prepared by BasePHY will all be phase-aligned. The concrete PHY should shift
+        # them so that DB/STB/CS are delayed by 90 degrees in relation to CLK/DQS.
+
+        # Signal values (de)serialized during 1 sysclk.
+        # These signals must be populated in specific PHY implementations.
+        self.clk_1ck_out  = clk_1ck_out  = Signal(2*nphases)
+        self.stb_1ck_out  = stb_1ck_out  = Signal(2*nphases)
+        self.cs_n_1ck_out = cs_n_1ck_out = Signal(2*nphases)
+
+        self.dqs_1ck_out = dqs_1ck_out = Signal(2*nphases)
+        self.dqs_1ck_in  = dqs_1ck_in  = Signal(2*nphases)
+        self.dqs_oe      = dqs_oe      = Signal()
+
+        self.db_1ck_out  = db_1ck_out  = [Signal(2*nphases) for _ in range(databits)]
+        self.db_1ck_in   = db_1ck_in   = [Signal(2*nphases) for _ in range(databits)]
+        self.db_oe       = db_oe       = Signal()
+
+        # Clocks -----------------------------------------------------------------------------------
+        self.comb += clk_1ck_out.eq(bitpattern("-_-_-_-_"))
+
+        # DB muxing --------------------------------------------------------------------------------
+        # Commands allowed by FSM
+        cmd_valid = Signal()
+
+        # Muxed cmd/data/mask
+        db_1ck_data = [Signal(2*nphases) for _ in range(databits)]
+        db_1ck_mask = [Signal(2*nphases) for _ in range(databits)]
+        db_1ck_cmd  = [Signal(2*nphases) for _ in range(databits)]
+        dq_data_en  = Signal()
+        dq_mask_en  = Signal()
+        dq_cmd_en   = Signal()
+        dq_read_stb = Signal()
+
+        # Output enable when writing cmd/data/mask
+        # Mask is being send during negative half of sysclk
+        self.comb += db_oe.eq(cmd_valid & (dq_data_en | dq_mask_en | dq_cmd_en))
+
+        # Mux between cmd/data/mask
+        for i in range(databits):
+            self.comb += \
+                If(dq_data_en,
+                    db_1ck_out[i].eq(db_1ck_data[i])
+                ).Elif(dq_mask_en,
+                    db_1ck_out[i].eq(db_1ck_mask[i])
+                ).Else(
+                    db_1ck_out[i].eq(db_1ck_cmd[i])
+                )
+
+        # Parallel commands ------------------------------------------------------------------------
+        # We need to insert 2 full-clk cycles of STB=0 before any command, to mark the beginning of
+        # Request Packet. For that reason we use the previous values of DFI commands. To always be
+        # able to meet tCSS, we have to add a delay of 1 more sysclk.
+        # list from oldest to newest: dfi[N-1][p0], dfi[N-1][p1], ..., dfi[N][p0], dfi[N][p1], ...
+        dfi_adapters = []
+        for phase in dfi_hist[2].phases + dfi_hist[1].phases + dfi_hist[0].phases:
+            adapter = DFIAdapter(phase)
+            self.submodules += adapter
+            dfi_adapters.append(adapter)
+            self.comb += [
+                # We always send one WORD, which consists of 32 bytes.
+                adapter.bc.eq(0),
+                # Always use fast refresh (equivalent to auto refresh) instead of low-power refresh
+                # (equivalent to self refresh).
+                adapter.ref_op.eq(adapter.REF_OP["FST"]),
+            ]
+
+        # Serialize commands to DB pins
+        for i in range(databits):
+            # A list of differential DB values using previous DFI coomand:
+            # db_p[p][i], db_n[p][i], db_p[p+1][i], db_n[p+1][i], ...
+            bits = [db for a in dfi_adapters[:nphases] for db in [a.db_p[i], a.db_n[i]]]
+            self.comb += db_1ck_cmd[i].eq(Cat(*bits))
+
+        # Commands go on the 2nd cycle, so use previous DFI
+        self.comb += dq_cmd_en.eq(reduce(or_, [a.cmd_valid for a in dfi_adapters[:nphases]]))
+
+        # Power Up Reset ---------------------------------------------------------------------------
+        # During Power Up, after stabilizing clocks, Power Up Reset must be done. It consists of a
+        # a Parallel Reset followed by two Serial Resets (2x8=16 full-rate cycles = 4 sys cycles).
+        # We use an FSM to make sure that we pass only the commands from the controller that are
+        # supported in the current state.
+        t_reset          = 5e-6
+        t_zqcinit        = 1e-6
+        serial_reset_len = 4
+
+        stb_reset_seq      = Signal()
+        serial_reset_count = Signal(max=serial_reset_len + 1)
+
+        # prolong the cmd_valid for the cmd latency (length of history)
+        self.submodules.cmd_valid_sr = ShiftRegister(len(dfi_adapters) // nphases)
+        self.comb += cmd_valid.eq(reduce(or_, self.cmd_valid_sr))
+
+        self.submodules.reset_timer = WaitTimer(ceil(t_reset * sys_clk_freq))
+        self.submodules.zqcinit_timer = WaitTimer(ceil(t_zqcinit * sys_clk_freq))
+
+        self.submodules.reset_fsm = fsm = FSM()
+        fsm.act("IDLE",
+            NextValue(serial_reset_count, 0),
+            NextValue(self._reset_done.status, 0),
+            self.cmd_valid_sr.i.eq(dfi_adapters[2*nphases+0].is_cmd("RESET")),
+            If(self.cmd_valid_sr.i,
+                NextState("RESET_RECEIVED")
+            ),
+        )
+        fsm.act("RESET_RECEIVED",
+            NextState("SERIAL_RESET")
+        )
+        fsm.act("SERIAL_RESET",
+            self.reset_timer.wait.eq(1),
+            If(serial_reset_count != serial_reset_len,
+               stb_reset_seq.eq(1),
+               NextValue(serial_reset_count, serial_reset_count + 1),
+            ),
+            If(self.reset_timer.done,
+                NextValue(self._reset_done.status, 1),
+                NextState("RESET_DONE")
+            )
+        )
+        fsm.act("RESET_DONE",
+            self.cmd_valid_sr.i.eq(dfi_adapters[2*nphases+0].is_cmd(["PRE", "MRS", "ZQC_INIT"])),
+            If(dfi_adapters[2*nphases+0].is_cmd("ZQC_INIT"),
+                NextState("ZQC_INIT")
+            )
+        )
+        fsm.act("ZQC_INIT",
+            self.zqcinit_timer.wait.eq(1),
+            If(self.zqcinit_timer.done,
+                NextState("READY")
+            )
+        )
+        fsm.act("READY",
+            self._init_done.status.eq(1),
+            self.cmd_valid_sr.i.eq(1),
+            If(dfi_adapters[2*nphases+0].is_cmd("UTR") & (dfi_adapters[2*nphases+0].utr_en == 1),
+                NextState("UTR_MODE")
+            ),
+            If(self._reset_fsm.re,
+                NextState("IDLE")
+            )
+        )
+        fsm.act("UTR_MODE",
+            self._init_done.status.eq(1),
+            self.cmd_valid_sr.i.eq(reduce(or_, [dfi_adapters[p].is_cmd(["UTR", "RD"])
+                                                for p in [2*nphases, 2*nphases+self.settings.rdphase]])),
+            If(dfi_adapters[2*nphases+0].is_cmd("UTR") & (dfi_adapters[2*nphases+0].utr_en == 0),
+                NextState("READY")
+            )
+        )
+
+        # STB --------------------------------------------------------------------------------------
+        # Currently not sending any serial commands, but the STB pin must be held low for 2 full
+        # rate cycles before writing a parallel command to activate the DRAM.
+        stb_bits = []
+
+        assert self.settings.rdphase == 3
+        read_sent = [Signal(), Signal()]
+        self.comb += read_sent[0].eq(dfi_adapters[3].cmd_valid & (dfi_adapters[3].is_cmd("RD") | dfi_adapters[3].is_cmd("WR")))
+        self.sync += read_sent[1].eq(read_sent[0])
+
+        for p in range(nphases):
+            # Use cmd from current and prev cycle, depending on which phase the command appears on
+            preamble = (dfi_adapters[p+2].cmd_valid | dfi_adapters[p+1].cmd_valid) & cmd_valid
+
+            # force 000100xxxxxxxxxx after preamble to generate Burst Stop
+            assert self.settings.rdphase == 3
+            burst_stop = {
+                0: [0, 0],
+                1: [0, 1],
+                2: [0, 0],
+                3: [1, 1],
+            }[(p+1)%4]
+            read = read_sent[0] if p == 3 else read_sent[1]
+            burst_stop_zero = [cmd_valid & read & (bs == 0) & self._burst_stop.storage
+                               for bs in burst_stop]
+
+            # We only want to use STB to start parallel commands, serial reset or to send NOPs. NOP
+            # is indicated by the first two bits being high (0b11, and other as "don't care"), so
+            # we can simply hold STB high all the time and reset is zeros for 8 cycles (1 sysclk).
+            # stb_bits += 2 * [~(preamble | stb_reset_seq)]
+            stb_bits += [
+                ~(preamble | stb_reset_seq | burst_stop_zero[0]),
+                ~(preamble | stb_reset_seq | burst_stop_zero[1]),
+            ]
+
+        self.comb += stb_1ck_out.eq(Cat(*stb_bits))
+
+        # Chip Select ------------------------------------------------------------------------------
+        # RPC has quite high required time of CS# low before sending a command (tCSS), this means
+        # that we would need 1 more cmd_latency to support it for all standard frequencies. To meet
+        # tCSH we hold CS# low 1 cycle after each command (and for writes until the burst ends).
+        tCSS = 10e-9
+        tCSH =  5e-9
+        # CS# is held for 2 sysclks before any command, and 1 sysclk after any command
+        assert 2 * 1/sys_clk_freq >= tCSS, "tCSS not met for commands on phase 0"
+        assert 1 * 1/sys_clk_freq >= tCSH, "tCSH not met for commands on phase 3"
+
+        cs         = Signal()
+        cs_burst_hold = Signal()
+        self.submodules.cs_hold = ShiftRegister(2)
+
+        # FIXME: currently we hold CS low constantly to avoid problems with signal integrity on our board
+        # lock CS when DFI sends cs_n=0 only on phase 0 (avoids start condition problems)
+        cs_lock = Signal()
+        cs_lock_cond = reduce(and_, [dfi_hist[0].phases[p].cs_n for p in range(1, nphases)])
+        cs_lock_cond = cs_lock_cond & ~dfi_hist[0].p0.cs_n
+        self.sync += If(cs_lock_cond, cs_lock.eq(1)).Elif(self._reset_fsm.re, cs_lock.eq(0))
+
+        _any_cmd_valid = reduce(or_, (a.cmd_valid for a in dfi_adapters))
+        self.comb += [
+            # self.cs_hold.i.eq(cmd_valid & (_any_cmd_valid | cs_burst_hold)),
+            # cs.eq(reduce(or_, self.cs_hold.sr)),
+            # cs_n_1ck_out.eq(Replicate(~cs, len(cs_n_1ck_out))),
+            cs_n_1ck_out.eq(Replicate(~cs_lock, len(cs_n_1ck_out))),
+        ]
+
+        # Data IN ----------------------------------------------------------------------------------
+        # Synchronize the deserializer because we deserialize over 2 cycles.
+        dq_in_cnt = Signal()
+        self.sync += If(dq_read_stb, dq_in_cnt.eq(~dq_in_cnt)).Else(dq_in_cnt.eq(0))
+
+        # Deserialize read data
+        # sys_clk:    ------------____________------------____________
+        # sysx4_clk:  ---___---___---___---___---___---___---___---___
+        # DB num:     <0><1><2><3><4><5><6><7><8><9><a><b><c><d><e><f>
+        for i in range(databits):
+            # BL=16 -> 2ck
+            n_1ck = 2*nphases
+            rbits_2ck = Signal(2*n_1ck)
+            rbits_1ck = Signal(n_1ck)
+
+            self.comb += rbits_1ck.eq(db_1ck_in[i])
+            self.sync += Case(dq_in_cnt, {
+                0: rbits_2ck[:n_1ck].eq(rbits_1ck),
+                1: rbits_2ck[n_1ck:].eq(rbits_1ck),
+            })
+
+            bs = BitSlip(len(rbits_2ck), cycles=bitslip_cycles,
+                rst = self.get_rst(i//8, self._rdly_dq_bitslip_rst.re),
+                slp = self.get_inc(i//8, self._rdly_dq_bitslip.re),
+            )
+            self.submodules += bs
+            self.comb += bs.i.eq(rbits_2ck)
+
+            for p in range(nphases):
+                self.comb += [
+                    dfi.phases[p].rddata[i+0*databits].eq(bs.o[p*nphases+0]),
+                    dfi.phases[p].rddata[i+1*databits].eq(bs.o[p*nphases+1]),
+                    dfi.phases[p].rddata[i+2*databits].eq(bs.o[p*nphases+2]),
+                    dfi.phases[p].rddata[i+3*databits].eq(bs.o[p*nphases+3]),
+                ]
+
+        # Data OUT ---------------------------------------------------------------------------------
+        # TODO: add 1 to tWR bacause we need 2 cycles to send data from 1 cycle
+
+        # Before sending the actual data we have to send 2 32-bit data masks (4 DDR cycles). In the
+        # mask each 0 bit means "write byte" and 1 means "mask byte". The 1st 32-bits mask the first
+        # data WORD (32 bytes), and the 2nd 32-bits mask the last data WORD. Because we always send
+        # 1 WORD of data (BC=0), we don't care about the 2nd mask (can send 1).
+        #
+        # Write data
+        # DFI valid:  xxxxxxxxxxxxxxxxxx
+        # sys_clk:    ------____________------------____________------------____________
+        # sysx4_clk:  ---___---___---___---___---___---___---___---___---___---___---___
+        # DB num:           <M><M><M><M><0><1><2><3><4><5><6><7><8><9><a><b><c><d><e><f>
+
+        # Synchronize to 2 cycles, reset counting when dq_data_en turns high.
+        db_cnt = Signal()
+        self.sync += If(dq_data_en, db_cnt.eq(~db_cnt)).Else(db_cnt.eq(0))
+
+        for i in range(databits):
+            # Write data ---------------------------------------------------------------------------
+            wbits = []
+            for p in range(nphases):
+                _dfi = dfi_hist[1] if p < nphases//2 else dfi_hist[2]
+                wbits += [
+                    _dfi.phases[p].wrdata[i+0*databits],
+                    _dfi.phases[p].wrdata[i+1*databits],
+                    _dfi.phases[p].wrdata[i+2*databits],
+                    _dfi.phases[p].wrdata[i+3*databits],
+                ]
+
+            # Mux datas from 2 cycles to always serialize single cycle.
+            wbits_2ck = [Cat(*wbits[:2*nphases]), Cat(*wbits[2*nphases:])]
+            wbits_1ck = Signal(2*nphases)
+            self.comb += wbits_1ck.eq(Array(wbits_2ck)[db_cnt])
+            self.comb += db_1ck_data[i].eq(Cat(*wbits_1ck))
+
+            # Data mask ----------------------------------------------------------------------------
+            mask = [
+                Constant(0),                                    # phase 0
+                Constant(0),                                    # phase 0
+                Constant(0),                                    # phase 1
+                Constant(0),                                    # phase 1
+                dfi_hist[0].phases[i//8 + 0].wrdata_mask[i%8],  # WL-2
+                dfi_hist[0].phases[i//8 + 2].wrdata_mask[i%8],  # WL-2
+                Constant(1),                                    # WL-1
+                Constant(1),                                    # WL-1
+            ]
+            self.comb += db_1ck_mask[i].eq(Cat(*mask))
+
+        # DQS --------------------------------------------------------------------------------------
+        # Strobe pattern can go over 2 sysclk (do not count while transmitting mask)
+        dqs_cnt = Signal()
+        self.sync += If(dqs_oe & (~dq_mask_en), dqs_cnt.eq(~dqs_cnt)).Else(dqs_cnt.eq(0))
+
+        pattern_2ck = [Signal(2*nphases), Signal(2*nphases)]
+        self.comb += dqs_1ck_out.eq(Array(pattern_2ck)[dqs_cnt])
+
+        # To avoid having to serialize dqs_oe, we serialize predefined pattern on dqs_out
+        # All the patterns will be shifted back 90 degrees!
+        data_pattern = [bitpattern("-_-_-_-_"), bitpattern("-_-_-_-_")]
+        mask_pattern = [bitpattern("__-_-_-_"), bitpattern("-_-_-_-_")]
+        phase_patterns = {
+            0: [bitpattern("______-_"), bitpattern("-_______")],
+            1: [bitpattern("________"), bitpattern("-_-_____")],
+            2: [bitpattern("________"), bitpattern("__-_-___")],
+            3: [bitpattern("________"), bitpattern("____-_-_")],
+        }
+
+        pattern_cases = \
+            If(dq_mask_en,
+                pattern_2ck[0].eq(mask_pattern[0]),
+                pattern_2ck[1].eq(mask_pattern[1]),
+            ).Elif(dq_data_en,
+                pattern_2ck[0].eq(data_pattern[0]),
+                pattern_2ck[1].eq(data_pattern[1]),
+            ).Else(
+                pattern_2ck[0].eq(0),
+                pattern_2ck[1].eq(0),
+            )
+        any_phase_valid = 0
+        for p in range(nphases):
+            phase_valid = dfi_adapters[p].cmd_valid | dfi_adapters[nphases+p].cmd_valid
+            pattern_cases = \
+                If(phase_valid,
+                    pattern_2ck[0].eq(phase_patterns[p][0]),
+                    pattern_2ck[1].eq(phase_patterns[p][1]),
+                ).Else(pattern_cases)
+            any_phase_valid = any_phase_valid | phase_valid
+
+        self.comb += pattern_cases
+        self.comb += dqs_oe.eq(cmd_valid & (any_phase_valid | dq_mask_en | dq_data_en))
+
+        # Read Control Path ------------------------------------------------------------------------
+        # Creates a shift register of read commands coming from the DFI interface. This shift
+        # register is used to indicate to the DFI interface that the read data is valid.
+        self.submodules.rddata_en = rddata_en = ShiftRegister(self.settings.read_latency)
+        self.comb += rddata_en.i.eq(dfi.phases[self.settings.rdphase].rddata_en)
+        # -1 because of syncronious assignment
+        self.sync += [phase.rddata_valid.eq(rddata_en[-1]) for phase in dfi.phases]
+        # Strobe high when data from DRAM is available, before we can send it to DFI.
+        self.sync += dq_read_stb.eq(rddata_en[read_db_des_dly-1] | rddata_en[read_db_des_dly-1 + 1])
+
+        # Write Control Path -----------------------------------------------------------------------
+        # Creates a shift register of write commands coming from the DFI interface. This shift
+        # register is used to control DQ/DQS tristates.
+        self.submodules.wrdata_en = wrdata_en = ShiftRegister(self.settings.write_latency + 2 + 1)
+        self.comb += wrdata_en.i.eq(dfi.phases[self.settings.wrphase].wrdata_en & cmd_valid)
+        # DQS Preamble and data mask are transmitted 1 cycle before data, then 2 cycles of data
+        self.comb += dq_mask_en.eq(wrdata_en[write_latency])
+        self.comb += dq_data_en.eq(wrdata_en[write_latency + 1] | wrdata_en[write_latency + 2])
+        # Hold CS# low until end of write burst (use a latch as there can only be 1 write at a time)
+
+        cs_wr_hold = Signal()
+        self.sync += If(wrdata_en[0], cs_wr_hold.eq(1)).Elif(wrdata_en[-1], cs_wr_hold.eq(0))
+        cs_rd_hold = Signal()
+        self.sync += If(rddata_en[0], cs_rd_hold.eq(1)).Elif(rddata_en[-1], cs_rd_hold.eq(0))
+        self.comb += cs_burst_hold.eq(cs_wr_hold | cs_rd_hold)
+
+        # Additional variables for LiteScope -------------------------------------------------------
+        variables = ["dq_data_en", "dq_mask_en", "dq_cmd_en", "dq_read_stb", "dfi_adapters",
+                     "dq_in_cnt", "db_cnt", "dqs_cnt", "rddata_en", "wrdata_en"]
+        for v in variables:
+            setattr(self, v, locals()[v])
+
+    def get_rst(self, byte, rst):
+        return (self._dly_sel.storage[byte] & rst) | self._rst.storage
+
+    def get_inc(self, byte, inc):
+        return self._dly_sel.storage[byte] & inc
+
+    def do_finalize(self):
+        self.do_clock_serialization(self.clk_1ck_out, self.pads.clk_p, self.pads.clk_n)
+        self.do_stb_serialization(self.stb_1ck_out, self.pads.stb)
+        self.do_dqs_serialization(self.dqs_1ck_out, self.dqs_1ck_in, self.dqs_oe,
+                                  self.pads.dqs_p, self.pads.dqs_n)
+        self.do_db_serialization(self.db_1ck_out, self.db_1ck_in, self.db_oe, self.pads.db)
+        self.do_cs_serialization(self.cs_n_1ck_out, self.pads.cs_n)
+
+    # I/O implementation ---------------------------------------------------------------------------
+
+    def do_clock_serialization(self, clk_1ck_out, clk_p, clk_n):
+        raise NotImplementedError("Serialize the full-rate clock with 90 deg phase delay")
+
+    def do_stb_serialization(self, stb_1ck_out, stb):
+        raise NotImplementedError("Serialize the STB line")
+
+    def do_dqs_serialization(self, dqs_1ck_out, dqs_1ck_in, dqs_oe, dqs_p, dqs_n):
+        raise NotImplementedError("Tristate and (de)serialize DQS with 90 deg phase delay")
+
+    def do_db_serialization(self, db_1ck_out, db_1ck_in, db_oe, db):
+        raise NotImplementedError("Tristate and (de)serialize DB")
+
+    def do_cs_serialization(self, cs_n_1ck_out, cs_n):
+        raise NotImplementedError("Serialize the chip select line (CS#)")

--- a/litedram/phy/rpc/commands.py
+++ b/litedram/phy/rpc/commands.py
@@ -1,0 +1,291 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+
+class ModeRegister:
+    """RPC Mode Register encoding (RPC has only 1 mode register)"""
+    def __init__(self):
+        self.cl      = Signal(3)
+        # TODO: in LPDDR3 nWR is the number of clock cycles determining when to start internal
+        # precharge for a write burst when auto-precharge is enabled (ceil(tRW/tCK) ?)
+        self.nwr     = Signal(3)
+        self.zout    = Signal(4)
+        self.odt     = Signal(3)
+        self.odt_stb = Signal(1)
+        self.csr_fx  = Signal(1)
+        self.odt_pd  = Signal(1)
+        self.tm      = Signal(1)
+
+    CL = {
+        8:  0b000,  # default
+        10: 0b001,
+        11: 0b010,
+        13: 0b011,
+        3:  0b110,
+    }
+    NWR = {
+        4:  0b000,
+        6:  0b001,
+        7:  0b010,
+        8:  0b011,  # default
+        10: 0b100,
+        12: 0b101,
+        14: 0b110,
+        16: 0b111,
+    }
+    ZOUT = {  # resistance in Ohms
+        120:     0b0010,
+        90:      0b0100,
+        51.4:    0b0110,
+        60:      0b1000,
+        40:      0b1010,
+        36:      0b1100,
+        27.7:    0b1110,
+        "short": 0b0001,  # 0bxxx1
+        "open":  0b0000,  # output disabled, default
+    }
+    ODT = {
+        60:     0b001,
+        45:     0b010,
+        25.7:   0b011,
+        30:     0b100,
+        20:     0b101,
+        18:     0b110,
+        13.85:  0b111,
+        "open": 0b000,
+    }
+
+    # Encode mode register information in DFI address/bank
+    DFI_ENCODING = {
+        # field: (dfi_signal, width, offset)
+        "cl":      ("address", 3,  0),
+        # FIXME: not enough bits in DFI to store all data
+        "nwr":     None,  # ("address", 3,  3),
+        "zout":    ("address", 4,  3),
+        "odt":     ("address", 3,  7),
+        "csr_fx":  ("address", 1, 10),
+        "odt_stb": ("bank",    1,  0),
+        "odt_pd":  ("bank",    1,  1),
+        "tm":      None,
+    }
+
+    @classmethod
+    def dfi_encode(cls, **kwargs):
+        address = 0
+        bank = 0
+        for field, encoding in cls.DFI_ENCODING.items():
+            if encoding is None:
+                continue
+            sig, width, offset = encoding
+            value = (kwargs[field] & (2**width - 1)) << offset
+            if sig == "address":
+                address |= value
+            elif sig == "bank":
+                bank |= value
+            else:
+                raise ValueError(sig)
+        return address, bank
+
+    def dfi_decode(self, dfi_phase):
+        r = []
+        for field, encoding in self.DFI_ENCODING.items():
+            if encoding is None:
+                continue
+            sig, width, offset = encoding
+            r += [getattr(self, field).eq(getattr(dfi_phase, sig)[offset:offset+width])]
+        return r
+
+
+class DFIAdapter(Module):
+    """Translate DFI commands into RPC parallel commands format (Request Packet)
+
+    Maps DFI commands to RPC parallel packet commands (sent over DB lines). Some commands cannot
+    be represented by cas_n/ras_n/we_n combinations, for that reason when reset_n=0, some DFI
+    commands are interpreted specially:
+    - ACT -> perform a RESET sequence
+    - MRS -> write UTR, utr_op and utr_en are encoded in phase.address (see `dfi_utr_encode`)
+    - ZQC -> will perform di_ferent types of ZQ calibration: "init" when auto_precharge=1,
+             "reset" if auto_precharge=0
+    """
+    ZQC_OP = {
+        "init":  0b00,  # calibration after initialization
+        "long":  0b01,
+        "short": 0b10,
+        "reset": 0b11,  # ZQ reset
+    }
+    REF_OP = {
+        "FST": 0b00,  # FST refresh: tREFi = 100ns
+        "LP":  0b00,  # LP refresh:  tREFi = 3.2us
+    }
+    UTR_OP = {  # Utility Register read pattern
+        "0101": 0b00,
+        "1100": 0b01,
+        "0011": 0b10,
+        "1010": 0b11,
+    }
+
+    SPECIAL_CMDS = {
+        "RESET":    "ACT",
+        "UTR":      "MRS",
+        "ZQC_INIT": "ZQC",
+    }
+
+    @classmethod
+    def dfi_utr_encode(cls, utr_op, utr_en):
+        if isinstance(utr_op, str):
+            utr_op = cls.UTR_OP[utr_op]
+        address = 0
+        address |= (utr_en &  0b1) << 0
+        address |= (utr_op & 0b11) << 1
+        return address
+
+    def __init__(self, phase):
+        self.db_p = Signal(16)  # on positive edge
+        self.db_n = Signal(16)  # on negative edge
+
+        self.cmd_valid = Signal()
+        self.do_reset  = Signal()  # force sending RESET command
+        self.bc        = Signal(6)  # burst count (bs+1 = number of 32-byte words in the transfer)
+        self.ref_op    = Signal(2)
+
+        # # #
+
+        self.phase_cmd = phase_cmd = Signal(3)
+        self.comb += phase_cmd.eq(Cat(phase.cas_n, phase.ras_n, phase.we_n))
+
+        def _cmd(cas, ras, we):
+            assert cas in [0, 1] and ras in [0, 1] and we in [0, 1]
+            return ((1 - cas) << 0) | ((1 - ras) << 1) | ((1 - we) << 2)
+
+        self.dfi_cmds = dfi_cmds = {
+            "NOP": _cmd(cas=0, ras=0, we=0),
+            "ACT": _cmd(cas=0, ras=1, we=0),
+            "RD":  _cmd(cas=1, ras=0, we=0),
+            "WR":  _cmd(cas=1, ras=0, we=1),
+            "PRE": _cmd(cas=0, ras=1, we=1),
+            "REF": _cmd(cas=1, ras=1, we=0),
+            "ZQC": _cmd(cas=0, ras=0, we=1),
+            "MRS": _cmd(cas=1, ras=1, we=1),
+        }
+
+        # precharge/refresh use a bank bitmask, so PRECHARGE ALL uses 0b1111
+        self.special_cmds = special_cmds = Signal()
+        self.utr_en       = utr_en       = phase.address[0]
+        utr_op         = phase.address[1:3]
+        bk             = Signal(4)
+        zqc_op         = Signal(2)
+        auto_precharge = Signal()
+        mr             = ModeRegister()
+
+        self.comb += mr.dfi_decode(phase)
+        self.comb += [
+            special_cmds.eq(~phase.reset_n),
+            auto_precharge.eq(phase.address[10]),
+            If(auto_precharge,
+                bk.eq(0b1111),
+            ).Else(  # binary to one-hot encoded
+                Case(phase.bank[:2], {i: bk.eq(1 << i) for i in range(4)}),
+            ),
+            If(special_cmds,
+                If(auto_precharge,
+                    zqc_op.eq(self.ZQC_OP["init"]),
+                ).Else(
+                    zqc_op.eq(self.ZQC_OP["reset"]),
+                )
+            ).Else(
+                If(auto_precharge,
+                    zqc_op.eq(self.ZQC_OP["long"]),
+                ).Else(
+                    zqc_op.eq(self.ZQC_OP["short"]),
+                )
+            ),
+        ]
+
+        cases = {
+            "NOP": [
+                self.db_p.eq(0),
+                self.db_n.eq(0),
+            ],
+            "ACT": [
+                self.db_p[0:2  +1].eq(0b101),
+                self.db_p[3:4  +1].eq(phase.bank[:2]),
+                self.db_n[0      ].eq(0),
+                self.db_n[1:12 +1].eq(phase.address[:12]),  # row address
+            ],
+            "RD": [
+                self.db_p[0:2   +1].eq(0b000),
+                self.db_p[3:4   +1].eq(phase.bank[:2]),
+                self.db_p[5:10  +1].eq(self.bc),
+                self.db_p[13:15 +1].eq(phase.address[4:6 +1]),
+                self.db_n[0       ].eq(0),
+                self.db_n[13:15 +1].eq(phase.address[7:9 +1]),
+            ],
+            "WR": [
+                self.db_p[0:2   +1].eq(0b001),
+                self.db_p[3:4   +1].eq(phase.bank[:2]),
+                self.db_p[5:10  +1].eq(self.bc),
+                self.db_p[13:15 +1].eq(phase.address[4:6 +1]),
+                self.db_n[0       ].eq(0),
+                self.db_n[13:15 +1].eq(phase.address[7:9 +1]),
+            ],
+            "PRE": [
+                self.db_p[6:9+1].eq(bk),
+                self.db_p[0:2+1].eq(0b100),
+                self.db_n[0    ].eq(0),
+            ],
+            "REF": [
+                self.db_p[6:9+1].eq(bk),
+                self.db_p[0:2+1].eq(0b110),
+                self.db_n[1:2+3].eq(self.ref_op),
+                self.db_n[0    ].eq(0),
+            ],
+            "ZQC": [
+                self.db_p[0:2  +1].eq(0b001),
+                self.db_p[14:15+1].eq(zqc_op),
+                self.db_n[0      ].eq(1),
+            ],
+            "MRS": [
+                self.db_p[0:2  +1].eq(0b010),
+                self.db_p[3:15 +1].eq(Cat(mr.cl, mr.nwr, mr.zout, mr.odt)),
+                self.db_n[0      ].eq(0),
+                self.db_n[12:15+1].eq(Cat(mr.odt_stb, mr.csr_fx, mr.odt_pd, mr.tm)),
+            ],
+            "UTR": [
+                self.db_p[0:2  +1].eq(0b111),
+                self.db_p[3      ].eq(utr_en),
+                self.db_p[4:5  +1].eq(utr_op),
+                self.db_n[0      ].eq(0),
+            ],
+            "RESET": [
+                self.db_p.eq(0),
+                self.db_n.eq(1),
+            ],
+        }
+
+        self.comb += [
+            If(self._is_cmd("RESET"),
+                cases["RESET"],
+                self.cmd_valid.eq(1),
+            ).Elif(self._is_cmd("UTR"),
+                cases["UTR"],
+                self.cmd_valid.eq(1),
+            ).Else(
+                self.cmd_valid.eq(~self._is_cmd("NOP")),
+                Case(phase_cmd, {dfi_cmds[cmd]: cases[cmd] for cmd in dfi_cmds.keys()}),
+            ),
+        ]
+
+    def _is_cmd(self, cmd):
+        if isinstance(cmd, list):
+            return reduce(or_, (self._is_cmd(c) for c in cmd))
+        if cmd in ["RESET", "UTR", "ZQC_INIT"]:
+            return self.special_cmds & (self.phase_cmd == self.dfi_cmds[self.SPECIAL_CMDS[cmd]])
+        return self.phase_cmd == self.dfi_cmds[cmd]
+
+    def is_cmd(self, cmd):
+        return self._is_cmd(cmd) & self.cmd_valid

--- a/litedram/phy/rpc/s7phy.py
+++ b/litedram/phy/rpc/s7phy.py
@@ -1,0 +1,259 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.soc.interconnect.csr import *
+
+from litedram.common import *
+from litedram.phy.dfi import *
+from litedram.phy.rpc.basephy import BasePHY, bitpattern
+
+# Xilinx Artix7 RPC PHY ----------------------------------------------------------------------------
+
+class A7RPCPHY(BasePHY):
+    def __init__(self, iodelay_clk_freq, **kwargs):
+        self._rdly_dq_rst = CSR()
+        self._rdly_dq_inc = CSR()
+
+        self._db_enabled = CSRStorage(reset=1)
+        self._dqs_enabled = CSRStorage(reset=1)
+
+        kwargs.update(dict(
+            write_ser_latency = 1,  # OSERDESE2 8:1 DDR (4 full-rate clocks)
+            read_des_latency  = 2,  # ISERDESE2 NETWORKING
+            phytype           = self.__class__.__name__,
+        ))
+
+        super().__init__(**kwargs)
+
+        self.settings.delays = 32
+        self.settings.read_leveling = True
+
+        self.iodelay_clk_freq = iodelay_clk_freq
+        iodelay_tap_average = {
+            200e6: 78e-12,
+            300e6: 52e-12,
+            400e6: 39e-12,  # Only valid for -3 and -2/2E speed grades
+        }
+        self.half_sys8x_taps = math.floor(self.tck/(4*iodelay_tap_average[iodelay_clk_freq]))
+
+    def do_clock_serialization(self, clk_1ck_out, clk_p, clk_n):
+        clk = Signal()
+        self.oserdese2_ddr(din=clk_1ck_out, dout=clk, clk="sys4x_180")
+        self.specials += Instance("OBUFDS",
+            i_I  = clk,
+            o_O  = clk_p,
+            o_OB = clk_n,
+        )
+
+    def do_stb_serialization(self, stb_1ck_out, stb):
+        stb_out        = Signal()
+        stb_in         = Signal()
+        stb_in_delayed = Signal()
+        stb_t          = Signal()
+
+        self.stb_1ck_in = stb_1ck_in = Signal.like(stb_1ck_out)
+
+        self.oserdese2_ddr(din=stb_1ck_out, dout=stb_out,
+                           tin=Constant(0), tout=stb_t,
+                           clk="sys4x_90")
+
+        # Read path
+        self.idelaye2(
+            din=stb_in, dout=stb_in_delayed,
+            rst=self.get_rst(0, self._rdly_dq_rst.re),
+            inc=self.get_inc(0, self._rdly_dq_inc.re),
+        )
+        self.iserdese2_ddr(din=stb_in_delayed, dout=stb_1ck_in, clk="sys4x_180")
+
+        self.specials += Instance("IOBUF",
+            i_I   = stb_out,
+            o_O   = stb_in,
+            i_T   = stb_t,
+            io_IO = stb,
+        )
+
+    def do_db_serialization(self, db_1ck_out, db_1ck_in, db_oe, db):
+        for i in range(self.databits):
+            db_out        = Signal()
+            db_t          = Signal()
+            db_in         = Signal()
+            db_in_delayed = Signal()
+
+            # Write path
+            self.oserdese2_ddr(
+                din=db_1ck_out[i], dout=db_out,
+                tin=~(db_oe & self._db_enabled.storage), tout=db_t,
+                clk="sys4x_90",
+            )
+
+            # Read path
+            self.idelaye2(
+                din=db_in, dout=db_in_delayed,
+                rst=self.get_rst(i//8, self._rdly_dq_rst.re),
+                inc=self.get_inc(i//8, self._rdly_dq_inc.re),
+            )
+            self.iserdese2_ddr(din=db_in_delayed, dout=db_1ck_in[i], clk="sys4x_180")
+
+            self.specials += Instance("IOBUF",
+                i_I   = db_out,
+                o_O   = db_in,
+                i_T   = db_t,
+                io_IO = db[i],
+            )
+
+    def do_dqs_serialization(self, dqs_1ck_out, dqs_1ck_in, dqs_oe, dqs_p, dqs_n):
+        for i in range(len(dqs_p)):
+            dqs_out  = Signal()
+            dqs_in   = Signal()
+            dqs_t    = Signal()
+            dqs_in_delayed  = Signal()
+
+            self.oserdese2_ddr(
+                clk="sys4x_180",
+                din=dqs_1ck_out, dout=dqs_out,
+                tin=~(dqs_oe & self._dqs_enabled.storage), tout=dqs_t,
+            )
+
+            # TODO: proper deserialization
+            if i == 0:
+                self.idelaye2(
+                    din=dqs_in, dout=dqs_in_delayed,
+                    rst=self.get_rst(i//8, self._rdly_dq_rst.re),
+                    inc=self.get_inc(i//8, self._rdly_dq_inc.re),
+                )
+                self.iserdese2_ddr(
+                    clk="sys4x_90",
+                    din=dqs_in_delayed, dout=dqs_1ck_in)
+
+            self.specials += Instance("IOBUFDS",
+                i_T    = dqs_t,
+                i_I    = dqs_out,
+                o_O    = dqs_in,
+                io_IO  = dqs_p[i],
+                io_IOB = dqs_n[i],
+            )
+
+    def do_cs_serialization(self, cs_n_1ck_out, cs_n):
+        self.oserdese2_ddr(din=cs_n_1ck_out, dout=cs_n, clk="sys4x_90")
+
+    def idelaye2(self, *, din, dout, init=0, rst=None, inc=None):
+        assert not ((rst is None) ^ (inc is None))
+        fixed = rst is None
+
+        params = dict(
+            p_SIGNAL_PATTERN        = "DATA",
+            p_DELAY_SRC             = "IDATAIN",
+            p_CINVCTRL_SEL          = "FALSE",
+            p_HIGH_PERFORMANCE_MODE = "TRUE",
+            p_REFCLK_FREQUENCY      = self.iodelay_clk_freq/1e6,
+            p_PIPE_SEL              = "FALSE",
+            p_IDELAY_VALUE          = init,
+            p_IDELAY_TYPE           = "FIXED",
+            i_IDATAIN  = din,
+            o_DATAOUT  = dout,
+        )
+
+        if not fixed:
+            params.update(dict(
+                p_IDELAY_TYPE  = "VARIABLE",
+                i_C        = ClockSignal(),
+                i_LD       = rst,
+                i_CE       = inc,
+                i_LDPIPEEN = 0,
+                i_INC      = 1,
+            ))
+
+        self.specials += Instance("IDELAYE2", **params)
+
+    def odelaye2(self, *, din, dout, init=0, rst=None, inc=None):  # Not available for Artix7
+        assert not ((rst is None) ^ (inc is None))
+        fixed = rst is not None
+
+        params = dict(
+            p_SIGNAL_PATTERN        = "DATA",
+            p_DELAY_SRC             = "ODATAIN",
+            p_CINVCTRL_SEL          = "FALSE",
+            p_HIGH_PERFORMANCE_MODE = "TRUE",
+            p_REFCLK_FREQUENCY      = self.iodelay_clk_freq/1e6,
+            p_PIPE_SEL              = "FALSE",
+            p_ODELAY_VALUE          = init,
+            p_ODELAY_TYPE           = "FIXED",
+            i_ODATAIN  = din,
+            o_DATAOUT  = dout,
+        )
+
+        if not fixed:
+            params.update(dict(
+                p_ODELAY_TYPE  = "VARIABLE",
+                i_C        = ClockSignal(),
+                i_LD       = rst,
+                i_CE       = inc,
+                i_LDPIPEEN = 0,
+                i_INC      = 1,
+            ))
+
+        self.specials += Instance("ODELAYE2", **params)
+
+    def oserdese2_ddr(self, *, din, dout, clk, tin=None, tout=None):
+        assert self.nphases == 4
+        assert not ((tin is None) ^ (tout is None))
+
+        params = dict(
+            p_SERDES_MODE    = "MASTER",
+            p_DATA_WIDTH     = 2*self.nphases,
+            p_TRISTATE_WIDTH = 1,
+            p_DATA_RATE_OQ   = "DDR",
+            p_DATA_RATE_TQ   = "BUF",
+            i_RST    = ResetSignal(),
+            i_CLK    = ClockSignal(clk),
+            i_CLKDIV = ClockSignal("sys"),
+            o_OQ     = dout,
+            i_OCE    = 1,
+        )
+
+        for i in range(2*self.nphases):
+            params["i_D{}".format(i+1)] = din[i]
+
+        if tin is not None:
+            # with DATA_RATE_TQ=BUF tristate is asynchronous, so we need to delay it
+            tin_d = Signal()
+            self.sync += tin_d.eq(tin)
+
+            # register it on the CLKDIV (as it would be too short for 180 deg shifted clk)
+            tin_cdc = Signal()
+            sd_clkdiv = getattr(self.sync, clk)
+            sd_clkdiv += tin_cdc.eq(tin_d)
+
+            params.update(dict(i_TCE=1, i_T1=tin_cdc, o_TQ=tout))
+
+        self.specials += Instance("OSERDESE2", **params)
+
+    def iserdese2_ddr(self, *, din, dout, clk):
+        assert self.nphases == 4
+
+        params = dict(
+            p_SERDES_MODE    = "MASTER",
+            p_INTERFACE_TYPE = "NETWORKING",  # TODO: try using MEMORY mode?
+            p_DATA_WIDTH     = 2*self.nphases,
+            p_DATA_RATE      = "DDR",
+            p_NUM_CE         = 1,
+            p_IOBDELAY       = "IFD",
+            i_RST     = ResetSignal(),
+            i_CLK     = ClockSignal(clk),
+            i_CLKB    = ~ClockSignal(clk),
+            i_CLKDIV  = ClockSignal("sys"),
+            i_BITSLIP = 0,
+            i_CE1     = 1,
+            i_DDLY    = din,
+        )
+
+        for i in range(2*self.nphases):
+            # invert order
+            params["o_Q{}".format(i+1)] = dout[(2*self.nphases - 1) - i]
+
+        self.specials += Instance("ISERDESE2", **params)

--- a/litedram/phy/rpc/simphy.py
+++ b/litedram/phy/rpc/simphy.py
@@ -1,0 +1,265 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.fhdl.specials import Tristate
+
+from litex.soc.interconnect.csr import CSR
+
+from litedram.phy.rpc.basephy import BasePHY
+
+
+class SimulationPHY(BasePHY):
+    def __init__(self, *args, generate_read_data=True, **kwargs):
+        kwargs.update(dict(
+            write_ser_latency = 1,
+            read_des_latency  = 0,
+            phytype           = "RPC" + self.__class__.__name__,
+        ))
+        super().__init__(*args, **kwargs)
+
+        self.generate_read_data = generate_read_data
+
+        # fake delays (make no nsense in simulation, but sdram.c expects them)
+        self.settings.read_leveling = True
+        self.settings.delays = 1
+        self._rdly_dq_rst = CSR()
+        self._rdly_dq_inc = CSR()
+
+        # For simulation purpose (serializers/deserializers)
+        self.sd_ddr_90  = getattr(self.sync, "sys4x_90_ddr")
+        self.sd_ddr_180 = getattr(self.sync, "sys4x_180_ddr")
+
+    def do_clock_serialization(self, clk_1ck_out, clk_p, clk_n):
+        ser = Serializer(self.sync, self.sd_ddr_180, clk_1ck_out, delay=1)
+        self.submodules += ser
+        self.comb += clk_p.eq(ser.o)
+        self.comb += clk_n.eq(~ser.o)
+
+    def do_stb_serialization(self, stb_1ck_out, stb):
+        ser = Serializer(self.sync, self.sd_ddr_90, stb_1ck_out, delay=1)
+        self.submodules += ser
+        self.comb += stb.eq(ser.o)
+
+    def do_dqs_serialization(self, dqs_1ck_out, dqs_1ck_in, dqs_oe, dqs_p, dqs_n):
+        # Delay dqs_oe by 1 cycle (Serializer latency) and register it on output domain
+        dqs_oe_d   = Signal()
+        dqs_oe_cdc = Signal()
+        self.sync += dqs_oe_d.eq(dqs_oe)
+        self.sync.sys4x_180 += dqs_oe_cdc.eq(dqs_oe_d)
+
+        for i in range(len(dqs_p)):
+            dqs_out = Signal()
+            dqs_in  = Signal()  # TODO: use it for reading
+
+            ser = Serializer(self.sync, self.sd_ddr_180, dqs_1ck_out, delay=1)
+            self.submodules += ser
+            self.comb += dqs_out.eq(ser.o)
+
+            if i == 0:
+                des = Deserializer(self.sd_ddr_180, dqs_in, dqs_1ck_in)
+                self.submodules += des
+
+            # self.specials += Tristate(dqs_p[i],  dqs_out, dqs_oe_cdc, dqs_in)
+            # self.specials += Tristate(dqs_n[i], ~dqs_out, dqs_oe_cdc)
+            self.comb += [
+                If(dqs_oe_cdc,
+                    dqs_p[i].eq(dqs_out),
+                    dqs_n[i].eq(~dqs_out),
+                ),
+                dqs_in.eq(dqs_p[i]),
+            ]
+
+    def do_db_serialization(self, db_1ck_out, db_1ck_in, db_oe, db):
+        if self.generate_read_data:
+            # Dummy read data generator for simulation purpose
+            dq_in_dummy = Signal(self.databits)
+            gen = DummyReadGenerator(dq_in=db, dq_out=dq_in_dummy, stb_in=self.pads.stb,
+                                     cl=self.settings.cl)
+            self.submodules += ClockDomainsRenamer({"sys": "sys4x_180_ddr"})(gen)
+
+        # Delay db_oe by 1 cycle (Serializer latency) and register it on output domain
+        db_oe_d   = Signal()
+        db_oe_cdc = Signal()
+        self.sync += db_oe_d.eq(db_oe)
+        self.sync.sys4x_90 += db_oe_cdc.eq(db_oe_d)
+
+        for i in range(self.databits):
+            # To/from tristate
+            dq_out = Signal()
+            dq_in = Signal()
+
+            ser = Serializer(self.sync, self.sd_ddr_90, db_1ck_out[i], delay=1)
+            self.submodules += ser
+            self.comb += dq_out.eq(ser.o)
+
+            # Use sd_ddr_90 in simulation, in general leveling would be needed.
+            if self.generate_read_data:
+                des = Deserializer(self.sd_ddr_90, dq_in_dummy[i], db_1ck_in[i])
+            else:
+                des = Deserializer(self.sd_ddr_90, dq_in, db_1ck_in[i])
+            self.submodules += des
+
+            # self.specials += Tristate(db[i], dq_out, db_oe_cdc, dq_in)
+            self.comb += [
+                If(db_oe_cdc, db[i].eq(dq_out)),
+                dq_in.eq(db[i]),
+            ]
+
+    def do_cs_serialization(self, cs_n_1ck_out, cs_n):
+        ser = Serializer(self.sync, self.sd_ddr_90, cs_n_1ck_out, delay=1)
+        self.submodules += ser
+        self.comb += cs_n.eq(ser.o)
+
+# Simulation of READ ouput -------------------------------------------------------------------------
+
+class DummyReadGenerator(Module):
+    def __init__(self, stb_in, dq_in, dq_out, cl):
+        # self.sync should be a 4x DDR clock phase-aligned with CLK
+
+        data_counter = Signal(max=16)
+        cmd_counter = Signal(max=16)
+        # count STB zeros, 2 full-rate cycles (4 DDR) mean STB preamble, but more mean RESET
+        stb_zero_counter = Signal(max=4 + 2)
+        self.sync += \
+            If(stb_in == 0,
+                If(stb_zero_counter != 2**len(stb_zero_counter) - 1,
+                    stb_zero_counter.eq(stb_zero_counter + 1)
+                )
+            ).Else(
+                stb_zero_counter.eq(0)
+            )
+
+        # Because the generator clock domain is phase shifted in relation to DB, we have to
+        # register the value to hold it until the end of our clock, so that we get correct FSM
+        # transitions
+        # FIXME: would cause problems if clocks were aligned
+        dq_in_r = Signal.like(dq_in)
+        self.sync += dq_in_r.eq(dq_in)
+
+        # generate DQS just for viewing signal dump
+        dqs_out = Signal()
+        dqs_oe  = Signal()
+
+        data = Array([
+            0x0000,  # 0x0110,
+            0x1111,  # 0x1221,
+            0x2222,  # 0x2332,
+            0x3333,  # 0x3443,
+            0x4444,  # 0x4554,
+            0x5555,  # 0x5665,
+            0x6666,  # 0x6776,
+            0x7777,  # 0x7887,
+            0x8888,  # 0x8998,
+            0x9999,  # 0x9aa9,
+            0xaaaa,  # 0xabba,
+            0xbbbb,  # 0xbccb,
+            0xcccc,  # 0xcddc,
+            0xdddd,  # 0xdeed,
+            0xeeee,  # 0xeffe,
+            0xffff,  # 0xf00f,
+        ])
+
+        self.submodules.fsm = fsm = FSM()
+        fsm.act("IDLE",
+            NextValue(data_counter, 0),
+            If(stb_zero_counter == 4,
+                NextState("CHECK_CMD_P")
+            )
+        )
+        fsm.act("CHECK_CMD_P",
+            If(dq_in_r[:3] == 0,
+                NextState("CHECK_CMD_N")
+            ).Else(
+                NextState("IDLE")
+            )
+        )
+        fsm.act("CHECK_CMD_N",
+            If(dq_in_r[0] == 0,
+                NextState("CL_WAIT")
+            ).Else(
+                NextState("IDLE")
+            )
+        )
+        # 2x for DDR, -1 for CHECK_CMD_*, -2 for preamble
+        fsm.delayed_enter("CL_WAIT", "PREAMBLE_P", 2*(cl - 1) - 2)
+        fsm.act("PREAMBLE_P",
+            dqs_oe.eq(1),
+            dqs_out.eq(0),
+            NextState("PREAMBLE_N")
+        )
+        fsm.act("PREAMBLE_N",
+            dqs_oe.eq(1),
+            dqs_out.eq(0),
+            NextState("SEND_DATA")
+        )
+        fsm.act("SEND_DATA",
+            dqs_oe.eq(1),
+            dqs_out.eq(data_counter[0] == 0),
+            dq_out.eq(data[data_counter + cmd_counter]),
+            NextValue(data_counter, data_counter + 1),
+            If(data_counter == 16 - 1,
+                NextValue(cmd_counter, cmd_counter + 1),
+                NextState("IDLE")
+            )
+        )
+
+# I/O Primitives -----------------------------------------------------------------------------------
+
+class Serializer(Module):
+    """Serialize input signals into one output with 1 sd_clk clock latency"""
+    def __init__(self, sd_clk, sd_clkdiv, inputs, reset=0, name=None, delay=0):
+        # `delay` must be used to get correct data_cntr=0 for phase delayed signals
+        assert(len(inputs) > 0)
+        assert(len(s) == len(inputs[0]) for s in inputs)
+
+        data_width = len(inputs)
+        signal_width = len(inputs[0])
+        cntr_max = 2 * data_width
+
+        if not isinstance(inputs, Array):
+            inputs = Array(inputs)
+
+        self.o = Signal(signal_width)
+        data_cntr = Signal(max=cntr_max, name=name, reset=(0 - delay) % cntr_max)
+        sd_clkdiv += If(reset, data_cntr.eq(0)).Else(data_cntr.eq(data_cntr+1))
+
+        # If we used inputs combinatorically, then we will have a problem when the serialization
+        # clock is not phase-aligned with the `inputs` clock, e.g.
+        #  inputs clk 1:      | 0 : 1 : 2 : 3 | 4 : 5 : 6 : 7 |
+        #  serialized 90 deg:   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+        # Here input 3 becomes invalid before serialized output moves to 4, so it would actually
+        # send 3 for the 1st half and 7 for the 2nd half. To avoid this we introduce 1 clock
+        # latency of the inputs and use 2 registers to hold the values of subsequent inputs.
+        inputs_cnt = Signal()
+        inputs_d   = Array([Signal.like(i) for i in [*inputs, *inputs]])
+        sd_clk += [
+            inputs_cnt.eq(inputs_cnt + 1),
+            Case(inputs_cnt, {
+                0: [i_d.eq(i) for i_d, i in zip(inputs_d[data_width:], inputs)],
+                1: [i_d.eq(i) for i_d, i in zip(inputs_d[:data_width], inputs)],
+            })
+        ]
+
+        self.comb += self.o.eq(inputs_d[data_cntr])
+
+
+class Deserializer(Module):
+    """Deserialize an input signal into outputs in the `sd` clock domain"""
+    def __init__(self, sd, input, outputs, reset=0, name=None):
+        assert(len(outputs) > 0)
+        assert(len(s) == len(outputs[0]) for s in outputs)
+        assert(len(outputs[0]) == len(input))
+
+        data_width = len(outputs)
+        signal_width = len(outputs[0])
+
+        if not isinstance(outputs, Array):
+            outputs = Array(outputs)
+
+        data_cntr = Signal(log2_int(data_width), name=name)
+        sd += If(reset, data_cntr.eq(0)).Else(data_cntr.eq(data_cntr+1))
+        sd += outputs[data_cntr].eq(input)

--- a/litedram/phy/rpc/simsoc.py
+++ b/litedram/phy/rpc/simsoc.py
@@ -1,0 +1,356 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2020-2021 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import argparse
+
+from migen import *
+
+from litex.build.generic_platform import *
+from litex.build.sim import SimPlatform
+from litex.build.sim.config import SimConfig
+
+from litex.soc.integration.common import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.integration.soc import *
+from litex.soc.cores.bitbang import *
+from litex.soc.cores.cpu import CPUS
+
+from litedram.gen import LiteDRAMCoreControl
+from litedram.modules import EM6GA16L
+from litedram.core.controller import ControllerSettings
+from litedram.phy.rpc.simphy import SimulationPHY
+
+# Platform -----------------------------------------------------------------------------------------
+
+_io = [
+    # clocks added later
+    ("sys_rst", 0, Pins(1)),
+
+    ("serial", 0,
+        Subsignal("source_valid", Pins(1)),
+        Subsignal("source_ready", Pins(1)),
+        Subsignal("source_data",  Pins(8)),
+        Subsignal("sink_valid",   Pins(1)),
+        Subsignal("sink_ready",   Pins(1)),
+        Subsignal("sink_data",    Pins(8)),
+    ),
+
+    # RPC pads
+    ("rpcdram", 0,
+        Subsignal("clk_p", Pins(1)),
+        Subsignal("clk_n", Pins(1)),
+        Subsignal("cs_n",  Pins(1)),
+        Subsignal("dqs_p", Pins(1)),
+        Subsignal("dqs_n", Pins(1)),
+        Subsignal("stb",   Pins(1)),
+        Subsignal("db",    Pins(16)),
+    ),
+]
+
+class Platform(SimPlatform):
+    def __init__(self):
+        print('_io', end=' = '); __import__('pprint').pprint(_io)
+        SimPlatform.__init__(self, "SIM", _io)
+
+# DFI PHY model settings ---------------------------------------------------------------------------
+
+sdram_module_nphases = {
+    "SDR":   1,
+    "DDR":   2,
+    "LPDDR": 2,
+    "DDR2":  2,
+    "DDR3":  4,
+    "RPC":   4,
+    "DDR4":  4,
+}
+
+def get_sdram_phy_settings(memtype, data_width, clk_freq):
+    nphases = sdram_module_nphases[memtype]
+    assert memtype == "DDR3"
+
+    # Settings from s7ddrphy
+    tck                 = 2/(2*nphases*clk_freq)
+    cmd_latency         = 0
+    cl, cwl             = get_cl_cw(memtype, tck)
+    cl_sys_latency      = get_sys_latency(nphases, cl)
+    cwl                 = cwl + cmd_latency
+    cwl_sys_latency     = get_sys_latency(nphases, cwl)
+    rdcmdphase, rdphase = get_sys_phases(nphases, cl_sys_latency, cl)
+    wrcmdphase, wrphase = get_sys_phases(nphases, cwl_sys_latency, cwl)
+    read_latency        = 2 + cl_sys_latency + 2 + 3
+    write_latency       = cwl_sys_latency
+
+    sdram_phy_settings = {
+        "nphases":       nphases,
+        "rdphase":       rdphase,
+        "wrphase":       wrphase,
+        "rdcmdphase":    rdcmdphase,
+        "wrcmdphase":    wrcmdphase,
+        "cl":            cl,
+        "cwl":           cwl,
+        "read_latency":  read_latency,
+        "write_latency": write_latency,
+    }
+
+    return PhySettings(
+        phytype      = "SDRAMPHYModel",
+        memtype      = memtype,
+        databits     = data_width,
+        dfi_databits = data_width if memtype == "SDR" else 2*data_width,
+        **sdram_phy_settings,
+    )
+
+# Clocks -------------------------------------------------------------------------------------------
+
+class Clocks(dict):
+    # FORMAT: {name: {"freq_hz": _, "phase_deg": _}, ...}
+    def names(self):
+        return list(self.keys())
+
+    def add_io(self, io):
+        for name in self.names():
+            print((name + "_clk", 0, Pins(1)))
+            io.append((name + "_clk", 0, Pins(1)))
+
+    def add_clockers(self, sim_config):
+        for name, desc in self.items():
+            sim_config.add_clocker(name + "_clk", **desc)
+
+class _CRG(Module):
+    def __init__(self, platform, domains=None):
+        if domains is None:
+            domains = ["sys"]
+        # request() before clreating domains to avoid signal renaming problem
+        domains = {name: platform.request(name + "_clk") for name in domains}
+
+        self.clock_domains.cd_por = ClockDomain(reset_less=True)
+        for name in domains.keys():
+            setattr(self.clock_domains, "cd_" + name, ClockDomain(name=name))
+
+        int_rst = Signal(reset=1)
+        self.sync.por += int_rst.eq(0)
+        self.comb += self.cd_por.clk.eq(self.cd_sys.clk)
+
+        for name, clk in domains.items():
+            cd = getattr(self, "cd_" + name)
+            self.comb += cd.clk.eq(clk)
+            self.comb += cd.rst.eq(int_rst)
+
+# Simulation SoC -----------------------------------------------------------------------------------
+
+class SimSoC(SoCCore):
+    def __init__(self, clocks, trace_reset=1, auto_precharge=False, with_refresh=True, **kwargs):
+        platform     = Platform()
+        sys_clk_freq = clocks["sys"]["freq_hz"]
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCCore.__init__(self, platform, clk_freq=sys_clk_freq,
+            ident         = "LiteX Simulation",
+            ident_version = True,
+            cpu_variant   = "lite",
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, clocks.names())
+
+        # Debugging --------------------------------------------------------------------------------
+        platform.add_debug(self, reset=trace_reset)
+
+        # RPC DRAM ---------------------------------------------------------------------------------
+        sdram_module = EM6GA16L(sys_clk_freq, "1:4")
+        pads = platform.request("rpcdram")
+        self.submodules.ddrphy = SimulationPHY(pads, sys_clk_freq=sys_clk_freq, generate_read_data=True)
+        self.add_csr("ddrphy")
+
+        controller_settings = ControllerSettings()
+        controller_settings.auto_precharge = auto_precharge
+        controller_settings.with_refresh = with_refresh
+
+        self.add_sdram("sdram",
+            phy                     = self.ddrphy,
+            module                  = sdram_module,
+            origin                  = self.mem_map["main_ram"],
+            size                    = kwargs.get("max_sdram_size", 0x40000000),
+            l2_cache_size           = kwargs.get("l2_size", 8192),
+            l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+            l2_cache_reverse        = False,
+            controller_settings     = controller_settings
+        )
+        # Reduce memtest size for simulation speedup
+        self.add_constant("MEMTEST_DATA_SIZE", 8*1024)
+        self.add_constant("MEMTEST_ADDR_SIZE", 8*1024)
+
+        self.add_constant("CONFIG_SIM_DISABLE_BIOS_PROMPT")
+        # self.add_constant("CONFIG_DISABLE_DELAYS")
+
+        self.submodules.ddrctrl = LiteDRAMCoreControl()
+        self.add_csr("ddrctrl")
+        self.sync += If(self.ddrctrl.init_done.storage, Finish())
+
+        # Print info
+        def dump(obj):
+            print()
+            print(" " + obj.__class__.__name__)
+            print(" " + "-" * len(obj.__class__.__name__))
+            d = obj if isinstance(obj, dict) else vars(obj)
+            for var, val in d.items():
+                if var == "self":
+                    continue
+                print("  {}: {}".format(var, val))
+        print("=" * 80)
+        dump(clocks)
+        dump(self.ddrphy.settings)
+        dump(sdram_module.geom_settings)
+        dump(sdram_module.timing_settings)
+        print()
+        print("=" * 80)
+
+# Build --------------------------------------------------------------------------------------------
+
+def generate_gtkw_savefile(builder, vns, trace_fst):
+    from litex.build.sim import gtkwave as gtkw
+
+    dumpfile = os.path.join(builder.gateware_dir, "sim.{}".format("fst" if trace_fst else "vcd"))
+    savefile = os.path.join(builder.gateware_dir, "sim.gtkw")
+    soc = builder.soc
+    rdphase = soc.sdram.controller.settings.phy.rdphase
+    wrphase = soc.sdram.controller.settings.phy.wrphase
+
+    with gtkw.GTKWSave(vns, savefile=savefile, dumpfile=dumpfile) as save:
+        save.clocks()
+        save.add(soc.bus.slaves["main_ram"], mappers=[gtkw.wishbone_sorter(), gtkw.wishbone_colorer()])
+        save.fsm_states(soc)
+        # all dfi signals
+        save.add(soc.ddrphy.dfi, mappers=[gtkw.dfi_sorter(), gtkw.dfi_in_phase_colorer()])
+        # each phase in separate group
+        with save.gtkw.group("dfi phaseX", closed=True):
+            for i, phase in enumerate(soc.ddrphy.dfi.phases):
+                save.add(phase, group_name="dfi p{}".format(i), mappers=[
+                    gtkw.dfi_sorter(phases=False),
+                    gtkw.dfi_in_phase_colorer(),
+                ])
+        # only dfi command signals
+        save.add(soc.ddrphy.dfi, group_name="dfi commands", mappers=[
+            gtkw.regex_filter(gtkw.suffixes2re(["cas_n", "ras_n", "we_n"])),
+            gtkw.dfi_sorter(),
+            gtkw.dfi_per_phase_colorer(),
+        ])
+        # only dfi data signals
+        save.add(soc.ddrphy.dfi, group_name="dfi wrdata", mappers=[
+            gtkw.regex_filter(["wrdata$", f"p{wrphase}.*wrdata_en$"]),
+            gtkw.dfi_sorter(),
+            gtkw.dfi_per_phase_colorer(),
+        ])
+        save.add(soc.ddrphy.dfi, group_name="dfi wrdata_mask", mappers=[
+            gtkw.regex_filter(gtkw.suffixes2re(["wrdata_mask"])),
+            gtkw.dfi_sorter(),
+            gtkw.dfi_per_phase_colorer(),
+        ])
+        save.add(soc.ddrphy.dfi, group_name="dfi rddata", mappers=[
+            gtkw.regex_filter(gtkw.suffixes2re(["rddata", f"p{rdphase}.*rddata_valid"])),
+            gtkw.dfi_sorter(),
+            gtkw.dfi_per_phase_colorer(),
+        ])
+        # dram pads
+        save.group([s for s in vars(soc.ddrphy.pads).values() if isinstance(s, Signal)],
+            group_name = "pads",
+            mappers = [
+                gtkw.regex_filter(gtkw.suffixes2re(["dqs_n", "clk_n"]), negate=True),
+                gtkw.regex_sorter(["clk", "cs", "stb", "db", "dqs"]),
+                gtkw.regex_colorer({
+                    "yellow": gtkw.suffixes2re(["cs"]),
+                    "orange": gtkw.suffixes2re(["db", "dqs"]),
+                    "red": gtkw.suffixes2re(["stb"]),
+                }),
+            ],
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generic LiteX SoC Simulation")
+    builder_args(parser)
+    soc_core_args(parser)
+    parser.add_argument("--threads",         default=1,           help="Set number of threads (default=1)")
+    parser.add_argument("--rom-init",        default=None,        help="rom_init file")
+    parser.add_argument("--sdram-init",      default=None,        help="SDRAM init file")
+    parser.add_argument("--sdram-verbosity", default=0,           help="Set SDRAM checker verbosity")
+    parser.add_argument("--trace",           action="store_true", help="Enable Tracing")
+    parser.add_argument("--trace-fst",       action="store_true", help="Enable FST tracing (default=VCD)")
+    parser.add_argument("--trace-start",     default=0,           help="Cycle to start tracing")
+    parser.add_argument("--trace-end",       default=-1,          help="Cycle to end tracing")
+    parser.add_argument("--trace-reset",     default=1,           help="Tracing state at start")
+    parser.add_argument("--opt-level",       default="O3",        help="Compilation optimization level")
+    parser.add_argument("--sys-clk-freq",    default="100e6",     help="Core clock frequency")
+    parser.add_argument("--auto-precharge",  action="store_true", help="Use DRAM auto precharge")
+    parser.add_argument("--no-refresh",      action="store_true", help="Disable DRAM refresher")
+    parser.add_argument("--gtkw-savefile",   action="store_true", help="Generate GTKWSave savefile")
+    args = parser.parse_args()
+
+    soc_kwargs     = soc_core_argdict(args)
+    builder_kwargs = builder_argdict(args)
+
+    sys_clk_freq = int(float(args.sys_clk_freq))
+    clocks = Clocks({
+        "sys":           dict(freq_hz=sys_clk_freq),
+        "sys2x":         dict(freq_hz=2*sys_clk_freq),
+        "sys4x":         dict(freq_hz=4*sys_clk_freq),
+        "sys4x_90":      dict(freq_hz=4*sys_clk_freq, phase_deg=90),
+        "sys4x_180":     dict(freq_hz=4*sys_clk_freq, phase_deg=180),
+        "sys4x_90_ddr":  dict(freq_hz=2*4*sys_clk_freq, phase_deg=2*90),
+        "sys4x_180_ddr": dict(freq_hz=2*4*sys_clk_freq, phase_deg=(2*180)%360),
+    })
+
+    clocks.add_io(_io)
+
+    sim_config = SimConfig()
+    clocks.add_clockers(sim_config)
+
+    # Configuration --------------------------------------------------------------------------------
+
+    cpu = CPUS[soc_kwargs.get("cpu_type", "vexriscv")]
+    if soc_kwargs["uart_name"] == "serial":
+        soc_kwargs["uart_name"] = "sim"
+        sim_config.add_module("serial2console", "serial")
+    if args.rom_init:
+        soc_kwargs["integrated_rom_init"] = get_mem_data(args.rom_init, cpu.endianness)
+    args.with_sdram = True
+    soc_kwargs["integrated_main_ram_size"] = 0x0
+    soc_kwargs["sdram_verbosity"]          = int(args.sdram_verbosity)
+
+    # SoC ------------------------------------------------------------------------------------------
+    soc = SimSoC(
+        clocks         = clocks,
+        trace_reset    = args.trace_reset,
+        auto_precharge = args.auto_precharge,
+        with_refresh   = not args.no_refresh,
+        sdram_init     = [] if args.sdram_init is None else get_mem_data(args.sdram_init, cpu.endianness),
+        l2_size        = args.l2_size,
+        **soc_kwargs)
+
+    # Build/Run ------------------------------------------------------------------------------------
+    builder_kwargs["csr_csv"] = "csr.csv"
+    builder = Builder(soc, **builder_kwargs)
+    vns = builder.build(run=False, threads=args.threads, sim_config=sim_config,
+        opt_level   = args.opt_level,
+        trace       = args.trace,
+        trace_fst   = args.trace_fst,
+        trace_start = int(args.trace_start),
+        trace_end   = int(args.trace_end))
+
+    if args.gtkw_savefile:
+        generate_gtkw_savefile(builder, vns, trace_fst=args.trace_fst)
+
+    builder.build(build=False, threads=args.threads, sim_config=sim_config,
+        opt_level   = args.opt_level,
+        trace       = args.trace,
+        trace_fst   = args.trace,
+        trace_start = int(args.trace_start),
+        trace_end   = int(args.trace_end)
+    )
+
+if __name__ == "__main__":
+    main()

--- a/test/common.py
+++ b/test/common.py
@@ -566,6 +566,17 @@ class MemoryTestDataMixin:
                     0x0000000000000000000000000000000000000000000000000000000000000000,  # 0x60
                 ]
             ),
+            "8bit_to_256bit":  dict(
+                #       address, data
+                pattern=[(i, 0x10 + i) for i in range(128)],
+                expected=[
+                    # data, address
+                    0x2f2e2d2c2b2a292827262524232221201f1e1d1c1b1a19181716151413121110,  # 0x00
+                    0x4f4e4d4c4b4a494847464544434241403f3e3d3c3b3a39383736353433323130,  # 0x20
+                    0x6f6e6d6c6b6a696867666564636261605f5e5d5c5b5a59585756555453525150,  # 0x40
+                    0x8f8e8d8c8b8a898887868584838281807f7e7d7c7b7a79787776757473727170,  # 0x60
+                ]
+            ),
             "32bit_to_256bit_not_aligned":  dict(
                 pattern=[
                     # address, data
@@ -689,6 +700,10 @@ class MemoryTestDataMixin:
         data["32bit_to_64bit"] = dict(
             pattern  = data["32bit_to_128bit"]["pattern"].copy(),
             expected = half_width(data["32bit_to_128bit"]["expected"], from_width=128),
+        )
+        data["8bit_to_128bit"] = dict(
+            pattern  = data["8bit_to_256bit"]["pattern"].copy(),
+            expected = half_width(data["8bit_to_256bit"]["expected"], from_width=256),
         )
 
         return data

--- a/test/test_adaptation.py
+++ b/test/test_adaptation.py
@@ -118,7 +118,7 @@ class TestAdapter(MemoryTestDataMixin, unittest.TestCase):
             dut.memory.read_handler(dut.read_crossbar_port),
             timeout_generator(1000),
         ]
-        run_simulation(dut, generators, vcd_name='sim.vcd')
+        run_simulation(dut, generators)
         self.assertEqual(dut.memory.mem, mem_expected)
         self.assertEqual(dut.read_driver.rdata, [data for adr, data in pattern])
 
@@ -157,6 +157,14 @@ class TestAdapter(MemoryTestDataMixin, unittest.TestCase):
     def test_converter_1to8(self):
         # Verify 32-bit to 256-bit up-conversion.
         self.converter_test(test_data="32bit_to_256bit", user_data_width=32, native_data_width=256)
+
+    def test_converter_1to16(self):
+        # Verify 32-bit to 256-bit up-conversion.
+        self.converter_test(test_data="8bit_to_128bit", user_data_width=8, native_data_width=128)
+
+    def test_converter_1to32(self):
+        # Verify 32-bit to 256-bit up-conversion.
+        self.converter_test(test_data="8bit_to_256bit", user_data_width=8, native_data_width=256)
 
     def test_up_converter_read_latencies(self):
         # Verify that up-conversion works with different port reader latencies

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -93,6 +93,20 @@ class TestWishbone(MemoryTestDataMixin, unittest.TestCase):
         port = LiteDRAMNativePort("both", address_width=30, data_width=64)
         self.wishbone_readback_test(data["pattern"], data["expected"], wb, port)
 
+    def test_wishbone_32bit_to_128bit(self):
+        # Verify Wishbone with 32-bit data width up-converted to 128-bit data width.
+        data = self.pattern_test_data["32bit_to_128bit"]
+        wb   = wishbone.Interface(adr_width=30, data_width=32)
+        port = LiteDRAMNativePort("both", address_width=30, data_width=128)
+        self.wishbone_readback_test(data["pattern"], data["expected"], wb, port)
+
+    def test_wishbone_32bit_to_256bit(self):
+        # Verify Wishbone with 32-bit data width up-converted to 128-bit data width.
+        data = self.pattern_test_data["32bit_to_256bit"]
+        wb   = wishbone.Interface(adr_width=30, data_width=32)
+        port = LiteDRAMNativePort("both", address_width=30, data_width=256)
+        self.wishbone_readback_test(data["pattern"], data["expected"], wb, port)
+
     def test_wishbone_32bit_base_address(self):
         # Verify Wishbone with 32-bit data width and non-zero base address.
         data   = self.pattern_test_data["32bit"]


### PR DESCRIPTION
This PR adds a PHY for Etron RPC DRAM. The code directory structure resembles the one used for LPDDR4/LPDDR5.  The RPC PHY was actually the first of these PHYs and there are some design choices that could potentially be revised, applying the modifications from LPDDR4/5. Currently the PHY has some limitations, but it is functional and we were able to successfully use it on a modified Arty A7 board, although we were not able to reach the default Arty frequency due to hardware limitations. The current state of the PHY is described in more details in the readme under `litedram/phy/rpc/README.md`. 