### PR TITLE
add burst converter tests, fix downconverting burst

### DIFF
--- a/test/test_avalon.py
+++ b/test/test_avalon.py
@@ -187,21 +187,23 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
             self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xc0ffee00)
             self.assertEqual((yield dut.avalon.readdatavalid), 1)
             self.assertEqual((yield from dut.avalon.continue_read_burst()), 0x76543210)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xfedcba98)
             yield
             yield
             yield
             yield
             self.assertEqual((yield from dut.avalon.bus_read(0x0000)), 0x01234567)
-            self.assertEqual((yield from dut.avalon.bus_read(0x0002)), 0x89abcdef)
-            self.assertEqual((yield from dut.avalon.bus_read(0x0004)), 0xdeadbeef)
-            self.assertEqual((yield from dut.avalon.bus_read(0x0006)), 0xc0ffee00)
-            self.assertEqual((yield from dut.avalon.bus_read(0x0008)), 0x76543210)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0001)), 0x89abcdef)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0002)), 0xdeadbeef)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0003)), 0xc0ffee00)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0004)), 0x76543210)
             yield
             yield
 
         avl  = avalon.AvalonMMInterface(adr_width=30, data_width=32)
         port = LiteDRAMNativePort("both", address_width=32, data_width=16)
-        dut = DUT(port, avl, base_address=0x0, mem_expected=data + 10 * [0])
+        dut = DUT(port, avl, base_address=0x0, mem_expected=data + 6 * [0])
         generators = [
             main_generator(dut),
             dut.mem.write_handler(dut.port),
@@ -209,8 +211,7 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
         ]
 
         run_simulation(dut, generators, vcd_name="avalon_" + self._testMethodName + ".vcd")
-        dut.mem.show_content()
-        self.assertEqual(dut.mem.mem, data)
+        self.assertEqual(dut.mem.mem, [0x4567, 0x0123, 0xcdef, 0x89ab, 0xbeef, 0xdead, 0xee00, 0xc0ff, 0x3210, 0x7654, 0xba98, 0xfedc])
 
     def test_avalon_burst_upconvert(self):
         data = [0x01234567, 0x89abcdef, 0xdeadbeef, 0xc0ffee00, 0x76543210, 0xfedcba98]

--- a/test/test_avalon.py
+++ b/test/test_avalon.py
@@ -162,7 +162,7 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
 
         avl  = avalon.AvalonMMInterface(adr_width=30, data_width=32)
         port = LiteDRAMNativePort("both", address_width=30, data_width=32)
-        dut = DUT(port, avl, base_address=0x0, mem_expected=data)
+        dut = DUT(port, avl, base_address=0x0, mem_expected=[0x4567, 0x0123, 0xcdef, 0x89ab, 0xbeef, 0xdead, 0xee00, 0xc0ff, 0x3210, 0x7654])
         generators = [
             main_generator(dut),
             dut.mem.write_handler(dut.port),
@@ -170,7 +170,7 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
         ]
 
         run_simulation(dut, generators, vcd_name='sim.vcd')
-        self.assertEqual(dut.mem.mem, data)
+        self.assertEqual(dut.mem.mem, data + [0,0,0,0,0])
 
     def test_avalon_burst_downconvert(self):
         data = [0x01234567, 0x89abcdef, 0xdeadbeef, 0xc0ffee00, 0x76543210, 0xfedcba98]
@@ -178,7 +178,7 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
         def main_generator(dut):
             yield from dut.avalon.bus_write(0x0, data)
             yield
-            self.assertEqual((yield from dut.avalon.bus_read(0x0000, burstcount=5)), 0x01234567)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0000, burstcount=6)), 0x01234567)
             self.assertEqual((yield dut.avalon.readdatavalid), 1)
             self.assertEqual((yield from dut.avalon.continue_read_burst()), 0x89abcdef)
             self.assertEqual((yield dut.avalon.readdatavalid), 1)
@@ -201,7 +201,7 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
 
         avl  = avalon.AvalonMMInterface(adr_width=30, data_width=32)
         port = LiteDRAMNativePort("both", address_width=32, data_width=16)
