### PR TITLE
frontend/dma.py: Remove left-over rsv_level documentation

### DIFF
--- a/litedram/frontend/dma.py
+++ b/litedram/frontend/dma.py
@@ -46,9 +46,6 @@ class LiteDRAMDMAReader(Module, AutoCSR):
 
     source : Record("data")
         Source for DRAM word results from reading.
-
-    rsv_level: Signal()
-        FIFO reservation level counter
     """
 
     def __init__(self, port, fifo_depth=16, fifo_buffered=False, with_csr=False):


### PR DESCRIPTION
Was reworked in a previous commit and rsv_level didn't survive