### PR TITLE
Add support for clam shell topology

### DIFF
--- a/litedram/common.py
+++ b/litedram/common.py
@@ -229,13 +229,13 @@ class PhySettings(Settings):
             write_dq_dqs_training: bool = False,
             write_latency_calibration: bool = False,
             read_leveling: bool = False,
+            is_clam_shell: bool = False,
         ):
         if strobes is None:
             strobes = databits // 8
         self.set_attributes(locals())
         self.cwl = cl if cwl is None else cwl
         self.is_rdimm = False
-        self.is_clam_shell = False
 
     # Optional DDR3/DDR4 electrical settings:
     # rtt_nom: Non-Writes on-die termination impedance
@@ -258,11 +258,6 @@ class PhySettings(Settings):
         assert self.memtype == "DDR4"
         self.is_rdimm = True
         self.set_attributes(locals())
-
-    # Optional Clam Shell configuration
-    def set_clam_shell(self):
-        assert self.memtype == "DDR4"
-        self.is_clam_shell = True
 
 class GeomSettings(Settings):
     def __init__(self, bankbits, rowbits, colbits):

--- a/litedram/common.py
+++ b/litedram/common.py
@@ -235,6 +235,7 @@ class PhySettings(Settings):
         self.set_attributes(locals())
         self.cwl = cl if cwl is None else cwl
         self.is_rdimm = False
+        self.is_clam_shell = False
 
     # Optional DDR3/DDR4 electrical settings:
     # rtt_nom: Non-Writes on-die termination impedance
@@ -257,6 +258,11 @@ class PhySettings(Settings):
         assert self.memtype == "DDR4"
         self.is_rdimm = True
         self.set_attributes(locals())
+
+    # Optional Clam Shell configuration
+    def set_clam_shell(self):
+        assert self.memtype == "DDR4"
+        self.is_clam_shell = True
 
 class GeomSettings(Settings):
     def __init__(self, bankbits, rowbits, colbits):

--- a/litedram/core/__init__.py
+++ b/litedram/core/__init__.py
@@ -17,11 +17,12 @@ from litedram.core.crossbar import LiteDRAMCrossbar
 class LiteDRAMCore(Module, AutoCSR):
     def __init__(self, phy, geom_settings, timing_settings, clk_freq, **kwargs):
         self.submodules.dfii = DFIInjector(
-            addressbits = max(geom_settings.addressbits, getattr(phy, "addressbits", 0)),
-            bankbits    = max(geom_settings.bankbits, getattr(phy, "bankbits", 0)),
-            nranks      = phy.settings.nranks,
-            databits    = phy.settings.dfi_databits,
-            nphases     = phy.settings.nphases)
+            addressbits   = max(geom_settings.addressbits, getattr(phy, "addressbits", 0)),
+            bankbits      = max(geom_settings.bankbits, getattr(phy, "bankbits", 0)),
+            nranks        = phy.settings.nranks,
+            databits      = phy.settings.dfi_databits,
+            nphases       = phy.settings.nphases,
+            is_clam_shell = phy.settings.is_clam_shell)
         self.comb += self.dfii.master.connect(phy.dfi)
 
         self.submodules.controller = controller = LiteDRAMController(

--- a/litedram/dfii.py
+++ b/litedram/dfii.py
@@ -21,6 +21,7 @@ class PhaseInjector(Module, AutoCSR):
             CSRField("ras",  size=1, description="DFI row address strobe bus"),
             CSRField("wren", size=1, description="DFI write data enable bus"),
             CSRField("rden", size=1, description="DFI read data enable bus"),
+            # Separate cs for clam shell topology
             CSRField("cs_top",   size=1, description="DFI chip select bus for top half only"),
             CSRField("cs_bottom",   size=1, description="DFI chip select bus for bottom half only"),
         ], description="Control DFI signals on a single phase")
@@ -98,7 +99,10 @@ class DFIInjector(Module, AutoCSR):
                 # Through LiteDRAM controller.
                 ).Else(
                     self.slave.connect(self.master),
-                    [self.master.phases[i].cs_n.eq(Replicate(self.slave.phases[i].cs_n, 2)) for i in range(nphases)],
+                    # Broadcast cs_n for clam shell topology
+                    If(is_clam_shell,
+                        [self.master.phases[i].cs_n.eq(Replicate(self.slave.phases[i].cs_n, 2)) for i in range(nphases)],
+                    )
                 )
             # Software Control (through CSRs).
             # --------------------------------

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -1029,7 +1029,7 @@ def get_sdram_phy_c_header(phy_settings, timing_settings, geom_settings):
                     b += f"/* {comment} for top */"
                     b += f"sdram_dfii_pi0_address_write({a ^ a_inv:#x});"
                     b += f"sdram_dfii_pi0_baddress_write({ba ^ ba_inv:d});"
