### PR TITLE
litedram_gen: Don't block user port with no CPU

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -655,7 +655,13 @@ class LiteDRAMCore(SoCCore):
 
         # User ports -------------------------------------------------------------------------------
         user_enable = Signal()
-        self.sync += user_enable.eq(self.ddrctrl.init_done.storage & ~self.ddrctrl.init_error.storage)
+        if cpu_type is not None:
+            # block user port access until ready
+            self.sync += user_enable.eq(self.ddrctrl.init_done.storage & ~self.ddrctrl.init_error.storage)
+        else:
+            # memtest without CPU uses the user port, so don't block
+            self.comb += user_enable.eq(1)
+
         self.comb += [
             platform.request("user_clk").eq(ClockSignal()),
             platform.request("user_rst").eq(ResetSignal()),


### PR DESCRIPTION
Change e52ece0b8a7 blocks access to user ports prior to dram init.
As noted in https://github.com/enjoy-digital/litedram/pull/286#issuecomment-981362385 this is a problem for cpu-less designs, since the initial memtest requires the user port.

Instead enable the user port unconditionally in that case.