### PR TITLE
gen: gate AXI user ports until ready

### DIFF
--- a/litedram/gen.py
+++ b/litedram/gen.py
@@ -278,6 +278,48 @@ def get_axi_user_port_ios(_id, aw, dw, iw):
         ),
     ]
 
+def connect_axi_user_port(axi_port, axi_port_io, user_enable):
+    return [
+        # AW Channel.
+        axi_port.aw.valid.eq(axi_port_io.awvalid & user_enable),
+        axi_port_io.awready.eq(axi_port.aw.ready & user_enable),
+        axi_port.aw.addr.eq(axi_port_io.awaddr),
+        axi_port.aw.burst.eq(axi_port_io.awburst),
+        axi_port.aw.len.eq(axi_port_io.awlen),
+        axi_port.aw.size.eq(axi_port_io.awsize),
+        axi_port.aw.id.eq(axi_port_io.awid),
+
+        # W Channel.
+        axi_port.w.valid.eq(axi_port_io.wvalid & user_enable),
+        axi_port_io.wready.eq(axi_port.w.ready & user_enable),
+        axi_port.w.last.eq(axi_port_io.wlast),
+        axi_port.w.strb.eq(axi_port_io.wstrb),
+        axi_port.w.data.eq(axi_port_io.wdata),
+
+        # B Channel.
+        axi_port_io.bvalid.eq(axi_port.b.valid & user_enable),
+        axi_port.b.ready.eq(axi_port_io.bready & user_enable),
+        axi_port_io.bresp.eq(axi_port.b.resp),
+        axi_port_io.bid.eq(axi_port.b.id),
+
+        # AR Channel.
+        axi_port.ar.valid.eq(axi_port_io.arvalid & user_enable),
+        axi_port_io.arready.eq(axi_port.ar.ready & user_enable),
+        axi_port.ar.addr.eq(axi_port_io.araddr),
+        axi_port.ar.burst.eq(axi_port_io.arburst),
+        axi_port.ar.len.eq(axi_port_io.arlen),
+        axi_port.ar.size.eq(axi_port_io.arsize),
+        axi_port.ar.id.eq(axi_port_io.arid),
+
+        # R Channel.
+        axi_port_io.rvalid.eq(axi_port.r.valid & user_enable),
+        axi_port.r.ready.eq(axi_port_io.rready & user_enable),
+        axi_port_io.rlast.eq(axi_port.r.last),
+        axi_port_io.rresp.eq(axi_port.r.resp),
+        axi_port_io.rdata.eq(axi_port.r.data),
+        axi_port_io.rid.eq(axi_port.r.id),
+    ]
+
 def get_fifo_user_port_ios(_id, dw):
     return [
         ("user_fifo_{}".format(_id), 0,
@@ -787,46 +829,7 @@ class LiteDRAMCore(SoCCore):
                         axi_port.data_width,
                         port["id_width"]))
                 _axi_port_io = platform.request("user_port_{}".format(name))
