### PR TITLE
test: lock in DDR4 x16 tFAW >= 28 nCK floor across the family (regression)

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -86,6 +86,40 @@ class TestSDRAMModules(unittest.TestCase):
         module = cls(clk_freq=100e6, rate="1:4")
         self.assertEqual(cls.speedgrade_timings["2133"].tFAW[0], 28)
 
+    def test_ddr4_x16_tfaw_uses_ck_minimum(self):
+        # JEDEC DDR4 (JESD79-4) fixes the tFAW nCK floor at 28 for x16
+        # organisation (vs 20 nCK for x4/x8). PRs #392 and #393 corrected
+        # the two DDR4 x16 outliers in this repo (MT40A512M16 bare-chip
+        # and MTA4ATF51264HZ SODIMM); this regression test locks the
+        # invariant in across every DDR4 device whose per-device
+        # organisation is x16 (`ngroups == 2`, `ngroupbanks == 4`), so
+        # any future addition or accidental (20, ...) regression fails
+        # loudly at test time.
+        names = [
+            "EDY4016A",
+            "MT40A256M16",
+            "MT40A512M16",
+            "MTA4ATF51264HZ",
+        ]
+        for name in names:
+            cls = getattr(litedram.modules, name)
+            with self.subTest(module=name):
+                # Every listed class has ngroups=2 (x16 per-device shape).
+                self.assertEqual(cls.ngroups, 2, f"{name}: expected x16 shape (ngroups=2)")
+                # Every listed class exposes at least one speedgrade; check
+                # each speedgrade's tFAW nCK floor without hard-coding which
+                # speedgrade names exist (defensive against future edits).
+                for sg_name, sg in cls.speedgrade_timings.items():
+                    if sg_name == "default":
+                        continue
+                    tfaw = sg.tFAW
+                    self.assertIsNotNone(tfaw, f"{name}[{sg_name}]: tFAW missing")
+                    self.assertIsInstance(tfaw, tuple, f"{name}[{sg_name}]: tFAW not a tuple")
+                    self.assertGreaterEqual(
+                        tfaw[0], 28,
+                        f"{name}[{sg_name}]: JEDEC DDR4 x16 requires tFAW nCK floor >= 28",
+                    )
+
     def test_ddr3_x16_trrd_uses_ck_minimum(self):
         # JEDEC DDR3 fixes the tRRD nCK floor at 6 for x16 organisation
         # (vs 4 for x4/x8). Every DDR3 part below is an x16 device, so the


### PR DESCRIPTION
## Summary

#392 and #393 corrected the two DDR4 x16 outliers in this repo whose
\`tFAW\` was still encoded with the x4/x8 20 nCK floor instead of the
JEDEC (JESD79-4) x16 28 nCK floor: **MT40A512M16** (bare chip, #392)
and **MTA4ATF51264HZ** (SODIMM, #393). \`MT40A256M16\` already carried
the correct 28 nCK floor.

This test-only PR locks the invariant in going forward: every DDR4
module whose per-device organisation is characterised as x16 in this
repo (\`ngroups == 2, ngroupbanks == 4\`) must have \`tFAW\` nCK >= 28
at every speedgrade it exposes. Any future addition or accidental
\`(20, ...)\` regression on an x16 part will now fail loudly rather
than silently under-constrain the four-ACT window.

## What's added

One new test, \`test_ddr4_x16_tfaw_uses_ck_minimum\`, in the same
style as \`test_ddr3_x16_tfaw_800_ns_minimum\` added in #394:

\`\`\`python
def test_ddr4_x16_tfaw_uses_ck_minimum(self):
    names = [
        \"EDY4016A\",
        \"MT40A256M16\",
        \"MT40A512M16\",
        \"MTA4ATF51264HZ\",
    ]
    for name in names:
        cls = getattr(litedram.modules, name)
        with self.subTest(module=name):
            self.assertEqual(cls.ngroups, 2, ...)   # confirm x16 shape
            for sg_name, sg in cls.speedgrade_timings.items():
                if sg_name == \"default\":
                    continue
                self.assertGreaterEqual(sg.tFAW[0], 28, ...)
\`\`\`

The test iterates every speedgrade of every listed class (instead of
hard-coding \"2400\" or \"2133\"), so a future speedgrade addition
can't accidentally slip through with a 20 nCK floor.

## Modules covered

All four DDR4 modules whose per-device organisation is x16 in this
repo (\`ngroups == 2\`):

- \`EDY4016A\` (Elpida DDR4)
- \`MT40A256M16\` (Micron DDR4)
- \`MT40A512M16\` (Micron DDR4, fixed in #392)
- \`MTA4ATF51264HZ\` (Micron DDR4 SODIMM, fixed in #393)

## Why this is worth its own PR

Pure test-only — **no behaviour change**. The invariant it locks in
was established by already-merged fixes (#392 / #393) and is
currently satisfied by every listed part; the test simply codifies
the rule so it stays true. Kept as its own PR (rather than folded
into a module fix) so the diff is unambiguously additive and can be
reviewed in seconds, mirroring the split used in #394.

## Test run

\`python -m unittest test.test_modules\` runs cleanly on \`master\`
with the new test added — all listed modules already meet the floor.