### PR TITLE
phy: Align Artix-7 DDR3 reads without altering CL

### DIFF
--- a/litedram/phy/s7ddrphy.py
+++ b/litedram/phy/s7ddrphy.py
@@ -70,6 +70,13 @@ class S7DDRPHY(Module, AutoCSR):
         rdphase         = get_sys_phase(nphases, cl_sys_latency,   cl + cmd_latency)
         wrphase         = get_sys_phase(nphases, cwl_sys_latency, cwl + cmd_latency)
 
+        # Artix-7 requires read data one memory-clock phase into the ISERDESE2 word for reliable
+        # read leveling. This was previously achieved by programming CL + 1 in the DDR3 MR0. Keep
+        # the configured CL unchanged and express the compensation in the PHY schedule instead.
+        if (memtype == "DDR3") and (not with_odelay):
+            phase_cycles, rdphase = divmod(rdphase + 1, nphases)
+            cl_sys_latency -= phase_cycles
+
         # Registers --------------------------------------------------------------------------------
         self._rst             = CSRStorage()
 
@@ -120,12 +127,6 @@ class S7DDRPHY(Module, AutoCSR):
 
         wdly_dq_bitslip_rst  = cdc(self._wdly_dq_bitslip_rst.wr_stb)
         wdly_dq_bitslip  = cdc(self._wdly_dq_bitslip.wr_stb)
-
-        # PHY settings -----------------------------------------------------------------------------
-        if (memtype == "DDR3") and (not with_odelay):
-            # DDR3 Write leveling is not possible on Artix7 due to the lack of ODELAYE2, adding +1
-            # to cl in MR register increases sys_clk_freq range.
-            cl += 1
 
         # Some calibrations like write_leveling or latency calibration are not supported
         # for DDR2 chip.

--- a/test/test_s7ddrphy.py
+++ b/test/test_s7ddrphy.py
@@ -1,0 +1,106 @@
+#
+# This file is part of LiteDRAM.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+from types import SimpleNamespace
+
+from migen import *
+
+from litedram.common import get_default_cl
+from litedram.init import get_ddr3_phy_init_sequence
+from litedram.phy.s7ddrphy import A7DDRPHY, K7DDRPHY
+
+
+class TestS7DDRPHYSettings(unittest.TestCase):
+    sys_clk_freqs       = [50e6, 100e6, 125e6, 150e6, 175e6, 225e6]
+    ddr3_cls            = range(5, 15)
+    read_pipeline_cycles = 6
+
+    @staticmethod
+    def get_pads():
+        return Record([
+            ("a",       15),
+            ("ba",       3),
+            ("ras_n",    1),
+            ("cas_n",    1),
+            ("we_n",     1),
+            ("clk_p",    1),
+            ("clk_n",    1),
+            ("dq",       8),
+            ("dm",       1),
+            ("dqs_p",    1),
+            ("dqs_n",    1),
+        ])
+
+    @staticmethod
+    def get_rdphase(phy):
+        return phy.settings.rdphase.reset.value
+
+    @staticmethod
+    def get_mr0_cl(phy):
+        init_sequence, _ = get_ddr3_phy_init_sequence(
+            phy_settings    = phy.settings,
+            timing_settings = SimpleNamespace(tWTR=2),
+        )
+        mr0 = next(address for comment, address, _, _, _ in init_sequence
+            if comment.startswith("Load Mode Register 0"))
+        mr0_to_cl = {
+            0b0010 :  5,
+            0b0100 :  6,
+            0b0110 :  7,
+            0b1000 :  8,
+            0b1010 :  9,
+            0b1100 : 10,
+            0b1110 : 11,
+            0b0001 : 12,
+            0b0011 : 13,
+            0b0101 : 14,
+        }
+        mr0_cl = ((mr0 >> 2) & 0b1) | (((mr0 >> 4) & 0b111) << 1)
+        return mr0_to_cl[mr0_cl]
+
+    def test_a7_default_cl_is_preserved(self):
+        for sys_clk_freq in self.sys_clk_freqs:
+            with self.subTest(sys_clk_freq=sys_clk_freq):
+                phy         = A7DDRPHY(self.get_pads(), sys_clk_freq=sys_clk_freq)
+                tck         = 1/(4*sys_clk_freq)
+                expected_cl = get_default_cl("DDR3", tck)
+
+                self.assertEqual(phy.settings.cl, expected_cl)
+                self.assertEqual(self.get_mr0_cl(phy), expected_cl)
+
+    def test_a7_read_alignment(self):
+        for cl in self.ddr3_cls:
+            for cmd_latency in range(3):
+                with self.subTest(cl=cl, cmd_latency=cmd_latency):
+                    phy = A7DDRPHY(self.get_pads(),
+                        sys_clk_freq = 100e6,
+                        cl           = cl,
+                        cmd_latency  = cmd_latency,
+                    )
+                    rdphase          = self.get_rdphase(phy)
+                    read_sys_latency = phy.settings.read_latency - self.read_pipeline_cycles
+
+                    self.assertEqual(phy.settings.cl, cl)
+                    self.assertEqual(self.get_mr0_cl(phy), cl)
+                    self.assertEqual(
+                        rdphase + cl + cmd_latency,
+                        read_sys_latency*phy.settings.nphases + 1,
+                    )
+
+    def test_k7_read_alignment_is_unchanged(self):
+        for cl in self.ddr3_cls:
+            with self.subTest(cl=cl):
+                phy              = K7DDRPHY(self.get_pads(), sys_clk_freq=100e6, cl=cl)
+                rdphase          = self.get_rdphase(phy)
+                read_sys_latency = phy.settings.read_latency - self.read_pipeline_cycles
+
+                self.assertEqual(phy.settings.cl, cl)
+                self.assertEqual(self.get_mr0_cl(phy), cl)
+                self.assertEqual(
+                    rdphase + cl,
+                    read_sys_latency*phy.settings.nphases,
+                )


