### PR TITLE
W9825G6KH6 seems to use 8192 refresh cycles not 8000

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -541,7 +541,7 @@ class W9825G6KH6(SDRModule):
     nrows  = 8192
     ncols  = 512
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8000, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 10))
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 10))
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 60), tFAW=None, tRAS=42)}
 
 # DDR ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/148607/140591902-b87f0370-6409-42c6-b806-2294f0945bab.png)
I am not sure what they mean by 8K refresh cycles.
I assumed it is 8000 not 8192, but the datasheet does not make it clear anywhere else.
This part suggests it is 8192:
![image](https://user-images.githubusercontent.com/148607/140591978-44c2150a-3d42-4be6-959d-9e6fbd61ba06.png)
