### PR TITLE
litedram/address_mapping Add bank_byte_alignment

### DIFF
--- a/litedram/core/controller.py
+++ b/litedram/core/controller.py
@@ -40,7 +40,13 @@ class ControllerSettings(Settings):
         with_auto_precharge = True,
 
         # Address mapping
-        address_mapping     = "ROW_BANK_COL"):
+        address_mapping     = "ROW_BANK_COL",
+
+        # bank_byte_alignment specify how many bytes should be in between each bank change (minimum).
+        # This is usefull when you want to match a L2 cache sets size.
+        # For instance you have a L2 cache of 256KB with 4 ways => Sets size of 256KB/4=64KB
+        # => Ideal bank_byte_alignment = 0x10000
+        bank_byte_alignment     = 0):
         self.set_attributes(locals())
 
 # Controller ---------------------------------------------------------------------------------------

--- a/litedram/core/crossbar.py
+++ b/litedram/core/crossbar.py
@@ -127,7 +127,7 @@ class LiteDRAMCrossbar(Module):
         nmasters   = len(self.masters)
 
         # Address mapping --------------------------------------------------------------------------
-        cba_shifts = {"ROW_BANK_COL": controller.settings.geom.colbits - controller.address_align}
+        cba_shifts = {"ROW_BANK_COL": max(controller.settings.geom.colbits - controller.address_align, log2_int(controller.settings.bank_byte_alignment //(controller.data_width // 8))) }
         cba_shift = cba_shifts[controller.settings.address_mapping]
         m_ba      = [m.get_bank_address(self.bank_bits, cba_shift)for m in self.masters]
         m_rca     = [m.get_row_column_address(self.bank_bits, self.rca_bits, cba_shift) for m in self.masters]


### PR DESCRIPTION
This PR add ControllerSettings.bank_byte_alignment which allow to specifiy how many byte (minimum) there should be between bank address change.

This allow to align it to L2 cache sets size, which improve performances quite a bit on VexiiRiscv :
VexiiRiscv RV64GC with hadware prefetch, 256KB 4way L2, running at 100 Mhz => 
```
without this PR
  Write speed: 197.1MiB/s
   Read speed: 379.4MiB/s 

With this PR and 
            self.add_sdram("sdram",
                phy           = self.ddrphy,
                module        = MT41K256M16(sys_clk_freq, "1:4"),
                l2_cache_size = kwargs.get("l2_size", 8192),
               controller_settings=ControllerSettings(bank_byte_alignment= 256*1024//4) # <-----
            )
  Write speed: 252.3MiB/s
   Read speed: 424.6MiB/s
``` 

When set to 0 (default value) it will not interfer with the previous behaviour of address_mapping     = "ROW_BANK_COL",
  

