### PR TITLE
adapter: flush repeated upconverter chunks

### DIFF
--- a/litedram/frontend/adapter.py
+++ b/litedram/frontend/adapter.py
@@ -157,6 +157,8 @@ class LiteDRAMNativePortUpConverter(Module):
 
         # Defines cmd type and the chunks that have been requested for the current port_to command.
         sel              = Signal(ratio)
+        cmd_sel          = Signal(ratio)
+        cmd_selected     = Signal()
         cmd_buffer       = stream.SyncFIFO([("sel", ratio), ("we", 1)], 0)
         self.submodules += cmd_buffer
         # Store last received command.
@@ -186,7 +188,7 @@ class LiteDRAMNativePortUpConverter(Module):
                 NextValue(cmd_addr, port_from.cmd.addr),
                 NextValue(cmd_we, port_from.cmd.we),
                 NextValue(cmd_last, port_from.cmd.last),
-                NextValue(sel, 1 << port_from.cmd.addr[:log2_int(ratio)]),
+                NextValue(sel, cmd_sel),
                 If(port_from.cmd.we,
                     NextState("FILL"),
                 ).Else(
@@ -213,7 +215,7 @@ class LiteDRAMNativePortUpConverter(Module):
                 port_from.cmd.ready.eq(port_from.cmd.valid),
                 NextValue(cmd_last, port_from.cmd.last),
                 If(port_from.cmd.valid,
-                    NextValue(sel, sel | 1 << port_from.cmd.addr[:log2_int(ratio)])
+                    NextValue(sel, sel | cmd_sel)
                 )
             )
         )
@@ -231,6 +233,8 @@ class LiteDRAMNativePortUpConverter(Module):
         )
 
         self.comb += [
+            cmd_sel.eq(1 << port_from.cmd.addr[:log2_int(ratio)]),
+            cmd_selected.eq((sel & cmd_sel) != 0),
             cmd_buffer.source.ready.eq(wdata_finished | rdata_finished),
             addr_changed.eq(cmd_addr[log2_int(ratio):] != port_from.cmd.addr[log2_int(ratio):]),
             # Collision happens on write to read transition when address does not change.
@@ -238,11 +242,13 @@ class LiteDRAMNativePortUpConverter(Module):
             # Go to the next command if one of the following happens:
             #  - port_to address changes.
             #  - cmd type changes.
+            #  - the requested chunk has already been selected.
             #  - we received all the `ratio` commands.
             #  - this is the last command in a sequence.
             #  - master requests a flush (even after the command has been sent).
-            next_cmd.eq(addr_changed | (cmd_we != port_from.cmd.we) | (sel == 2**ratio - 1)
-                        | cmd_last | port_from.flush),
+            next_cmd.eq(addr_changed | (cmd_we != port_from.cmd.we)
+                        | (port_from.cmd.valid & cmd_selected)
+                        | (sel == 2**ratio - 1) | cmd_last | port_from.flush),
         ]
 
         self.sync += [

--- a/test/test_adapter.py
+++ b/test/test_adapter.py
@@ -307,6 +307,37 @@ class TestAdapter(MemoryTestDataMixin, unittest.TestCase):
         self.converter_readback_test(dut, pattern=pattern, mem_expected=mem_expected,
                                      main_generator=main_generator)
 
+    def test_up_converter_auto_flush_on_repeated_chunk(self):
+        # Verify that up-conversion does not merge two commands using the same chunk.
+        def main_generator(dut):
+            yield from dut.write(0x19, 0xffffffff, wait_data=False)
+            yield from dut.write(0x19, 0x11111111, wait_data=False)
+            yield from dut.read(0x19, wait_data=False, last=1)
+
+            yield from dut.write_driver.wait_all()
+            yield from dut.read_driver.wait_all()
+            for _ in range(8):  # wait for memory
+                yield
+
+        mem_expected = [
+            0x00000000000000000000000000000000,  # 0x00
+            0x00000000000000000000000000000000,  # 0x04
+            0x00000000000000000000000000000000,  # 0x08
+            0x00000000000000000000000000000000,  # 0x0c
+            0x00000000000000000000000000000000,  # 0x10
+            0x00000000000000000000000000000000,  # 0x14
+            0x00000000000000001111111100000000,  # 0x18
+            0x00000000000000000000000000000000,  # 0x1c
+        ]
+        pattern = [
+            (0x19, 0x11111111),
+        ]
+
+        dut  = ConverterDUT(user_data_width=32, native_data_width=128,
+                            mem_depth=len(mem_expected), separate_rw=False)
+        self.converter_readback_test(dut, pattern=pattern, mem_expected=mem_expected,
+                                     main_generator=main_generator)
+
     def test_up_converter_write_with_gap(self):
         # Verify that the up-converter can mask data properly when sending non-sequential writes
         def main_generator(dut):


### PR DESCRIPTION
Fixes #358.

The native port up-converter merged commands while building a wider native word, but it did not detect when a new command targeted a chunk that was already selected in the current aggregate. In that case, the command could be accepted while its write data stayed behind in the write-data FIFO; a later colliding read could then observe the older value.

This adds a repeated-chunk check to the existing `next_cmd` conditions, so the current aggregate is committed before accepting another command for the same chunk. Address changes, read/write changes, full aggregates, `cmd.last`, and explicit flushes keep their existing behavior.

A regression test covers the simplified issue sequence: write `0xffffffff` to `0x19`, write `0x11111111` to `0x19`, then read `0x19` and expect the second value.

Tests:
- `pytest -q test/test_adapter.py`
- `pytest -q test/test_adaptation.py`