### PR TITLE
frontend: suppress FIFO bypass drain padding

### DIFF
--- a/litedram/frontend/fifo.py
+++ b/litedram/frontend/fifo.py
@@ -309,8 +309,8 @@ class LiteDRAMFIFO(Module):
             dram_inc     = Signal()
             dram_dec     = Signal()
             dram_cnt     = Signal(port_address_width)
-            dram_inc_mod = Signal(max=data_width_ratio)
-            dram_dec_mod = Signal(max=data_width_ratio)
+            dram_inc_mod = Signal(max=max(data_width_ratio, 2))
+            dram_dec_mod = Signal(max=max(data_width_ratio, 2))
             dram_flush_count  = Signal(max=max(data_width_ratio, 2))
             dram_flush_output = Signal(max=max(data_width_ratio, 2))
             dram_flush_total  = Signal(max=max(data_width_ratio, 2))
@@ -341,7 +341,11 @@ class LiteDRAMFIFO(Module):
                 ),
                 If(pre_converter.sink.valid & pre_converter.sink.ready,
                     If(data_width_ratio > 1,
-                        NextValue(dram_inc_mod, dram_inc_mod + 1),
+                        If(dram_inc_mod == (data_width_ratio - 1),
+                            NextValue(dram_inc_mod, 0),
+                        ).Else(
+                            NextValue(dram_inc_mod, dram_inc_mod + 1),
+                        )
                     )
                 ),
 
@@ -351,7 +355,11 @@ class LiteDRAMFIFO(Module):
                 ),
                 If(post_converter.source.valid & post_converter.source.ready,
                     If(data_width_ratio > 1,
-                        NextValue(dram_dec_mod, dram_dec_mod + 1),
+                        If(dram_dec_mod == (data_width_ratio - 1),
+                            NextValue(dram_dec_mod, 0),
+                        ).Else(
+                            NextValue(dram_dec_mod, dram_dec_mod + 1),
+                        )
                     )
                 ),
 
@@ -373,41 +381,59 @@ class LiteDRAMFIFO(Module):
                     )
                 )
             )
