### PR TITLE
modules: bump H5TC4G63CFR -800 tFAW to JEDEC x16 50 ns floor

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -909,7 +909,8 @@ class H5TC4G63CFR(DDR3Module):
     # timings
     technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 7.5), tZQCS=(64, 80))
     speedgrade_timings = {
-        "800":  _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 260), tFAW=(None, 40), tRAS=37.5),
+        # JEDEC DDR3-800 x16 tFAW ns floor is 50 ns (vs 40 ns for x4/x8).
+        "800":  _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 260), tFAW=(None, 50), tRAS=37.5),
     }
     speedgrade_timings["default"] = speedgrade_timings["800"]
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -64,6 +64,7 @@ class TestSDRAMModules(unittest.TestCase):
         self.assertEqual(module.nrows, 32768)
         self.assertEqual(module.ncols, 1024)
         self.assertEqual(cls.speedgrade_timings["800"].tRFC, (None, 260))
+        self.assertEqual(cls.speedgrade_timings["800"].tFAW, (None, 50))
 
     def test_h5tq4g63xfr_geometry_and_speedgrades(self):
         for name in ["H5TQ4G63CFR", "H5TQ4G63EFR"]:


### PR DESCRIPTION
## Summary

H5TC4G63CFR was re-modelled as the SK hynix DDR3L 4Gb x16 device in
909fe8b (\"modules: fix SK hynix DDR3L geometry\"), and #382 corrected
its \`tRRD\` nCK floor to the x16 value. The \`-800\` \`tFAW\` ns floor is
still encoded with the x4/x8 value:

\`\`\`python
\"800\":  _SpeedgradeTimings(... tFAW=(None, 40), ...)
\`\`\`

JEDEC DDR3/DDR3L specifies the four-bank window \`tFAW\` ns floor as
**50 ns for DDR3-800 x16 organisation** (vs 40 ns for x4 and x8).
Every other x16 DDR3-800 module in \`litedram/modules.py\` already
encodes the 50 ns floor — MT41J128M16, MT41J256M16, MT41K64M16,
K4B2G1646F — so H5TC4G63CFR is the lone outlier.

## Change

\`\`\`diff
-        \"800\":  _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 260), tFAW=(None, 40), tRAS=37.5),
+        \"800\":  _SpeedgradeTimings(tRP=15, tRCD=15, tWR=15, tRFC=(None, 260), tFAW=(None, 50), tRAS=37.5),
\`\`\`

Plus a brief inline comment recording the JEDEC x16 floor for future
maintainers.

## Test

Extends the existing \`test_h5tc4g63cfr_geometry_and_trfc\` (added in
909fe8b, further covered in #382) with one extra assertion locking
the corrected value:

\`\`\`python
self.assertEqual(cls.speedgrade_timings[\"800\"].tFAW, (None, 50))
\`\`\`

\`python -m unittest test.test_modules\` runs all 16 tests cleanly
with the change applied.

## Why this is separate from #382

#382 bumps the **technology-scope** \`tRRD\` nCK floor; this PR bumps
a **speedgrade-scope** \`tFAW\` ns floor in the \`-800\` entry. Each is
a one-line edit driven by the same x16 JEDEC rule on a different
parameter, and they are cleanly reviewable independently.