### PR DESCRIPTION
Follow-up to #397 and @gatecat's observation about the similar Artix-7 read-path workaround.

## Summary

- Keep the frequency-selected DDR3 CL unchanged in MR0.
- Move the Artix-7 read command by one memory-clock phase to retain the established ISERDESE2 word alignment.
- Fold DFI phase wrapping into the controller-visible read latency.
- Add Series-7 settings and MR0 tests covering default frequencies, every legal DDR3 CL, command latencies, and the unchanged Kintex-7 path.

## Rationale

Since 6f323f6, the Artix-7 PHY has calculated its read phase and system latency from the selected CL but programmed `CL + 1` in MR0. This places returned data one memory-clock phase into the ISERDESE2 word and improved read-leveling reliability, but it represents PHY alignment by changing the DRAM timing configuration. It also turns an explicitly selected CL 14 into the unsupported MR0 value 15.

The new schedule keeps the same intra-word read position by incrementing `rdphase` instead. `divmod()` normalizes the phase and carries a phase wrap into `read_latency`, making both parts of the timing relationship explicit.

## Testing

- `pytest -q test/test_s7ddrphy.py test/test_ddr3_phy_settings.py test/test_nxddrphy.py test/test_init.py test/test_gen.py`: 13 passed, 86 subtests passed.
- Artix-7 PHY standalone Verilog elaboration: 2,628 lines generated with the expected OSERDESE2/ISERDESE2 instances.
- Digilent Arty SoC generation with gateware/software compilation disabled: completed successfully; generated settings are CL 6, CWL 5, read phase 3, and write phase 3 at 100 MHz.

## Hardware Validation

This is intentionally a draft until it has been exercised on Artix-7 hardware. The useful checks are read-leveling windows and repeated memory tests at 50, 75, 100, and 125 MHz. A phase-wrap configuration, such as CL 13, should also be tested if practical because it reduces the controller-visible read latency by one system cycle.