-            fsm.act("PUMP_PRECONVERTER",
-                pre_converter.source.connect(post_converter.sink),
-                If(dram_flush_output < dram_flush_count,
-                    post_converter.source.connect(post_fifo.sink),
-                ).Else(
-                    post_fifo.sink.valid.eq(0),
-                    post_converter.source.ready.eq(1),
-                ),
-                If(pre_converter.source.valid,
-                    If(post_converter.source.valid & post_converter.source.ready,
-                        NextValue(dram_flush_total, dram_flush_total + 1),
-                        If(dram_flush_output < dram_flush_count,
-                            NextValue(dram_flush_output, dram_flush_output + 1),
+            if data_width_ratio == 1:
+                # The flush states are unreachable when the converters have equal widths. Keep
+                # their hardware paths inert to avoid a combinatorial valid loop through the two
+                # identity converters.
+                fsm.act("PUMP_PRECONVERTER",
+                    NextState("BYPASS"),
+                )
+                fsm.act("DRAIN_POSTCONVERTER",
+                    NextState("BYPASS"),
+                )
+            else:
+                fsm.act("PUMP_PRECONVERTER",
+                    pre_converter.source.connect(post_converter.sink),
+                    If(dram_flush_output < dram_flush_count,
+                        post_converter.source.connect(post_fifo.sink),
+                    ).Else(
+                        post_fifo.sink.valid.eq(0),
+                        post_converter.source.ready.eq(1),
+                    ),
+                    If(pre_converter.source.valid,
+                        If(post_converter.source.valid & post_converter.source.ready,
+                            If(dram_flush_output < dram_flush_count,
+                                NextValue(dram_flush_output, dram_flush_output + 1),
+                            ),
+                            If(dram_flush_total == (data_width_ratio - 1),
+                                NextValue(dram_inc_mod, 0),
+                                NextValue(dram_dec_mod, 0),
+                                NextValue(dram_flush_count, 0),
+                                NextValue(dram_flush_output, 0),
+                                NextValue(dram_flush_total, 0),
+                                NextState("BYPASS")
+                            ).Else(
+                                NextValue(dram_flush_total, dram_flush_total + 1),
+                            )
+                        )
+                    ).Else(
+                        pre_converter.sink.valid.eq(1),
+                    )
+                )
+                fsm.act("DRAIN_POSTCONVERTER",
+                    If(dram_dec_mod == 0,
+                        If(dram_flush_count == 0,
+                            NextState("BYPASS"),
+                        ).Else(
+                            NextState("PUMP_PRECONVERTER"),
                         ),
-                        If(dram_flush_total == (data_width_ratio - 1),
-                            NextValue(dram_inc_mod, 0),
-                            NextValue(dram_dec_mod, 0),
-                            NextValue(dram_flush_count, 0),
-                            NextState("BYPASS")
+                    ).Else(
+                        If(post_converter.source.valid & post_converter.source.ready,
+                            If(dram_dec_mod == (data_width_ratio - 1),
+                                NextValue(dram_dec_mod, 0),
+                            ).Else(
+                                NextValue(dram_dec_mod, dram_dec_mod + 1),
+                            )
                         )
                     )
-                ).Else(
-                    pre_converter.sink.valid.eq(1),
                 )
-            )
-            fsm.act("DRAIN_POSTCONVERTER",
-                If(dram_dec_mod == 0,
-                    If(dram_flush_count == 0,
-                        NextState("BYPASS"),
-                    ).Else(
-                        NextState("PUMP_PRECONVERTER"),
-                    ),
-                ).Else(
-                    If(post_converter.source.valid & post_converter.source.ready,
-                        NextValue(dram_dec_mod, dram_dec_mod + 1),
-                    )
-                )
-            )

--- a/litedram/frontend/fifo.py
+++ b/litedram/frontend/fifo.py
@@ -5,8 +5,6 @@
 # Copyright (c) 2020 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import math
-
 from migen import *
 
 from litex.soc.interconnect import stream
@@ -311,8 +309,11 @@ class LiteDRAMFIFO(Module):
             dram_inc     = Signal()
             dram_dec     = Signal()
             dram_cnt     = Signal(port_address_width)
-            dram_inc_mod = Signal(max(int(math.log2(data_width_ratio)), 1))
-            dram_dec_mod = Signal(max(int(math.log2(data_width_ratio)), 1))
+            dram_inc_mod = Signal(max=data_width_ratio)
+            dram_dec_mod = Signal(max=data_width_ratio)
+            dram_flush_count  = Signal(max=max(data_width_ratio, 2))
+            dram_flush_output = Signal(max=max(data_width_ratio, 2))
+            dram_flush_total  = Signal(max=max(data_width_ratio, 2))
 
             self.submodules.fsm = fsm = FSM(reset_state="BYPASS")
             fsm.act("BYPASS",
@@ -321,6 +322,11 @@ class LiteDRAMFIFO(Module):
                 If(dram_store_threshold,
                     NextValue(dram_first, 1),
                     NextValue(dram_cnt,   0),
+                    NextValue(dram_inc_mod, 0),
+                    NextValue(dram_dec_mod, 0),
+                    NextValue(dram_flush_count,  0),
+                    NextValue(dram_flush_output, 0),
+                    NextValue(dram_flush_total,  0),
                     NextState("DRAM")
                 )
             )
@@ -355,33 +361,49 @@ class LiteDRAMFIFO(Module):
                 # Switch back to Bypass mode when no remaining DRAM word.
                 If((dram_first == 0) & (dram_cnt == 0),
                     dram_store.eq(0),
-                    If((dram_dec_mod == 0) & (dram_inc_mod == 0), 
+                    NextValue(dram_flush_count, dram_inc_mod),
+                    NextValue(dram_flush_output, 0),
+                    NextValue(dram_flush_total,  0),
+                    If(dram_dec_mod != 0,
+                        NextState("DRAIN_POSTCONVERTER")
+                    ).Elif(dram_inc_mod == 0,
                         NextState("BYPASS")
                     ).Else(
                         NextState("PUMP_PRECONVERTER"),
-                        NextValue(dram_dec_mod, dram_inc_mod),
                     )
                 )
             )
             fsm.act("PUMP_PRECONVERTER",
                 pre_converter.source.connect(post_converter.sink),
-                If(dram_inc_mod == 0,
-                    NextState("DRAIN_POSTCONVERTER")
+                If(dram_flush_output < dram_flush_count,
+                    post_converter.source.connect(post_fifo.sink),
+                ).Else(
+                    post_fifo.sink.valid.eq(0),
+                    post_converter.source.ready.eq(1),
+                ),
+                If(pre_converter.source.valid,
+                    If(post_converter.source.valid & post_converter.source.ready,
+                        NextValue(dram_flush_total, dram_flush_total + 1),
+                        If(dram_flush_output < dram_flush_count,
+                            NextValue(dram_flush_output, dram_flush_output + 1),
+                        ),
+                        If(dram_flush_total == (data_width_ratio - 1),
+                            NextValue(dram_inc_mod, 0),
+                            NextValue(dram_dec_mod, 0),
+                            NextValue(dram_flush_count, 0),
+                            NextState("BYPASS")
+                        )
+                    )
                 ).Else(
                     pre_converter.sink.valid.eq(1),
-                    If(pre_converter.source.valid & pre_converter.source.ready,
-                        NextValue(dram_inc_mod, dram_inc_mod + 1),
-                    )
                 )
             )
             fsm.act("DRAIN_POSTCONVERTER",
-                pre_converter.source.connect(post_converter.sink),
                 If(dram_dec_mod == 0,
-                    If(dram_inc_mod == 0,
+                    If(dram_flush_count == 0,
                         NextState("BYPASS"),
                     ).Else(
                         NextState("PUMP_PRECONVERTER"),
-                        NextValue(dram_dec_mod, dram_inc_mod),
                     ),
                 ).Else(
                     If(post_converter.source.valid & post_converter.source.ready,

--- a/test/test_fifo.py
+++ b/test/test_fifo.py
@@ -342,6 +342,7 @@ class TestFIFO(unittest.TestCase):
                 data = (yield from dut.read())
                 self.assertEqual(data, 10 + N + i)
             for i in range(16):
+                self.assertEqual((yield dut.fifo.source.valid), 0)
                 yield
 
         dut = FIFODUT(data_width=32, base=16, depth=64, with_bypass=True)
@@ -355,5 +356,5 @@ class TestFIFO(unittest.TestCase):
         run_simulation(dut, generators)
 
     def test_fifo_partial_bypass_reader(self):
-        for N in range(3):
+        for N in range(5):
             self.fifo_partial_bypass_reader_test(N)

--- a/test/test_fifo.py
+++ b/test/test_fifo.py
@@ -10,6 +10,7 @@ import random
 
 from migen import *
 
+from litex.gen.fhdl import verilog
 from litex.soc.interconnect.stream import *
 
 from litedram.common import LiteDRAMNativeWritePort
@@ -21,8 +22,9 @@ from test.common import *
 
 
 class FIFODUT(Module):
-    def __init__(self, base, depth, data_width=8, address_width=32, with_bypass=False):
-        port_data_width = data_width if not with_bypass else 4*data_width
+    def __init__(self, base, depth, data_width=8, address_width=32, with_bypass=False,
+        data_width_ratio=4):
+        port_data_width = data_width if not with_bypass else data_width_ratio*data_width
         self.write_port = LiteDRAMNativeWritePort(address_width=32, data_width=port_data_width)
         self.read_port  = LiteDRAMNativeReadPort(address_width=32,  data_width=port_data_width)
         self.submodules.fifo = LiteDRAMFIFO(
@@ -321,7 +323,7 @@ class TestFIFO(unittest.TestCase):
     def test_fifo_delayed_reader_with_bypass(self):
         self.fifo_delayed_reader_test(with_bypass=True)
 
-    def fifo_partial_bypass_reader_test(self, N):
+    def fifo_partial_bypass_reader_test(self, N, data_width_ratio=4):
         # Verify FIFO works correctly when reader reads N words through the bypass
         def generator(dut):
             for i in range(64):
@@ -345,7 +347,13 @@ class TestFIFO(unittest.TestCase):
                 self.assertEqual((yield dut.fifo.source.valid), 0)
                 yield
 
-        dut = FIFODUT(data_width=32, base=16, depth=64, with_bypass=True)
+        dut = FIFODUT(
+            data_width       = 32,
+            data_width_ratio = data_width_ratio,
+            base             = 16,
+            depth            = 64,
+            with_bypass      = True,
+        )
         generators = [
             generator(dut),
             checker(dut),
@@ -358,3 +366,17 @@ class TestFIFO(unittest.TestCase):
     def test_fifo_partial_bypass_reader(self):
         for N in range(5):
             self.fifo_partial_bypass_reader_test(N)
+
+    def test_fifo_partial_bypass_reader_ratio_3(self):
+        self.fifo_partial_bypass_reader_test(N=1, data_width_ratio=3)
+
+    def test_fifo_bypass_equal_data_widths(self):
+        dut = FIFODUT(
+            data_width       = 32,
+            data_width_ratio = 1,
+            base             = 16,
+            depth            = 64,
+            with_bypass      = True,
+        )
+        dut.clock_domains.cd_sys = ClockDomain()
+        verilog.convert(dut, ios={dut.fifo.sink.valid}, comb_cycle_policy="error")


### PR DESCRIPTION
## Summary

Fix `LiteDRAMFIFO` bypass-to-DRAM drain handling when the bypass path consumes a non-DRAM-word-aligned number of input words.

This follows up on #372. The original timeout case is now covered on `master`, but the current drain/pump workaround can still expose padded converter words as real FIFO output. With a 4:1 stream-to-DRAM width ratio, reading `N = 1`, `2`, or `3` words through bypass before the writer completes can produce extra zero words after the expected payload.

Fixes #372.

## Implementation

- Size `dram_inc_mod` / `dram_dec_mod` for the actual `data_width_ratio`.
- When leaving DRAM mode, first drain any already-active post-converter output.
- Flush the residual pre-converter word only when needed.
- Forward only the real residual words from that flushed word and silently drain the padded converter output.
- Reset the drain bookkeeping when entering DRAM mode.

The existing FSM structure is preserved; the change only makes the `PUMP_PRECONVERTER` / `DRAIN_POSTCONVERTER` handoff explicit about real vs padded tokens.

## Tests

Updated `test_fifo_partial_bypass_reader` to:

- cover `N = 0..4`, including aligned and unaligned bypass counts;
- assert that no extra FIFO output is valid after the expected payload.

Validation:

- `pytest test/test_fifo.py -q`

Result:

`14 passed`
