### PR TITLE
Add MT46H128M16 and change bankmaschine to not use A10 for col addresses.

### DIFF
--- a/litedram/core/bankmachine.py
+++ b/litedram/core/bankmachine.py
@@ -34,7 +34,10 @@ class _AddressSlicer:
 
     def col(self, address):
         split = self.colbits - self.address_align
-        return Cat(Replicate(0, self.address_align), address[:split])
+        if self.colbits>10: # A10 is reserved for auto-precharge, this bit needs to be skipped for col addresses
+            return Cat(Replicate(0, self.address_align), address[:10-self.address_align], 0, address[10-self.address_align:split])
+        else:
+            return Cat(Replicate(0, self.address_align), address[:split])
 
 # BankMachine --------------------------------------------------------------------------------------
 

--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -590,6 +590,14 @@ class MT46H64M16(LPDDRModule):
     technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=None)
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 72), tFAW=None, tRAS=None)}
 
+class MT46H128M16(LPDDRModule):
+    # geometry
+    nbanks = 4
+    nrows  = 16384
+    ncols  = 2048
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=None)
+    speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 72), tFAW=None, tRAS=None)}
 
 class MT46H32M32(LPDDRModule):
     # geometry


### PR DESCRIPTION
For larger memories, the col encoding needs to skip `A10` because that one is reserved for auto-precharge.
The remaining col encoding bits are then mapped to `A11` and higher.

I think that newer RAM generations are defining additional reserved address bits, e.g. for DDR4 `A12` is used for burst-chop. But I ignored those higher bits, as we don't have any module with that many col bits used.