### PR TITLE
frontend/fifo.py: The fifo_depth was being set incorrectly.

### DIFF
--- a/litedram/frontend/fifo.py
+++ b/litedram/frontend/fifo.py
@@ -226,7 +226,7 @@ class LiteDRAMFIFO(Module):
         if not with_bypass:
             assert data_width_ratio == 1
         fifo_base       = int(base/(port_data_width/8))
-        fifo_depth      = int(depth/(port_data_width/8))
+        fifo_depth      = int(depth/data_width_ratio)
         pre_fifo_depth  = max( pre_fifo_depth, 2*data_width_ratio)
         post_fifo_depth = max(post_fifo_depth, 2*data_width_ratio)
 


### PR DESCRIPTION
@enjoy-digital I believe the delayed write to FIFO test passes, because the write function waits for the FIFO sink to be valid (?) I didn't look into the test very deeply, but I can if you need me to.