### PR TITLE
modules: bump tRRD nCK floor to 6 for DDR3 x16 parts (extends #382)

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -764,7 +764,8 @@ class AS4C128M16(DDR3Module):
     nrows  = 16384
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 6), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 6), tZQCS=(64, 80))
     speedgrade_timings = {
         "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=13.75, tRFC=(160, None), tFAW=(None, 40), tRAS=35),
     }
@@ -776,7 +777,8 @@ class MT41K64M16(DDR3Module):
     nrows  = 8192
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 10), tZQCS=(64, 80))
     speedgrade_timings = {
         "800":  _SpeedgradeTimings(tRP=13.1,  tRCD=13.1,  tWR=13.1,  tRFC=(64,  None), tFAW=(None, 50), tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.1,  tRCD=13.1,  tWR=13.1,  tRFC=(86,  None), tFAW=(None, 50), tRAS=37.5),
@@ -817,7 +819,8 @@ class MT41J128M16(DDR3Module):
     nrows  = 16384
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 10), tZQCS=(64, 80))
     speedgrade_timings = {
         "800":  _SpeedgradeTimings(tRP=13.1,  tRCD=13.1,  tWR=13.1,  tRFC=(64, None),  tFAW=(None, 50), tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.1,  tRCD=13.1,  tWR=13.1,  tRFC=(86, None),  tFAW=(None, 50), tRAS=37.5),
@@ -846,7 +849,8 @@ class MT41J256M16(DDR3Module):
     nrows  = 32768
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 10), tZQCS=(64, 80))
     speedgrade_timings = {
         "800":  _SpeedgradeTimings(tRP=13.1,  tRCD=13.1,  tWR=13.1,  tRFC=(139, None), tFAW=(None, 50), tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.1,  tRCD=13.1,  tWR=13.1,  tRFC=(138, None), tFAW=(None, 50), tRAS=37.5),
@@ -863,7 +867,8 @@ class MT41J512M16(DDR3Module):
     nrows  = 65536
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 10), tZQCS=(64, 80))
     speedgrade_timings = {
         "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=13.75, tRFC=(280, None), tFAW=(None, 40), tRAS=39),
     }
@@ -892,7 +897,8 @@ class K4B2G1646F(DDR3Module):
     nrows  = 16384
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 10), tZQCS=(64, 80))
     speedgrade_timings = {
         "800":  _SpeedgradeTimings(tRP=15,     tRCD=15,     tWR=15, tRFC=(104, None), tFAW=(None, 50), tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.125, tRCD=13.125, tWR=15, tRFC=(139, None), tFAW=(None, 50), tRAS=37.5),
@@ -1023,7 +1029,8 @@ class AS4C256M16D3A(DDR3Module):
     nrows  = 32768
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 7.5), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 7.5), tZQCS=(64, 80))
     speedgrade_timings = {
         "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=15, tRFC=(None, 260), tFAW=(None, 40), tRAS=35),
     }