-        dut = DUT(port, avl, base_address=0x0, mem_expected=data)
+        dut = DUT(port, avl, base_address=0x0, mem_expected=data + 10 * [0])
         generators = [
             main_generator(dut),
             dut.mem.write_handler(dut.port),

--- a/test/test_avalon.py
+++ b/test/test_avalon.py
@@ -171,3 +171,85 @@ class TestAvalon(MemoryTestDataMixin, unittest.TestCase):
 
         run_simulation(dut, generators, vcd_name='sim.vcd')
         self.assertEqual(dut.mem.mem, data)
+
+    def test_avalon_burst_downconvert(self):
+        data = [0x01234567, 0x89abcdef, 0xdeadbeef, 0xc0ffee00, 0x76543210, 0xfedcba98]
+
+        def main_generator(dut):
+            yield from dut.avalon.bus_write(0x0, data)
+            yield
+            self.assertEqual((yield from dut.avalon.bus_read(0x0000, burstcount=5)), 0x01234567)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0x89abcdef)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xdeadbeef)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xc0ffee00)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0x76543210)
+            yield
+            yield
+            yield
+            yield
+            self.assertEqual((yield from dut.avalon.bus_read(0x0000)), 0x01234567)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0002)), 0x89abcdef)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0004)), 0xdeadbeef)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0006)), 0xc0ffee00)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0008)), 0x76543210)
+            yield
+            yield
+
+        avl  = avalon.AvalonMMInterface(adr_width=30, data_width=32)
+        port = LiteDRAMNativePort("both", address_width=32, data_width=16)
+        dut = DUT(port, avl, base_address=0x0, mem_expected=data)
+        generators = [
+            main_generator(dut),
+            dut.mem.write_handler(dut.port),
+            dut.mem.read_handler(dut.port),
+        ]
+
+        run_simulation(dut, generators, vcd_name="avalon_" + self._testMethodName + ".vcd")
+        dut.mem.show_content()
+        self.assertEqual(dut.mem.mem, data)
+
+    def test_avalon_burst_upconvert(self):
+        data = [0x01234567, 0x89abcdef, 0xdeadbeef, 0xc0ffee00, 0x76543210, 0xfedcba98]
+
+        def main_generator(dut):
+            yield from dut.avalon.bus_write(0x0, data)
+            yield
+            self.assertEqual((yield from dut.avalon.bus_read(0x0000, burstcount=6)), 0x01234567)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0x89abcdef)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xdeadbeef)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xc0ffee00)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0x76543210)
+            self.assertEqual((yield dut.avalon.readdatavalid), 1)
+            self.assertEqual((yield from dut.avalon.continue_read_burst()), 0xfedcba98)
+            yield
+            yield
+            yield
+            yield
+            self.assertEqual((yield from dut.avalon.bus_read(0x0000)), 0x01234567)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0001)), 0x89abcdef)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0002)), 0xdeadbeef)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0003)), 0xc0ffee00)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0004)), 0x76543210)
+            self.assertEqual((yield from dut.avalon.bus_read(0x0005)), 0xfedcba98)
+            yield
+            yield
+
+        avl  = avalon.AvalonMMInterface(adr_width=30, data_width=32)
+        port = LiteDRAMNativePort("both", address_width=30, data_width=64)
+        dut = DUT(port, avl, base_address=0x0, mem_expected=data)
+        generators = [
+            main_generator(dut),
+            dut.mem.write_handler(dut.port),
+            dut.mem.read_handler(dut.port),
+        ]
+
+        run_simulation(dut, generators, vcd_name="avalon_" + self._testMethodName + ".vcd")
+        self.assertEqual(dut.mem.mem, [0x89abcdef01234567, 0xc0ffee00deadbeef, 0xfedcba9876543210, 0, 0, 0])


### PR DESCRIPTION
This backports the tests from https://github.com/enjoy-digital/litedram/pull/340
to current master, to compare test results for up/downconverting bursts.
After fixes of issues uncovered by the tests, the downconverter
shows similar garbled memory contents in the RAM of the simulator:
![image](https://github.com/enjoy-digital/litedram/assets/148607/cfeb2c04-e163-44e7-be63-37cb7f680685)
```
0x00000000: 0xee00
0x00000001: 0xc0ff
0x00000002: 0x3210
0x00000003: 0x7654
0x00000004: 0xba98
0x00000005: 0xfedc
```