### PR TITLE
modules: encode DDR4 x16 tFAW nCK floor for MT40A512M16

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -1204,7 +1204,8 @@ class MT40A512M16(DDR4Module):
     trfc  = {"1x": (None, 350), "2x": (None, 260),   "4x": (None, 160)}
     technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 4.9), tZQCS=(128, 80))
     speedgrade_timings = {
-        "2400": _SpeedgradeTimings(tRP=13.32, tRCD=13.32, tWR=15, tRFC=trfc, tFAW=(20, 25), tRAS=32),
+        # JEDEC DDR4 x16 organisation requires the 28 nCK tFAW floor (vs 20 nCK for x4/x8).
+        "2400": _SpeedgradeTimings(tRP=13.32, tRCD=13.32, tWR=15, tRFC=trfc, tFAW=(28, 25), tRAS=32),
     }
     speedgrade_timings["default"] = speedgrade_timings["2400"]
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -78,6 +78,17 @@ class TestSDRAMModules(unittest.TestCase):
         self.assertEqual(cls.speedgrade_timings["1866"].tFAW, (32, 40))
         self.assertEqual(module.timing_settings.tFAW, 8)
 
+    def test_mt40a512m16_tfaw_uses_x16_ck_minimum(self):
+        # JEDEC DDR4 pins the tFAW nCK floor at 28 for x16 organisation
+        # (vs 20 for x4/x8). MT40A512M16 is a DDR4 x16 device (ngroups=2,
+        # ngroupbanks=4) and must honour the same floor as its sibling
+        # MT40A256M16, which already encodes tFAW=(28, 35).
+        cls = litedram.modules.MT40A512M16
+        module = cls(clk_freq=100e6, rate="1:4")
+        self.assertEqual(cls.speedgrade_timings["2400"].tFAW[0], 28)
+        # And the x16 sibling stays consistent (regression guard).
+        self.assertEqual(litedram.modules.MT40A256M16.speedgrade_timings["2400"].tFAW[0], 28)
+
     def test_ddr3_x16_trrd_uses_ck_minimum(self):
         # JEDEC DDR3 fixes the tRRD nCK floor at 6 for x16 organisation
         # (vs 4 for x4/x8). Every DDR3 part below is an x16 device, so the


### PR DESCRIPTION
## Summary

The MT40A512M16 DDR4 x16 module in `litedram/modules.py` encodes its
`tFAW` at DDR4-2400 with the x4/x8 nCK floor:

```python
class MT40A512M16(DDR4Module):
    ngroupbanks = 4
    ngroups     = 2                                      # x16 shape
    ...
    "2400": _SpeedgradeTimings(... tFAW=(20, 25), ...)   # x4/x8 floor
```

JEDEC JESD79-4 fixes the four-bank window `tFAW` **nCK floor at
28 nCK for x16 organisation** (vs 20 nCK for x4 and x8) — the same
class of bug as #381 (LPDDR4 tFAW nCK) and #384 (DDR3 x16 tFAW ns).
At controller clocks low enough that the ns side rounds to fewer
than 28 nCK the resolved cycle count under-constrains the four-ACT
window.

The sibling `MT40A256M16`, which is the same Micron DDR4 x16 family
(`ngroups=2, ngroupbanks=4`) at DDR4-2400, already encodes the
correct floor:

```python
class MT40A256M16(DDR4Module):
    ...
    "2400": _SpeedgradeTimings(... tFAW=(28, 35), ...)   # x16 floor
```

so MT40A512M16 is the lone outlier among the two Micron DDR4 x16
parts in the module list.

## Change

Bump only the nCK element of `tFAW` from 20 to 28. The ns element is
left at the per-device value (25) matching the convention established
by #381/#384 (touch nCK only, leave datasheet-derived ns alone). If a
future PR wants to align the ns side with the sibling MT40A256M16
(35 ns), that can be done independently under its own review.

```diff
-        \"2400\": _SpeedgradeTimings(... tFAW=(20, 25), ...)
+        # JEDEC DDR4 x16 organisation requires the 28 nCK tFAW floor (vs 20 nCK for x4/x8).
+        \"2400\": _SpeedgradeTimings(... tFAW=(28, 25), ...)
```

## Test

Adds `test_mt40a512m16_tfaw_uses_x16_ck_minimum`, mirroring the style
of `test_mt53e256m16d1_tfaw_uses_ck_minimum` (LPDDR4, #381) and
`test_ddr4_rdimm_tfaw_uses_ck_minimum` (DDR4 RDIMM):

```python
def test_mt40a512m16_tfaw_uses_x16_ck_minimum(self):
    cls = litedram.modules.MT40A512M16
    module = cls(clk_freq=100e6, rate=\"1:4\")
    self.assertEqual(cls.speedgrade_timings[\"2400\"].tFAW[0], 28)
    # And the x16 sibling stays consistent (regression guard).
    self.assertEqual(litedram.modules.MT40A256M16.speedgrade_timings[\"2400\"].tFAW[0], 28)
```

`python -m unittest test.test_modules` runs cleanly with the change
applied.

## Why this is a separate PR from #391

#391 targets DDR3 x16 `tRRD` on the ISSI IS43TR16* parts (extends
#382/#383). This PR is orthogonal — different DRAM generation (DDR4
vs DDR3), different vendor (Micron vs ISSI), different timing
parameter (`tFAW` vs `tRRD`), and is cleanly reviewable on its own.