### PR TITLE
frontend/bist: replicate LFSR output to fill the DRAM port

### DIFF
--- a/litedram/frontend/bist.py
+++ b/litedram/frontend/bist.py
@@ -52,10 +52,8 @@ class LFSR(Module):
             curval.insert(0, nv)
             curval.pop()
 
-        self.sync += [
-            state.eq(Cat(*curval[:n_state])),
-            self.o.eq(Cat(*curval))
-        ]
+        self.sync += state.eq(Cat(*curval[:n_state]))
+        self.comb += self.o.eq(Cat(*curval))
 
 # Counter ------------------------------------------------------------------------------------------
 

--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -856,7 +856,7 @@ def main():
     builder_arguments = builder_argdict(args)
     builder_arguments["compile_gateware"] = False
 
-    soc     = LiteDRAMCore(platform, core_config, integrated_rom_size=0x8000)
+    soc     = LiteDRAMCore(platform, core_config, integrated_rom_size=0xC000)
     builder = Builder(soc, **builder_arguments)
     builder.build(build_name=args.name, regular_comb=False)
 

--- a/test/common.py
+++ b/test/common.py
@@ -354,6 +354,21 @@ class MemoryTestDataMixin:
         )
         expected = data["32bit_long_sequential"]["expected"]
         expected[16//4:(16 + 64)//4] = list(range(64//4))
+
+        lfsr_out_width = 31
+        # replicate LFSR output to fill the data_width
+        for test_case, config in data.items():
+            expected = config["expected"]
+
+            # extract data width from test case name
+            data_width = int(test_case.split("bit")[0])
+
+            for i, value in enumerate(expected):
+                for _ in range(data_width, lfsr_out_width - 1, -lfsr_out_width):
+                    value |= value << lfsr_out_width
+                    value &= (1 << data_width) - 1
+                expected[i] = value
+
         return data
 
     @property


### PR DESCRIPTION
Rework LFSR module so it is an actual LFSR and can work with larger states.
The old LFSR module, when initialized with n_state of 1024, produced an equation so large, that Vivado complained about too many tokens on the same line.
Also, by using LFSR with n_state of 1024, we can fill an entire transfer to the SDRAM.

I took LFSR coefficients from here: https://datacipy.cz/lfsr_table.pdf

Signed-off-by: Michal Sieron <msieron@antmicro.com>