-                    b += f"sdram_dfii_control_write({cmd}|DFII_COMMAND_CS_TOP);"
+                    b += f"command_p0({cmd}|DFII_COMMAND_CS_TOP);"
                     if delay:
                         b += f"cdelay({delay});\n"
                     b.newline()
@@ -1045,7 +1045,7 @@ def get_sdram_phy_c_header(phy_settings, timing_settings, geom_settings):
                     baddr = ba ^ ba_inv
                     baddr = swap_bit(baddr, 0, 1)
                     b += f"sdram_dfii_pi0_baddress_write({baddr:d});"
-                    b += f"sdram_dfii_control_write({cmd}|DFII_COMMAND_CS_BOTTOM);"
+                    b += f"command_p0({cmd}|DFII_COMMAND_CS_BOTTOM);"
                     if delay:
                         b += f"cdelay({delay});\n"
                     b.newline()

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -951,6 +951,9 @@ def get_sdram_phy_c_header(phy_settings, timing_settings, geom_settings):
     if phy_settings.is_rdimm:
         assert phy_settings.memtype == "DDR4"
         r.define("SDRAM_PHY_DDR4_RDIMM")
+    if phy_settings.is_clam_shell:
+        assert phy_settings.memtype == "DDR4"
+        r.define("SDRAM_PHY_CLAM_SHELL")
 
     # litedram doesn't support multiple ranks
     supported_memory = 2 ** (geom_settings.bankbits +

--- a/litedram/phy/usddrphy.py
+++ b/litedram/phy/usddrphy.py
@@ -32,7 +32,8 @@ class USDDRPHY(Module, AutoCSR):
         cwl              = None,
         cmd_latency      = 0,
         cmd_delay        = None,
-        is_rdimm         = False):
+        is_rdimm         = False,
+        is_clam_shell    = False):
         phytype     = self.__class__.__name__
         device      = {"USDDRPHY": "ULTRASCALE", "USPDDRPHY": "ULTRASCALE_PLUS"}[phytype]
         pads        = PHYPadsCombiner(pads)
@@ -124,6 +125,8 @@ class USDDRPHY(Module, AutoCSR):
                 rcd_odt_cke_drive = 0x5,
                 rcd_clk_drive     = 0x5
             )
+        if is_clam_shell:
+            self.settings.set_clam_shell()
 
         # DFI Interface ----------------------------------------------------------------------------
         self.dfi = dfi = Interface(addressbits, bankbits, nranks, 2*databits, nphases)

--- a/litedram/phy/usddrphy.py
+++ b/litedram/phy/usddrphy.py
@@ -97,7 +97,8 @@ class USDDRPHY(Module, AutoCSR):
             memtype                   = memtype,
             databits                  = databits,
             dfi_databits              = 2*databits,
-            nranks                    = nranks,
+            # nranks                    = nranks,
+            nranks                    = 1, # Pretend to be one-rank
             nphases                   = nphases,
             rdphase                   = self._rdphase.storage,
             wrphase                   = self._wrphase.storage,

--- a/litedram/phy/usddrphy.py
+++ b/litedram/phy/usddrphy.py
@@ -98,8 +98,7 @@ class USDDRPHY(Module, AutoCSR):
             memtype                   = memtype,
             databits                  = databits,
             dfi_databits              = 2*databits,
-            # nranks                    = nranks,
-            nranks                    = 1, # Pretend to be one-rank
+            nranks                    = nranks//2 if is_clam_shell else nranks,
             nphases                   = nphases,
             rdphase                   = self._rdphase.storage,
             wrphase                   = self._wrphase.storage,
@@ -114,6 +113,7 @@ class USDDRPHY(Module, AutoCSR):
             read_leveling             = True,
             delays                    = 512,
             bitslips                  = 8,
+            is_clam_shell             = is_clam_shell,
         )
 
         if is_rdimm:
@@ -125,8 +125,6 @@ class USDDRPHY(Module, AutoCSR):
                 rcd_odt_cke_drive = 0x5,
                 rcd_clk_drive     = 0x5
             )
-        if is_clam_shell:
-            self.settings.set_clam_shell()
 
         # DFI Interface ----------------------------------------------------------------------------
         self.dfi = dfi = Interface(addressbits, bankbits, nranks, 2*databits, nphases)


### PR DESCRIPTION
VCU128 uses clam shell topology for its DRAM components. This pull request adds support for VCU128 clam shell topology.

Clam shell topology:

1. DRAM chips are on top and bottom sides of the PCB
2. There are cs_n pins for the top and the bottom half
3. Address pins are mirrored for the bottom half

See https://github.com/litex-hub/litex-boards/issues/496 for background.