### PR TITLE
Make tests safe to run in parallel

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -10,10 +10,10 @@ import os
 
 def build_config(name):
     errors = 0
-    os.system("rm -rf examples/build")
-    os.system("cd examples && python3 ../litedram/gen.py {}.yml".format(name))
-    errors += not os.path.isfile("examples/build/gateware/litedram_core.v")
-    os.system("rm -rf examples/build")
+    os.system(f"rm -rf examples/{name}")
+    os.system(f"mkdir -p examples/{name} && cd examples/{name} && python3 ../../litedram/gen.py ../{name}.yml")
+    errors += not os.path.isfile(f"examples/{name}/build/gateware/litedram_core.v")
+    os.system(f"rm -rf examples/{name}")
     return errors
 
 

--- a/test/test_lpddr4.py
+++ b/test/test_lpddr4.py
@@ -687,6 +687,7 @@ class VerilatorLPDDR4Tests(unittest.TestCase):
         # refresh and no L2 cache (masked write must work)
         self.run_test([
             "--finish-after-memtest", "--log-level", "warn",
+            "--output-dir", "build/test_lpddr4_sim_x2rate_no_cache",
             "--double-rate-phy",
             "--l2-size", "0",
             "--no-refresh",  # FIXME: LiteDRAM sends refresh commands when only MRW/MRR are allowed
@@ -696,6 +697,7 @@ class VerilatorLPDDR4Tests(unittest.TestCase):
         # Fast test of simulation with L2 cache (so no data masking is required)
         self.run_test([
             "--finish-after-memtest", "--log-level", "warn",
+            "--output-dir", "build/test_lpddr4_sim_fast",
             "--disable-delay",
             "--no-refresh",
         ])

--- a/test/test_lpddr5.py
+++ b/test/test_lpddr5.py
@@ -746,6 +746,7 @@ class VerilatorLPDDR5Tests(unittest.TestCase):
             with self.subTest(wck_ck_ratio=wck_ck_ratio):
                 self.run_test([
                     "--finish-after-memtest", "--log-level=warn",
+                    "--output-dir", "build/test_lpddr5_sim_no_delays",
                     "--disable-delay",
                     f"--wck-ck-ratio={wck_ck_ratio}",
                     "--no-refresh",  # FIXME: avoids warnings before initialization
@@ -764,6 +765,7 @@ class VerilatorLPDDR5Tests(unittest.TestCase):
                 ]
                 self.run_test([
                     "--finish-after-memtest", "--log-level=warn",
+                    "--output-dir", "build/test_lpddr5_sim_delays_no_cache",
                     "--l2-size=0",
                     f"--wck-ck-ratio={wck_ck_ratio}",
                     "--no-refresh",  # FIXME: LiteDRAM sends refresh commands when only MRW/MRR are allowed


### PR DESCRIPTION
For example using pytest-parallel you can greatly reduce time it takes to run all tests.

```
$ pytest --workers auto test
```

Signed-off-by: Michal Sieron <msieron@antmicro.com>