### PR TITLE
modules: bump tRRD nCK floor to 6 for ISSI DDR3 x16 parts (extends #383)

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -945,7 +945,8 @@ class IS43TR16128B(DDR3Module):
     nrows  = 16384
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 6), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 6), tZQCS=(64, 80))
     speedgrade_timings = {
         "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=15, tRFC=(None, 160), tFAW=(None, 40), tRAS=35),
     }
@@ -957,7 +958,8 @@ class IS43TR16256A(DDR3Module):
     nrows  = 32768
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 6), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 6), tZQCS=(64, 80))
     speedgrade_timings = {
         "1600": _SpeedgradeTimings(tRP=13.75, tRCD=13.75, tWR=15, tRFC=(None, 260), tFAW=(None, 30), tRAS=35),
     }
@@ -969,7 +971,8 @@ class IS43TR16512B(DDR3Module):
     nrows  = 65536
     ncols  = 1024
     # timings
-    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 10), tZQCS=(64, 80))
+    # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+    technology_timings = _TechnologyTimings(tREFI=64e6/8192, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(6, 10), tZQCS=(64, 80))
     speedgrade_timings = {
         "800":  _SpeedgradeTimings(tRP=15,     tRCD=15,     tWR=15, tRFC=(None, 350), tFAW=(None, 50), tRAS=37.5),
         "1066": _SpeedgradeTimings(tRP=13.125, tRCD=13.125, tWR=15, tRFC=(None, 350), tFAW=(None, 50), tRAS=37.5),

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -91,6 +91,10 @@ class TestSDRAMModules(unittest.TestCase):
             "K4B2G1646F",
             "AS4C256M16D3A",
             "AS4C256M16D3C",
+            # ISSI DDR3 x16 series (extends the sweep to the IS43TR16* family).
+            "IS43TR16128B",
+            "IS43TR16256A",
+            "IS43TR16512B",
         ]
         for name in names:
             cls = getattr(litedram.modules, name)


### PR DESCRIPTION
## Summary

PR #383 applied the JEDEC DDR3 x16 `tRRD` nCK floor (6 nCK for x16
organisation vs 4 nCK for x4/x8) across the Micron / Samsung /
Alliance families in a single sweep, but the three ISSI IS43TR16*
x16 devices in `litedram/modules.py` were not part of that sweep
and are still encoded with the x4/x8 floor:

```python
class IS43TR16128B(DDR3Module):
    # ...
    technology_timings = _TechnologyTimings(... tRRD=(4, 6),  ...)   # x16 → should be 6 nCK

class IS43TR16256A(DDR3Module):
    # ...
    technology_timings = _TechnologyTimings(... tRRD=(4, 6),  ...)   # x16 → should be 6 nCK

class IS43TR16512B(DDR3Module):
    # ...
    technology_timings = _TechnologyTimings(... tRRD=(4, 10), ...)   # x16 → should be 6 nCK
```

All three are unambiguously x16 by the `TR16` model-number token in
the ISSI part-number scheme and by their `nbanks=8, ncols=1024`
geometry — the same shape used to identify the x16 devices in #383.

## Change

Bump only the nCK element of `tRRD` from 4 to 6, matching the
convention established in #382/#383. The ns element is left at the
per-device datasheet value.

```diff
- technology_timings = _TechnologyTimings(... tRRD=(4, 6),  ...)   # IS43TR16128B
+ # JEDEC DDR3 x16 organisation requires the 6 nCK tRRD floor (vs 4 nCK for x4/x8).
+ technology_timings = _TechnologyTimings(... tRRD=(6, 6),  ...)

- technology_timings = _TechnologyTimings(... tRRD=(4, 6),  ...)   # IS43TR16256A
+ technology_timings = _TechnologyTimings(... tRRD=(6, 6),  ...)

- technology_timings = _TechnologyTimings(... tRRD=(4, 10), ...)   # IS43TR16512B
+ technology_timings = _TechnologyTimings(... tRRD=(6, 10), ...)
```

## Test

`test_ddr3_x16_trrd_uses_ck_minimum` already asserts
`tRRD[0] >= 6` for every DDR3 x16 class listed in its `names`
tuple. The three ISSI parts are appended to that list so the
invariant is locked in for them too:

```python
names = [
    # ... (existing entries from #383)
    "K4B2G1646F",
    "AS4C256M16D3A",
    "AS4C256M16D3C",
    # ISSI DDR3 x16 series (extends the sweep to the IS43TR16* family).
    "IS43TR16128B",
    "IS43TR16256A",
    "IS43TR16512B",
]
```

`python -m unittest test.test_modules` runs all tests cleanly with
the change applied.

## Why this is a separate PR from #383

#383 was intentionally scoped to a specific sweep list (Micron /
Samsung / Alliance x16 parts) with per-device geometry verification.
The ISSI IS43TR16* parts share the exact same rationale and shape
but were not in that list — this PR extends the same fix to them.