### PR TITLE
modules: encode DDR4 x16 tFAW nCK floor for MTA4ATF51264HZ (extends #392)

### DIFF
--- a/litedram/modules.py
+++ b/litedram/modules.py
@@ -1238,7 +1238,9 @@ class MTA4ATF51264HZ(DDR4Module):
     trfc  = {"1x": (None, 350), "2x": (None, 260),   "4x": (None, 160)}
     technology_timings = _TechnologyTimings(tREFI=trefi, tWTR=(4, 7.5), tCCD=(4, None), tRRD=(4, 4.9), tZQCS=(128, 80))
     speedgrade_timings = {
-        "2133": _SpeedgradeTimings(tRP=13.5, tRCD=13.5, tWR=15, tRFC=trfc, tFAW=(20, 25), tRAS=33),
+        # ngroups=2 characterises this SODIMM as built from DDR4 x16 devices.
+        # JEDEC DDR4 x16 organisation requires the 28 nCK tFAW floor (vs 20 nCK for x4/x8).
+        "2133": _SpeedgradeTimings(tRP=13.5, tRCD=13.5, tWR=15, tRFC=trfc, tFAW=(28, 25), tRAS=33),
     }
     speedgrade_timings["default"] = speedgrade_timings["2133"]
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -78,6 +78,14 @@ class TestSDRAMModules(unittest.TestCase):
         self.assertEqual(cls.speedgrade_timings["1866"].tFAW, (32, 40))
         self.assertEqual(module.timing_settings.tFAW, 8)
 
+    def test_mta4atf51264hz_tfaw_uses_x16_ck_minimum(self):
+        # MTA4ATF51264HZ is a DDR4 SODIMM whose per-device organisation is
+        # characterised as x16 in this repo (ngroups=2, ngroupbanks=4).
+        # JEDEC DDR4 x16 pins the tFAW nCK floor at 28 (vs 20 for x4/x8).
+        cls = litedram.modules.MTA4ATF51264HZ
+        module = cls(clk_freq=100e6, rate="1:4")
+        self.assertEqual(cls.speedgrade_timings["2133"].tFAW[0], 28)
+
     def test_ddr3_x16_trrd_uses_ck_minimum(self):
         # JEDEC DDR3 fixes the tRRD nCK floor at 6 for x16 organisation
         # (vs 4 for x4/x8). Every DDR3 part below is an x16 device, so the


### PR DESCRIPTION
## Summary

The MTA4ATF51264HZ DDR4 SODIMM in `litedram/modules.py` is
characterised with the DDR4 x16 per-device organisation
(`ngroups=2, ngroupbanks=4`) — the same shape used for MT40A256M16
and MT40A512M16 — but its \`tFAW\` at DDR4-2133 still uses the x4/x8
nCK floor:

\`\`\`python
class MTA4ATF51264HZ(DDR4Module):
    ngroupbanks = 4
    ngroups     = 2                                      # x16 shape
    ...
    \"2133\": _SpeedgradeTimings(... tFAW=(20, 25), ...)   # x4/x8 floor
\`\`\`

JEDEC JESD79-4 fixes the four-bank window \`tFAW\` **nCK floor at
28 nCK for x16 organisation** (vs 20 nCK for x4 and x8) — the same
class of bug fixed for MT40A512M16 in #392. At controller clocks
low enough that the ns side rounds to fewer than 28 nCK the resolved
cycle count under-constrains the four-ACT window.

## Change

Bump only the nCK element of \`tFAW\` from 20 to 28, matching the
convention established by #381, #384 and #392 (touch nCK only, leave
datasheet-derived ns alone).

\`\`\`diff
-        \"2133\": _SpeedgradeTimings(... tFAW=(20, 25), ...)
+        # ngroups=2 characterises this SODIMM as built from DDR4 x16 devices.
+        # JEDEC DDR4 x16 organisation requires the 28 nCK tFAW floor (vs 20 nCK for x4/x8).
+        \"2133\": _SpeedgradeTimings(... tFAW=(28, 25), ...)
\`\`\`

## Test

Adds \`test_mta4atf51264hz_tfaw_uses_x16_ck_minimum\`, mirroring the
style of the MT40A512M16 test added in #392:

\`\`\`python
def test_mta4atf51264hz_tfaw_uses_x16_ck_minimum(self):
    cls = litedram.modules.MTA4ATF51264HZ
    module = cls(clk_freq=100e6, rate=\"1:4\")
    self.assertEqual(cls.speedgrade_timings[\"2133\"].tFAW[0], 28)
\`\`\`

\`python -m unittest test.test_modules\` runs cleanly with the
change applied.

## Why this is a separate PR from #392

#392 targets the MT40A512M16 bare-chip DDR4 x16 outlier. This PR
extends the same JEDEC x16 tFAW nCK floor to the sole DDR4 SODIMM
whose per-device characterisation in this repo is x16
(\`ngroups=2, ngroupbanks=4\`). The bare-chip fix and the SODIMM fix
touch different classes and can be reviewed independently; if the
maintainer prefers a different DIMM-level treatment they can defer
this PR without blocking #392.