### PR TITLE
modules: bump H5TC4G63CFR tRRD nCK floor to 6 for x16 organisation

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -907,7 +907,9 @@ class H5TC4G63CFR(DDR3Module):
     nrows  = 32768
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 7.5), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK
+    # for x4/x8). This matches the sibling x16 H5TQ4G63CFR definition.
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 7.5), tZQCS=(64, 80))
     speedgrade_timings = {
         "800":  _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 260), tFAW=(None, 40), tRAS=37.5),
     }

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -64,6 +64,9 @@ class TestSDRAMModules(unittest.TestCase):
         self.assertEqual(module.nrows, 32768)
         self.assertEqual(module.ncols, 1024)
         self.assertEqual(cls.speedgrade_timings["800"].tRFC, (None, 260))
+        # x16 DDR3 tRRD nCK floor is 6 nCK (vs 4 nCK for x4/x8) and must
+        # match the sibling H5TQ4G63CFR x16 definition.
+        self.assertEqual(cls.technology_timings.tRRD, (6, 7.5))
 
     def test_h5tq4g63xfr_geometry_and_speedgrades(self):
         for name in ["H5TQ4G63CFR", "H5TQ4G63EFR"]:


### PR DESCRIPTION
## Summary

H5TC4G63CFR was re-modelled as the SK hynix DDR3L 4Gb x16 device in
909fe8b ("modules: fix SK hynix DDR3L geometry"), but its `tRRD`
encoding was left at the x4/x8 nCK floor:

```python
technology_timings = _TechnologyTimings(... tRRD=(4, 7.5) ...)
```

JEDEC DDR3/DDR3L specifies the four-bank `tRRD` nCK floor as **6 nCK
for x16 organisation** (vs 4 nCK for x4 and x8). The sibling x16 SK
hynix part added in a59772c — H5TQ4G63CFR — already uses the correct
value:

```python
technology_timings = _TechnologyTimings(... tRRD=(6, 7.5) ...)
```

Both parts are 4Gb x16 DDR3 from SK hynix in the same H5T family; the
only intended difference is supply voltage (DDR3L vs DDR3), which
does not relax the `tRRD` nCK floor.

## Change

```diff
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 7.5), tZQCS=(64, 80))
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 7.5), tZQCS=(64, 80))
```

Plus a brief inline comment explaining the x16 floor and the
H5TQ4G63CFR cross-reference.

## Test

Extends the existing `test_h5tc4g63cfr_geometry_and_trfc` (added in
909fe8b) with one extra assertion so the regression is locked in:

```python
self.assertEqual(cls.technology_timings.tRRD, (6, 7.5))
```

`python -m unittest test.test_modules` runs all tests cleanly with the
change applied.

## Why this is a separate PR from #381

PR #381 fixes the analogous LPDDR4 `tFAW` 32 nCK floor on
MT53E256M16D1. This PR is unrelated except in flavour — it touches a
different module, a different timing parameter, and a different DRAM
generation, and is cleanly reviewable on its own.