-                self.comb += [
-                    # AW Channel.
-                    axi_port.aw.valid.eq(_axi_port_io.awvalid & user_enable),
-                    _axi_port_io.awready.eq(axi_port.aw.ready & user_enable),
-                    axi_port.aw.addr.eq(_axi_port_io.awaddr),
-                    axi_port.aw.burst.eq(_axi_port_io.awburst),
-                    axi_port.aw.len.eq(_axi_port_io.awlen),
-                    axi_port.aw.size.eq(_axi_port_io.awsize),
-                    axi_port.aw.id.eq(_axi_port_io.awid),
-
-                    # W Channel.
-                    axi_port.w.valid.eq(_axi_port_io.wvalid),
-                    _axi_port_io.wready.eq(axi_port.w.ready),
-                    axi_port.w.last.eq(_axi_port_io.wlast),
-                    axi_port.w.strb.eq(_axi_port_io.wstrb),
-                    axi_port.w.data.eq(_axi_port_io.wdata),
-
-                    # B Channel.
-                    _axi_port_io.bvalid.eq(axi_port.b.valid),
-                    axi_port.b.ready.eq(_axi_port_io.bready),
-                    _axi_port_io.bresp.eq(axi_port.b.resp),
-                    _axi_port_io.bid.eq(axi_port.b.id),
-
-                    # AR Channel.
-                    axi_port.ar.valid.eq(_axi_port_io.arvalid & user_enable),
-                    _axi_port_io.arready.eq(axi_port.ar.ready & user_enable),
-                    axi_port.ar.addr.eq(_axi_port_io.araddr),
-                    axi_port.ar.burst.eq(_axi_port_io.arburst),
-                    axi_port.ar.len.eq(_axi_port_io.arlen),
-                    axi_port.ar.size.eq(_axi_port_io.arsize),
-                    axi_port.ar.id.eq(_axi_port_io.arid),
-
-                    # R Channel.
-                    _axi_port_io.rvalid.eq(axi_port.r.valid),
-                    axi_port.r.ready.eq(_axi_port_io.rready),
-                    _axi_port_io.rlast.eq(axi_port.r.last),
-                    _axi_port_io.rresp.eq(axi_port.r.resp),
-                    _axi_port_io.rdata.eq(axi_port.r.data),
-                    _axi_port_io.rid.eq(axi_port.r.id),
-                ]
+                self.comb += connect_axi_user_port(axi_port, _axi_port_io, user_enable)
             # FIFO ---------------------------------------------------------------------------------
             elif port["type"] == "fifo":
                 data_width = port.get("data_width", self.sdram.crossbar.controller.data_width)

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -1,0 +1,106 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.gen.sim import run_simulation
+
+from litedram.frontend.axi import LiteDRAMAXIPort
+from litedram.gen import connect_axi_user_port
+
+
+axi_user_port_layout = [
+    ("awvalid", 1),
+    ("awready", 1),
+    ("awaddr",  32),
+    ("awburst", 2),
+    ("awlen",   8),
+    ("awsize",  3),
+    ("awid",    8),
+
+    ("wvalid", 1),
+    ("wready", 1),
+    ("wlast",  1),
+    ("wstrb",  4),
+    ("wdata",  32),
+
+    ("bvalid", 1),
+    ("bready", 1),
+    ("bresp",  2),
+    ("bid",    8),
+
+    ("arvalid", 1),
+    ("arready", 1),
+    ("araddr",  32),
+    ("arburst", 2),
+    ("arlen",   8),
+    ("arsize",  3),
+    ("arid",    8),
+
+    ("rvalid", 1),
+    ("rready", 1),
+    ("rlast",  1),
+    ("rresp",  2),
+    ("rdata",  32),
+    ("rid",    8),
+]
+
+
+class AXIUserPortDUT(Module):
+    def __init__(self):
+        self.user_enable = Signal()
+        self.axi  = LiteDRAMAXIPort(data_width=32, address_width=32, id_width=8)
+        self.pads = Record(axi_user_port_layout)
+
+        self.comb += connect_axi_user_port(self.axi, self.pads, self.user_enable)
+
+
+class TestGEN(unittest.TestCase):
+    def test_axi_user_port_block_until_ready(self):
+        dut = AXIUserPortDUT()
+
+        def main_generator():
+            yield dut.pads.awvalid.eq(1)
+            yield dut.pads.wvalid.eq(1)
+            yield dut.pads.bready.eq(1)
+            yield dut.pads.arvalid.eq(1)
+            yield dut.pads.rready.eq(1)
+
+            yield dut.axi.aw.ready.eq(1)
+            yield dut.axi.w.ready.eq(1)
+            yield dut.axi.b.valid.eq(1)
+            yield dut.axi.ar.ready.eq(1)
+            yield dut.axi.r.valid.eq(1)
+            yield
+
+            self.assertEqual((yield dut.axi.aw.valid), 0)
+            self.assertEqual((yield dut.pads.awready), 0)
+            self.assertEqual((yield dut.axi.w.valid), 0)
+            self.assertEqual((yield dut.pads.wready), 0)
+            self.assertEqual((yield dut.pads.bvalid), 0)
+            self.assertEqual((yield dut.axi.b.ready), 0)
+            self.assertEqual((yield dut.axi.ar.valid), 0)
+            self.assertEqual((yield dut.pads.arready), 0)
+            self.assertEqual((yield dut.pads.rvalid), 0)
+            self.assertEqual((yield dut.axi.r.ready), 0)
+
+            yield dut.user_enable.eq(1)
+            yield
+
+            self.assertEqual((yield dut.axi.aw.valid), 1)
+            self.assertEqual((yield dut.pads.awready), 1)
+            self.assertEqual((yield dut.axi.w.valid), 1)
+            self.assertEqual((yield dut.pads.wready), 1)
+            self.assertEqual((yield dut.pads.bvalid), 1)
+            self.assertEqual((yield dut.axi.b.ready), 1)
+            self.assertEqual((yield dut.axi.ar.valid), 1)
+            self.assertEqual((yield dut.pads.arready), 1)
+            self.assertEqual((yield dut.pads.rvalid), 1)
+            self.assertEqual((yield dut.axi.r.ready), 1)
+
+        run_simulation(dut, main_generator())


### PR DESCRIPTION
## Summary

This tightens the standalone generator AXI user-port gating when `block_until_ready` is enabled.

Previously, generated AXI ports gated `AW` and `AR` with `user_enable`, but left `W`, `B` and `R` active. This allowed write data to be accepted before the controller had reported `init_done`, which could desynchronize the first AXI write command/data pair in generated standalone cores.

The change factors the generated AXI pad wiring into a small helper and applies `user_enable` consistently to all AXI handshake channels:

- `AW` / `W` / `AR` valid and ready handshakes.
- `B` / `R` valid and ready handshakes.
- Payload signals remain directly wired, as with the other generated user ports.

Related to #345.

## Notes

This does not change the LiteDRAM DFI phase steering. For S7 DDR3, seeing write-related command activity on `wrcmdphase` is expected from the existing `wrphase - 1` command steering.

## Tests

- `pytest -q test/test_gen.py`
- `pytest -q test/test_axi.py`
- `pytest -q test/test_examples.py::TestExamples::test_arty`
