### PR TITLE
Added last signal to LiteDRAMWriter

### DIFF
--- a/litedram/frontend/dma.py
+++ b/litedram/frontend/dma.py
@@ -202,6 +202,7 @@ class LiteDRAMDMAWriter(Module, AutoCSR):
             self.comb += cmd.size.eq(int(log2(port.data_width//8)))
         self.comb += [
             cmd.addr.eq(sink.address),
+            cmd.last.eq(sink.last),
             cmd.valid.eq(fifo.sink.ready & sink.valid),
             sink.ready.eq(fifo.sink.ready & cmd.ready),
             fifo.sink.valid.eq(sink.valid & cmd.ready),


### PR DESCRIPTION
This PR adds a last signal transmission to the `LiteDRAMDMAWriter` to enable writing packets and stopping their transmission.

While extending LiteEth with RDMA with the pull request ["Implementing RoCEv2 passive receiver#198"](https://github.com/enjoy-digital/liteeth/pull/198), I noticed that the writer did not transfer the last signal to the port controller.