### PR TITLE
Add W9812G6JB SDRAM module

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -553,6 +553,15 @@ class W9825G6KH6(SDRModule):
     technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 10))
     speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 60), tFAW=None, tRAS=42)}
 
+class W9812G6JB(SDRModule):
+    # geometry
+    nbanks = 4
+    nrows  = 4096
+    ncols  = 512
+    # timings
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(2, None), tCCD=(1, None), tRRD=(None, 12))
+    speedgrade_timings = {"default": _SpeedgradeTimings(tRP=15, tRCD=15, tWR=20, tRFC=(None, 60), tFAW=None, tRAS=42)}
+
 # DDR ----------------------------------------------------------------------------------------------
 
 class DDRModule(SDRAMModule):                     memtype = "DDR"


### PR DESCRIPTION
Got it running at 90 MHz

```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2023 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Nov  9 2023 10:28:08
 BIOS CRC passed (7ebd4500)

 LiteX git sha1: f3f46e8c

--=============== SoC ==================--
CPU:		VexRiscv @ 90MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128.0KiB
SRAM:		8.0KiB
L2:		8.0KiB
SDRAM:		16.0MiB 16-bit @ 90MT/s (CL-2 CWL-2)
MAIN-RAM:	16.0MiB

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 25.3MiB/s
   Read speed: 39.8MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
             Timeout
No boot medium found

--============= Console ================--
```
