### PR TITLE
modules: encode LPDDR4 tFAW nCK floor for MT53E256M16D1

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -1313,6 +1313,9 @@ class MT53E256M16D1(SDRAMModule):
     # the controller during this time, after ZQCAL LATCH we have to wait tZQLAT=max(8ck, 30ns)
     technology_timings = _TechnologyTimings(tREFI=32e6/8192, tWTR=(8, 10), tCCD=tccd["masked-write"], tRRD=(4, 10), tZQCS=None)
     speedgrade_timings = {
-        "1866": _SpeedgradeTimings(tRP=(3, 21), tRCD=(4, 18), tWR=(4, 18), tRFC=180, tFAW=40, tRAS=(3, 42)),  # TODO: tRAS_max
+        # LPDDR4 8-bank tFAW per JESD209-4: max(32 nCK, 40 ns). Encoding
+        # the 32 nCK floor avoids under-constraining tFAW when the
+        # controller runs slower than the device speedgrade.
+        "1866": _SpeedgradeTimings(tRP=(3, 21), tRCD=(4, 18), tWR=(4, 18), tRFC=(None, 180), tFAW=(32, 40), tRAS=(3, 42)),  # TODO: tRAS_max
     }
     speedgrade_timings["default"] = speedgrade_timings["1866"]

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -65,6 +65,15 @@ class TestSDRAMModules(unittest.TestCase):
         self.assertEqual(module.ncols, 1024)
         self.assertEqual(cls.speedgrade_timings["800"].tRFC, (None, 260))
 
+    def test_mt53e256m16d1_tfaw_uses_ck_minimum(self):
+        cls = litedram.modules.MT53E256M16D1
+        # At a 100 MHz controller clock with 1:4 rate, the ns side of tFAW
+        # (40 ns) rounds to fewer cycles than the JEDEC 32 nCK minimum, so
+        # the nCK floor must be honoured.
+        module = cls(clk_freq=100e6, rate="1:4")
+        self.assertEqual(cls.speedgrade_timings["1866"].tFAW, (32, 40))
+        self.assertEqual(module.timing_settings.tFAW, 8)
+
     def test_h5tq4g63xfr_geometry_and_speedgrades(self):
         for name in ["H5TQ4G63CFR", "H5TQ4G63EFR"]:
             cls = getattr(litedram.modules, name)


### PR DESCRIPTION
## Summary

The MT53E256M16D1 LPDDR4 module encodes its `tFAW` and `tRFC` as bare
numbers in `litedram/modules.py`:

```python
"1866": _SpeedgradeTimings(... tRFC=180, tFAW=40, ...)
```

`tFAW=40` is interpreted as "40 ns, no nCK constraint". JEDEC JESD209-4
specifies LPDDR4 8-bank `tFAW = max(32 nCK, 40 ns)`, so at controller
clocks low enough that 40 ns rounds to fewer than 32 nCK the resolved
cycle count under-constrains the four-activate window and can let too
many `ACT`s into the rolling window. This is the same class of bug
fixed for the DDR4 RDIMM x4 modules in 183011d (HMA82GR7DJR4N /
M393A2K40DB3).

## Change

```diff
- "1866": _SpeedgradeTimings(... tRFC=180,        tFAW=40,      ...)
+ "1866": _SpeedgradeTimings(... tRFC=(None, 180), tFAW=(32, 40), ...)
```

- `tFAW=(32, 40)` — encodes the JEDEC 32 nCK floor.
- `tRFC=(None, 180)` — equivalent value, switched to the explicit
  tuple form for consistency with the surrounding tuple-form timings
  and with the H5TC4G63CFR fix in 909fe8b. No behaviour change for
  `tRFC`.

## Test

Adds `test_mt53e256m16d1_tfaw_uses_ck_minimum`, mirroring the
existing `test_ddr4_rdimm_tfaw_uses_ck_minimum` and
`test_h5tc4g63cfr_geometry_and_trfc` style:

```python
def test_mt53e256m16d1_tfaw_uses_ck_minimum(self):
    cls = litedram.modules.MT53E256M16D1
    module = cls(clk_freq=100e6, rate="1:4")
    self.assertEqual(cls.speedgrade_timings["1866"].tFAW, (32, 40))
    self.assertEqual(module.timing_settings.tFAW, 8)
```

`python -m unittest test.test_modules` runs all 17 tests cleanly with
the change applied.
