### PR TITLE
dma: keep CSR writer sink blocked while disabled

### DIFF
--- a/litedram/frontend/dma.py
+++ b/litedram/frontend/dma.py
@@ -249,7 +249,6 @@ class LiteDRAMDMAWriter(Module, AutoCSR):
         self.submodules.fsm = fsm
         self.comb += fsm.reset.eq(~self._enable.storage)
         fsm.act("IDLE",
-            self.sink.ready.eq(1),
             NextValue(offset, 0),
             NextState("RUN"),
         )

--- a/test/test_dma.py
+++ b/test/test_dma.py
@@ -124,6 +124,42 @@ class TestDMA(MemoryTestDataMixin, unittest.TestCase):
         data = self.pattern_test_data["32bit_duplicates"]
         self.dma_writer_test(data["pattern"], data["expected"], data_width=32)
 
+    def test_dma_writer_csr_disabled_sink_not_ready(self):
+        # Verify DMAWriter with CSR control does not sink data before being enabled.
+        class DUT(Module):
+            def __init__(self):
+                self.port = LiteDRAMNativeWritePort(address_width=32, data_width=32)
+                self.submodules.dma = LiteDRAMDMAWriter(self.port, with_csr=True)
+
+        def main_generator(dut):
+            yield dut.dma._base.storage.eq(0x00)
+            yield dut.dma._length.storage.eq(0x04)
+            yield dut.dma.sink.valid.eq(1)
+            yield dut.dma.sink.data.eq(0xdeadbeef)
+
+            for _ in range(4):
+                self.assertEqual((yield dut.dma.sink.ready), 0)
+                yield
+
+            yield dut.dma._enable.storage.eq(1)
+            while not (yield dut.dma.sink.ready):
+                yield
+            yield
+            yield dut.dma.sink.valid.eq(0)
+
+            for _ in range(8):  # wait for memory
+                yield
+
+        dut = DUT()
+        mem = DRAMMemory(32, 4)
+
+        run_simulation(dut, [
+            main_generator(dut),
+            mem.write_handler(dut.port),
+            timeout_generator(1000),
+        ])
+        self.assertEqual(mem.mem[0], 0xdeadbeef)
+
     # LiteDRAMDMAReader ----------------------------------------------------------------------------
 
     def dma_reader_test(self, pattern, mem_expected, data_width, **kwargs):


### PR DESCRIPTION
Fixes #356.

`LiteDRAMDMAWriter.add_csr()` resets its FSM while `_enable=0`. The reset state asserted `sink.ready`, so a CSR-controlled DMA writer could accept stream data before software enabled the transfer and drop that word.

This keeps the CSR writer sink backpressured while disabled by no longer asserting `sink.ready` from the reset/IDLE state. Once enabled, the existing RUN state drives ready from the internal address/data sink as before.

A regression test holds a valid stream word before enabling the DMA, checks `sink.ready` remains low, then enables the DMA and verifies the held word is written to memory.

Note: the packet `sink.last` termination feature discussed in the issue is intentionally left out of this PR since it changes DMA semantics and should probably be handled separately/explicitly.

Tests:
- `pytest -q test/test_dma.py`