### PR TITLE
Add AS4C128M16 DDR3L-1600 ram

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -618,6 +618,18 @@ class P3R1GE4JGF(DDR2Module):
 class DDR3Module(SDRAMModule):                     memtype = "DDR3"
 class DDR3RegisteredModule(SDRAMRegisteredModule): memtype = "DDR3"
 
+class AS4C128M16(DDR3Module):
+    # geometry
+    nbanks = 8
+    nrows  = 16384
+    ncols  = 1024
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 6), tZQCS=(64, 80))
+    speedgrade_timings = {
+        "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=13.75, tRFC=(160, None), tFAW=(None, 40), tRAS=35),
+    }
+    speedgrade_timings["default"] = speedgrade_timings["1600"]
+
 class MT41K64M16(DDR3Module):
     # geometry
     nbanks = 8


### PR DESCRIPTION
Add the AS4C128M16 DDR3L-1600 ram used on the Alchitry Au(+)

The tRFC timing is slightly worse than the MT41J128M16 which is already in litedram

Datasheet: https://www.alliancememory.com/wp-content/uploads/pdf/ddr3/Alliance%20Memory_2G%20128Mx16%20AS4C128M16D3LB-12BCN%20v1.0%20March%202016.pdf