### PR TITLE
Added AS4C4M16 for Arduino MKR Vidor 4000 support

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -490,6 +490,15 @@ class MT48LC32M8(SDRModule):
     technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 15))
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=20, tRCD=20, tWR=15, tRFC=(None, 66), tFAW=None, tRAS=44)}
 
+class AS4C4M16(SDRModule):
+    # geometry
+    nbanks = 4
+    nrows  = 4096
+    ncols  = 256
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/4096, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 14))
+    speedgrade_timings = {"default": _SpeedgradeTimings(tRP=22, tRCD=21, tWR=20, tRFC=(None, 63), tFAW=None, tRAS=42)}
+
 class AS4C16M16(SDRModule):
     # geometry
     nbanks = 4


### PR DESCRIPTION
Based off of https://www.alliancememory.com/wp-content/uploads/pdf/dram/64M-AS4C4M16SA-CI_v3.0_March%202015.pdf and confirmed working on a single device. 