@@ -1035,7 +1042,8 @@ class AS4C256M16D3C(DDR3Module):
     nrows  = 32768
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 7.5), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 7.5), tZQCS=(64, 80))
     speedgrade_timings = {
         "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=15, tRFC=(None, 260), tFAW=(None, 40), tRAS=35),
         "1866": _SpeedgradeTimings(tRP=13.91, tRCD=13.91, tWR=15, tRFC=(None, 260), tFAW=(None, 35), tRAS=34),

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -65,6 +65,25 @@ class TestSDRAMModules(unittest.TestCase):
         self.assertEqual(module.ncols, 1024)
         self.assertEqual(cls.speedgrade_timings["800"].tRFC, (None, 260))
 
+    def test_ddr3_x16_trrd_uses_ck_minimum(self):
+        # JEDEC DDR3 fixes the tRRD nCK floor at 6 for x16 organisation
+        # (vs 4 for x4/x8). Every DDR3 part below is an x16 device, so the
+        # first element of `technology_timings.tRRD` must be at least 6.
+        names = [
+            "AS4C128M16",
+            "MT41K64M16",
+            "MT41J128M16", "MT41K128M16",
+            "MT41J256M16", "MT41K256M16",
+            "MT41J512M16", "MT41K512M16",
+            "K4B2G1646F",
+            "AS4C256M16D3A",
+            "AS4C256M16D3C",
+        ]
+        for name in names:
+            cls = getattr(litedram.modules, name)
+            with self.subTest(module=name):
+                self.assertGreaterEqual(cls.technology_timings.tRRD[0], 6)
+
     def test_h5tq4g63xfr_geometry_and_speedgrades(self):
         for name in ["H5TQ4G63CFR", "H5TQ4G63EFR"]:
             cls = getattr(litedram.modules, name)


### PR DESCRIPTION
## Summary

JEDEC DDR3/DDR3L specifies the four-bank `tRRD` nCK floor as **6 nCK
for x16 organisation** (vs 4 nCK for x4 and x8). #382 corrected a
single x16 SK hynix part (H5TC4G63CFR) that was still encoded with the
x4/x8 floor; this PR applies the same fix to every other affected x16
DDR3 device in `litedram/modules.py`.

## Devices touched

All confirmed x16 by part-name convention and matching geometry
(`nbanks=8`, `ncols=1024`):

| Class | Vendor | Before | After |
|---|---|---|---|
| `AS4C128M16` | Alliance Memory | `tRRD=(4, 6)` | `tRRD=(6, 6)` |
| `MT41K64M16` | Micron DDR3L | `tRRD=(4, 10)` | `tRRD=(6, 10)` |
| `MT41J128M16` | Micron DDR3 | `tRRD=(4, 10)` | `tRRD=(6, 10)` |
| `MT41J256M16` | Micron DDR3 | `tRRD=(4, 10)` | `tRRD=(6, 10)` |
| `MT41J512M16` | Micron DDR3 | `tRRD=(4, 10)` | `tRRD=(6, 10)` |
| `K4B2G1646F` | Samsung | `tRRD=(4, 10)` | `tRRD=(6, 10)` |
| `AS4C256M16D3A` | Alliance Memory | `tRRD=(4, 7.5)` | `tRRD=(6, 7.5)` |
| `AS4C256M16D3C` | Alliance Memory DDR3L | `tRRD=(4, 7.5)` | `tRRD=(6, 7.5)` |

The DDR3L subclasses `MT41K128M16` / `MT41K256M16` / `MT41K512M16`
inherit their `MT41J*` base, so the fix lands on those automatically.

Only the **nCK** element of `tRRD` is touched. The ns element is left
at the per-device datasheet value, matching the convention set by
#382. A short inline comment is added on each modified line so the
JEDEC rationale is visible at the call site.

## Scope notes

- **`IMD128M16R39CG8GNF`** (also an x16 DDR3 part) is intentionally
  excluded. Its `tRRD=(4, 7.5)` was set explicitly from the ICMAX
  datasheet in 947c4a5, and an existing test in `test/test_modules.py`
  pins that value. The JEDEC-vs-datasheet question for that specific
  part deserves its own discussion and is left for a separate PR /
  issue.
- **`K4B1G0446F`** (Samsung, line 880) is **not** an x16 part — its
  name encodes the `04` (x4) organisation — so the existing 4 nCK
  `tRRD` floor is correct and unchanged.
- ISSI `IS43TR16128B/16256A/16512B` were inspected but excluded
  pending a datasheet double-check on the ISSI naming convention.
  Happy to follow up if the maintainers confirm those are x16.
- DDR4 has its own tRRD_S/tRRD_L split and is **not** in scope here.

## Test

Adds `test_ddr3_x16_trrd_uses_ck_minimum` to
`test/test_modules.py`. It iterates the eight modified classes plus
the three inherited DDR3L subclasses (eleven classes total) and
asserts `cls.technology_timings.tRRD[0] >= 6` for each.

```
$ python -m unittest test.test_modules
.............s...
----------------------------------------------------------------------
Ran 17 tests in 0.010s
OK (skipped=1)
```

## Why this is a sweep instead of one PR per device

Same JEDEC rule, same one-line edit pattern, same single-author
authority — splitting into eight per-device PRs would multiply review
overhead without adding any signal. Reviewing this PR class-by-class
in the diff is just as easy as reviewing eight tiny PRs back-to-back.

Closes #382's gap for the rest of the DDR3 x16 family.