### PR TITLE
litedram/phy/lpddr*: fix use of invalid escape sequence

### DIFF
--- a/litedram/phy/lpddr4/commands.py
+++ b/litedram/phy/lpddr4/commands.py
@@ -199,18 +199,18 @@ class Command(Module):
         assert len(self.dfi.address) >= 17, "At least 17 DFI addressbits needed for row address"
         mr_address = self.dfi.bank if is_mrw else self.dfi.address
         rules = {
-            "H":       lambda: 1,  # high
-            "L":       lambda: 0,  # low
-            "V":       lambda: 0,  # defined logic
-            "X":       lambda: 0,  # don't care
-            "BL":      lambda: 0,  # on-the-fly burst length, not using
-            "AP":      lambda: self.dfi.address[10],  # auto precharge
-            "AB":      lambda: self.dfi.address[10],  # all banks
-            "BA(\d+)": lambda i: self.dfi.bank[i],
-            "R(\d+)":  lambda i: self.dfi.address[i],  # row
-            "C(\d+)":  lambda i: self.dfi.address[i],  # column
-            "MA(\d+)": lambda i: mr_address[i],  # mode register address
-            "OP(\d+)": lambda i: self.dfi.address[i],  # mode register value, or operand for MPC
+            "H":        lambda: 1,  # high
+            "L":        lambda: 0,  # low
+            "V":        lambda: 0,  # defined logic
+            "X":        lambda: 0,  # don't care
+            "BL":       lambda: 0,  # on-the-fly burst length, not using
+            "AP":       lambda: self.dfi.address[10],  # auto precharge
+            "AB":       lambda: self.dfi.address[10],  # all banks
+            "BA(\\d+)": lambda i: self.dfi.bank[i],
+            "R(\\d+)":  lambda i: self.dfi.address[i],  # row
+            "C(\\d+)":  lambda i: self.dfi.address[i],  # column
+            "MA(\\d+)": lambda i: mr_address[i],  # mode register address
+            "OP(\\d+)": lambda i: self.dfi.address[i],  # mode register value, or operand for MPC
         }
         for pattern, value in rules.items():
             m = re.match(pattern, bit)

--- a/litedram/phy/lpddr5/commands.py
+++ b/litedram/phy/lpddr5/commands.py
@@ -275,27 +275,27 @@ class Command(Module):
         op = mpc_op if is_mpc else self.dfi.address
 
         rules = {
-            "H":       lambda: 1,  # high
-            "L":       lambda: 0,  # low
-            "V":       lambda: 0,  # defined logic
-            "X":       lambda: 0,  # don't care
-            "AB":      lambda: self.dfi.address[10],  # all banks
-            "AP":      lambda: self.dfi.address[10],  # auto precharge
-            "RFM":     lambda: 0,  # TODO: 1=RFM, 0=REF (Refresh Managemenent, only if r/o MR[27][0]=1, else always REF)
-            "SB(\d+)": lambda i: 0,  # sub-bank selection related to RFM
-            "WS_WR":   lambda: self.wck_sync == WCKSyncType.WR,  # Write WCK2CK SYNC
-            "WS_RD":   lambda: self.wck_sync == WCKSyncType.RD,  # Read WCK2CK SYNC
-            "WS_FS":   lambda: self.wck_sync == WCKSyncType.FS,  # FAST SYNC
-            "DC(\d+)": lambda i: 0,  # Data Copy, unimplemented
-            "WRX":     lambda: 0,  # Write X function, unimplemented
-            "WXSA":    lambda: 0,  # Write X function, unimplemented
-            "WXSB":    lambda: 0,  # Write X function, unimplemented
-            "BA(\d+)": lambda i: self.dfi.bank[i],  # only BA0-2 is used, in BG/B16 modes we always refresh banks (x, x+8)
-            "R(\d+)":  lambda i: self.dfi.address[i],  # row
+            "H":        lambda: 1,  # high
+            "L":        lambda: 0,  # low
+            "V":        lambda: 0,  # defined logic
+            "X":        lambda: 0,  # don't care
+            "AB":       lambda: self.dfi.address[10],  # all banks
+            "AP":       lambda: self.dfi.address[10],  # auto precharge
+            "RFM":      lambda: 0,  # TODO: 1=RFM, 0=REF (Refresh Managemenent, only if r/o MR[27][0]=1, else always REF)
+            "SB(\\d+)": lambda i: 0,  # sub-bank selection related to RFM
+            "WS_WR":    lambda: self.wck_sync == WCKSyncType.WR,  # Write WCK2CK SYNC
+            "WS_RD":    lambda: self.wck_sync == WCKSyncType.RD,  # Read WCK2CK SYNC
+            "WS_FS":    lambda: self.wck_sync == WCKSyncType.FS,  # FAST SYNC
+            "DC(\\d+)": lambda i: 0,  # Data Copy, unimplemented
+            "WRX":      lambda: 0,  # Write X function, unimplemented
+            "WXSA":     lambda: 0,  # Write X function, unimplemented
+            "WXSB":     lambda: 0,  # Write X function, unimplemented
+            "BA(\\d+)": lambda i: self.dfi.bank[i],  # only BA0-2 is used, in BG/B16 modes we always refresh banks (x, x+8)
+            "R(\\d+)":  lambda i: self.dfi.address[i],  # row
             # LPDDR5 specs split the regular column address into C[5:0] "column address" and B[3:0] "burst address"
-            "C(\d+)":  lambda i: self.dfi.address[i + 4],
-            "MA(\d+)": lambda i: mr_address[i],  # mode register address
-            "OP(\d+)": lambda i: op[i], # mode register value, or operand for MPC
+            "C(\\d+)":  lambda i: self.dfi.address[i + 4],
+            "MA(\\d+)": lambda i: mr_address[i],  # mode register address
+            "OP(\\d+)": lambda i: op[i], # mode register value, or operand for MPC
         }
 
         for pattern, value in rules.items():


### PR DESCRIPTION
This fixes multiple instances of:

litedram/phy/lpddr4/commands.py:209
  litedram-2023.12/litedram/phy/lpddr4/commands.py:209: DeprecationWarning: invalid escape sequence '\d'
    "BA(\d+)": lambda i: self.dfi.bank[i],