### PR TITLE
test: Lock ECP5/Gowin DDR3 write latency contracts

### DIFF
--- a/test/test_ddr3_phy_settings.py
+++ b/test/test_ddr3_phy_settings.py
@@ -1,0 +1,62 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litedram.common import get_default_cwl, get_sys_latency
+from litedram.phy.ecp5ddrphy import ECP5DDRPHY
+from litedram.phy.gw2ddrphy import GW2DDRPHY
+from litedram.phy.gw5ddrphy import GW5DDRPHY
+
+
+class TestDDR3PHYSettings(unittest.TestCase):
+    phys = [
+        ("ecp5", ECP5DDRPHY, 0),
+        ("gw2",  GW2DDRPHY, -1),
+        ("gw5",  GW5DDRPHY, -1),
+    ]
+    sys_clk_freqs = [75e6, 100e6, 125e6, 166e6, 200e6, 250e6]
+
+    @staticmethod
+    def get_pads():
+        return Record([
+            ("a",       15),
+            ("ba",       3),
+            ("ras_n",    1),
+            ("cas_n",    1),
+            ("we_n",     1),
+            ("clk_p",    1),
+            ("clk_n",    1),
+            ("dq",       8),
+            ("dm",       1),
+            ("dqs_p",    1),
+            ("dqs_n",    1),
+        ])
+
+    def test_default_cwl_is_preserved(self):
+        for name, phy_cls, _ in self.phys:
+            for sys_clk_freq in self.sys_clk_freqs:
+                with self.subTest(phy=name, sys_clk_freq=sys_clk_freq):
+                    phy          = phy_cls(self.get_pads(), sys_clk_freq=sys_clk_freq)
+                    tck          = 1/(2*sys_clk_freq)
+                    expected_cwl = get_default_cwl("DDR3", tck)
+
+                    self.assertEqual(phy.settings.cwl, expected_cwl)
+
+    def test_write_latency_matches_phy_pipeline(self):
+        for name, phy_cls, write_latency_offset in self.phys:
+            for sys_clk_freq in self.sys_clk_freqs:
+                with self.subTest(phy=name, sys_clk_freq=sys_clk_freq):
+                    phy             = phy_cls(self.get_pads(), sys_clk_freq=sys_clk_freq)
+                    cwl             = phy.settings.cwl
+                    cwl_sys_latency = get_sys_latency(phy.settings.nphases, cwl)
+
+                    self.assertEqual(
+                        phy.settings.write_latency,
+                        cwl_sys_latency + write_latency_offset,
+                    )


### PR DESCRIPTION
## Summary

- instantiate the ECP5, GW2 and GW5 DDR3 PHYs across frequencies spanning a CWL transition
- verify `settings.cwl` remains the DDR3 CWL selected from tCK
- lock the PHY pipeline contracts: `cwl_sys_latency` for ECP5 and `cwl_sys_latency - 1` for GW2/GW5

## Rationale

The memory CWL and the controller-to-PHY pipeline latency describe different interfaces. These tests prevent primitive-specific latency compensation from being folded into `settings.cwl`.

## Verification

- `pytest -q test/test_ddr3_phy_settings.py`
- `git diff --check`
- `python3 -m compileall -q test/test_ddr3_phy_settings.py`