### PR TITLE
Reset PHY cmd_latency to 0 for standalone gen on Genesys2

### DIFF
--- a/examples/genesys2.yml
+++ b/examples/genesys2.yml
@@ -12,7 +12,7 @@
     "uart":       "rs232",    # Type of UART interface (rs232, fifo)
 
     # PHY ----------------------------------------------------------------------
-    "cmd_latency":     1,             # Command additional latency
+    "cmd_latency":     0,             # Command additional latency
     "sdram_module":    "MT41J256M16", # SDRAM modules of the board or SO-DIMM
     "sdram_module_nb": 4,             # Number of byte groups
     "sdram_rank_nb":   1,             # Number of ranks


### PR DESCRIPTION
Commit `4e62d28` had set the cmd_latency in `examples/genesys2.yml` to 1. Later, due to a change to cmd/clk scan in liblitedram, the default in `s7ddrphy.py` was reset back to 0 in `496cd27`.  However, downstream users such as Microwatt were still left perplexed why pulling a new LiteDRAM would result in Memtest KO, see
https://github.com/antonblanchard/microwatt/issues/363 The present commit fixes the non-working cmd_latency in `genesys2.yml`.