### PR TITLE
litedram_gen: Fix duplicate with_uart value when cpu_type is None.

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -481,7 +481,6 @@ class LiteDRAMCore(SoCCore):
         if cpu_type is None:
             kwargs["integrated_rom_size"]  = 0
             kwargs["integrated_sram_size"] = 0
-            kwargs["with_uart"]            = False
             kwargs["with_timer"]           = False
             kwargs["with_ctrl"]            = False
 


### PR DESCRIPTION
Otherwise, the `with_uart` argument is provided twice, which gives the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/jf/src/litex/litedram/litedram/gen.py", line 825, in <module>
    main()
  File "/home/jf/src/litex/litedram/litedram/gen.py", line 812, in main
    soc     = LiteDRAMCore(platform, core_config, integrated_rom_size=0x8000)
  File "/home/jf/src/litex/litedram/litedram/gen.py", line 489, in __init__
    SoCCore.__init__(self, platform, sys_clk_freq,
TypeError: litex.soc.integration.soc_core.SoCCore.__init__() got multiple values for keyword argument 'with_uart'
```