### PR TITLE
Fix DFITimingsChecker for DDR4 simulation

### DIFF
--- a/litedram/phy/model.py
+++ b/litedram/phy/model.py
@@ -199,17 +199,12 @@ class DFITimingsChecker(Module):
         return self.ns_to_ps(max(c, t))
 
     def prepare_timings(self, timings, refresh_mode, memtype):
-        CK_NS = ["tRFC", "tWTR", "tFAW", "tCCD", "tRRD", "tZQCS"]
-        REF   = ["tREFI", "tRFC"]
         self.timings = timings
         new_timings  = {}
 
         tck = self.timings["tCK"]
 
         for key, val in self.timings.items():
-            if refresh_mode is not None and key in REF:
-                val = val[refresh_mode]
-
             if val is None:
                 val = 0
             elif key == "tCK":
@@ -561,9 +556,12 @@ class SDRAMPHYModel(Module):
         # DFI timing checker -----------------------------------------------------------------------
         if verbosity > SDRAM_VERBOSE_OFF:
             timings = {"tCK": (1e9 / clk_freq) / nphases}
+            CK_NS = ["tRFC", "tWTR", "tFAW", "tCCD", "tRRD", "tZQCS"]
+            REF = ["tREFI", "tRFC"]
 
             for name in _speedgrade_timings + _technology_timings:
-                timings[name] = self.module.get(name)
+                key = self.module.timing_settings.fine_refresh_mode if name in REF else None
+                timings[name] = self.module.get(name, key)
 
             timing_checker = DFITimingsChecker(
                 dfi          = self.dfi,


### PR DESCRIPTION
In case of DDR4 tRFC and tREFI timings are actually dictionaries with timings specific for the chosen refresh mode.

Right now, it is impossible to simulate DDR4, because an exception happens in `DFITimingsChecker.prepare_timings` method when indexing `val` variable.

This is due to the fact, that in `DFITimingsChecker.__init__` we request timing values from the module by name, ignoring the fact that some of them (tRFC and tREFI) need to be first accessed using the chosen refresh mode.

This commit fixes this error, by properly using `key` parameter when calling `SDRAMModule.get` method to get only required timing.

If one were to fix it in `DFITimingsChecker.prepare_timings` method, it would require duplicating logic from `SDRAMModule.get` so this is a simpler and cleaner solution.

Signed-off-by: Michal Sieron <msieron@antmicro.com>