### PR TITLE
gen: preserve CSR map in sim builds

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -490,6 +490,13 @@ class LiteDRAMCoreControl(LiteXModule):
         self.init_done  = CSRStorage()
         self.init_error = CSRStorage()
 
+# LiteDRAMCoreSimPHY -------------------------------------------------------------------------------
+
+class LiteDRAMCoreSimPHY(SDRAMPHYModel, AutoCSR):
+    def __init__(self, *args, **kwargs):
+        SDRAMPHYModel.__init__(self, *args, **kwargs)
+        self._reserved = CSRGap(name="reserved", name_start=None)
+
 # LiteDRAMCore -------------------------------------------------------------------------------------
 
 class LiteDRAMCore(SoCCore):
@@ -584,7 +591,7 @@ class LiteDRAMCore(SoCCore):
                 memtype    = sdram_module.memtype,
                 data_width = core_config["sdram_module_nb"]*8,
                 clk_freq   = sys_clk_freq)
-            self.ddrphy = sdram_phy = SDRAMPHYModel(
+            self.ddrphy = sdram_phy = LiteDRAMCoreSimPHY(
                 module    = sdram_module,
                 settings  = phy_settings,
                 clk_freq  = sys_clk_freq)

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -1,0 +1,59 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.build.sim    import SimPlatform
+from litex.build.xilinx import XilinxPlatform
+
+from litedram import modules as litedram_modules
+from litedram import phy     as litedram_phys
+from litedram.gen import LiteDRAMCore
+
+
+def core_config():
+    return {
+        "cpu"             : None,
+        "memtype"         : "DDR3",
+        "sdram_phy"       : litedram_phys.A7DDRPHY,
+        "sdram_module"    : litedram_modules.MT41K128M16,
+        "sdram_module_nb" : 2,
+        "sdram_rank_nb"   : 1,
+        "input_clk_freq"  : 100e6,
+        "sys_clk_freq"    : 100e6,
+        "iodelay_clk_freq": 200e6,
+        "cmd_latency"     : 0,
+        "speedgrade"      : -1,
+        "user_ports"      : {
+            "native_0": {
+                "type": "native",
+            },
+        },
+    }
+
+
+def csr_locations(platform):
+    soc = LiteDRAMCore(platform, core_config(), integrated_rom_size=0xc000)
+    soc.finalize()
+
+    csr_origin = soc.bus.regions["csr"].origin
+    return {
+        name: (region.origin - csr_origin)//soc.csr.paging
+        for name, region in soc.csr.regions.items()
+    }
+
+
+class TestGen(unittest.TestCase):
+    def test_sim_csr_map_matches_hardware(self):
+        hw_locations  = csr_locations(XilinxPlatform("", io=[], toolchain="vivado"))
+        sim_locations = csr_locations(SimPlatform("", io=[]))
+
+        for name in ["ddrctrl", "ddrphy", "sdram"]:
+            self.assertEqual(sim_locations[name], hw_locations[name])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #367.

When `litedram_gen` runs with `--sim`, the hardware PHY is replaced by `SDRAMPHYModel`. Since this model exposes no CSRs, LiteX compacted the generated CSR map and moved the `sdram` bank from location 2 to location 1, which made the sim-generated CSR files differ from hardware builds and removed `csrbank_2`.

This keeps the simulation PHY behavior unchanged, but uses a generator-local `LiteDRAMCoreSimPHY` wrapper with a single reserved `ddrphy` CSR slot. This preserves `ddrctrl`, `ddrphy`, and `sdram` bank locations without emulating hardware PHY calibration registers.

Tests:
- `pytest -q test/test_gen.py`
- `pytest -q test/test_examples.py::TestExamples::test_arty`
- Generated the issue's Artix-7 config with and without `--sim` and verified both keep `ddrctrl=0x0000`, `ddrphy=0x0800`, `sdram=0x1000`.