### PR TITLE
frontend/bist: properly signal finished writes

### DIFF
--- a/litedram/frontend/bist.py
+++ b/litedram/frontend/bist.py
@@ -186,12 +186,17 @@ class _LiteDRAMBISTGenerator(Module):
                 addr_gen.ce.eq(1),
                 NextValue(cmd_counter, cmd_counter + 1),
                 If(cmd_counter == (self.length[ashift:] - 1),
-                    NextState("DONE")
+                    NextState("AWAIT_FIFO_EMPTY")
                 ).Elif(~self.run_cascade_in,
                     NextState("WAIT")
                 )
             ),
             NextValue(self.ticks, self.ticks + 1)
+        )
+        fsm.act("AWAIT_FIFO_EMPTY",
+            If(~dma.fifo.source.valid,
+                NextState("DONE"),
+            ),
         )
         fsm.act("DONE",
             self.run_cascade_out.eq(1),

--- a/litedram/frontend/dma.py
+++ b/litedram/frontend/dma.py
@@ -200,8 +200,7 @@ class LiteDRAMDMAWriter(Module, AutoCSR):
             raise NotImplementedError
 
         # FIFO -------------------------------------------------------------------------------------
-        fifo = stream.SyncFIFO([("data", port.data_width)], fifo_depth, fifo_buffered)
-        self.submodules += fifo
+        self.submodules.fifo = fifo = stream.SyncFIFO([("data", port.data_width)], fifo_depth, fifo_buffered)
 
         if is_native:
             self.comb += cmd.we.eq(1)


### PR DESCRIPTION
Without it, software was resetting the generator too early and wrong data was being written to the RAM.

Signed-off-by: Michal Sieron <msieron@antmicro.com>