### PR TITLE
phy/ecp5ddrphy.py: added argument and logic to skip dm management when dm pads are not in the same group than rest of DRAM pads

### DIFF
--- a/litedram/phy/ecp5ddrphy.py
+++ b/litedram/phy/ecp5ddrphy.py
@@ -119,7 +119,10 @@ class ECP5DDRPHY(Module, AutoCSR):
         cwl          = None,
         cmd_delay    = 0,
         clk_polarity = 0,
-        dm_remapping = None):
+        dm_remapping = None,
+        dm_skip      = False, # unconditonally force DM IOs to zero and bypass ODDRX2DQA
+                              # and l2_cache must be set at target level to avoid partial access
+        ):
         assert isinstance(cmd_delay, int) and cmd_delay < 128
         pads        = PHYPadsCombiner(pads)
         memtype     = "DDR3"
@@ -327,24 +330,28 @@ class ECP5DDRPHY(Module, AutoCSR):
             ]
 
             # DM -----------------------------------------------------------------------------------
-            dm_o_data       = Signal(8)
-            dm_o_data_d     = Signal(8)
-            dm_o_data_muxed = Signal(4)
-            for n in range(8):
-                self.comb += dm_o_data[n].eq(dfi.phases[n//4].wrdata_mask[n%4*databits//8+dm_remapping.get(i, i)])
-            self.sync += dm_o_data_d.eq(dm_o_data)
-            dm_bl8_cases = {}
-            dm_bl8_cases[0] = dm_o_data_muxed.eq(dm_o_data[:4])
-            dm_bl8_cases[1] = dm_o_data_muxed.eq(dm_o_data_d[4:])
-            self.sync += Case(bl8_chunk, dm_bl8_cases)
-            self.specials += Instance("ODDRX2DQA",
-                i_RST     = ResetSignal("sys"),
-                i_SCLK    = ClockSignal("sys"),
-                i_ECLK    = ClockSignal("sys2x"),
-                i_DQSW270 = dqsw270,
-                **{f"i_D{n}": dm_o_data_muxed[n] for n in range(4)},
-                o_Q       = pads.dm[i]
-            )
+            if dm_skip:
+            # Force DM IOs to zero.
+                self.comb += pads.dm[i].eq(0)
+            else:
+                dm_o_data       = Signal(8)
+                dm_o_data_d     = Signal(8)
+                dm_o_data_muxed = Signal(4)
+                for n in range(8):
+                    self.comb += dm_o_data[n].eq(dfi.phases[n//4].wrdata_mask[n%4*databits//8+dm_remapping.get(i, i)])
+                self.sync += dm_o_data_d.eq(dm_o_data)
+                dm_bl8_cases = {}
+                dm_bl8_cases[0] = dm_o_data_muxed.eq(dm_o_data[:4])
+                dm_bl8_cases[1] = dm_o_data_muxed.eq(dm_o_data_d[4:])
+                self.sync += Case(bl8_chunk, dm_bl8_cases)
+                self.specials += Instance("ODDRX2DQA",
+                    i_RST     = ResetSignal("sys"),
+                    i_SCLK    = ClockSignal("sys"),
+                    i_ECLK    = ClockSignal("sys2x"),
+                    i_DQSW270 = dqsw270,
+                    **{f"i_D{n}": dm_o_data_muxed[n] for n in range(4)},
+                    o_Q       = pads.dm[i]
+                )
 
             # DQ -----------------------------------------------------------------------------------
             for j in range(8*i, 8*(i+1)):

--- a/litedram/phy/ecp5ddrphy.py
+++ b/litedram/phy/ecp5ddrphy.py
@@ -120,9 +120,7 @@ class ECP5DDRPHY(Module, AutoCSR):
         cmd_delay    = 0,
         clk_polarity = 0,
         dm_remapping = None,
-        dm_skip      = False, # unconditonally force DM IOs to zero and bypass ODDRX2DQA
-                              # and l2_cache must be set at target level to avoid partial access
-        ):
+        with_dm      = True):
         assert isinstance(cmd_delay, int) and cmd_delay < 128
         pads        = PHYPadsCombiner(pads)
         memtype     = "DDR3"
@@ -178,6 +176,7 @@ class ECP5DDRPHY(Module, AutoCSR):
             read_leveling = True,
             bitslips      = 4,
             delays        = 8,
+            with_dm       = with_dm,
         )
 
         # DFI Interface ----------------------------------------------------------------------------
@@ -330,10 +329,7 @@ class ECP5DDRPHY(Module, AutoCSR):
             ]
 
             # DM -----------------------------------------------------------------------------------
-            if dm_skip:
-            # Force DM IOs to zero.
-                self.comb += pads.dm[i].eq(0)
-            else:
+            if with_dm:
                 dm_o_data       = Signal(8)
                 dm_o_data_d     = Signal(8)
                 dm_o_data_muxed = Signal(4)
@@ -352,6 +348,9 @@ class ECP5DDRPHY(Module, AutoCSR):
                     **{f"i_D{n}": dm_o_data_muxed[n] for n in range(4)},
                     o_Q       = pads.dm[i]
                 )
+            else:
+                # DM-less configurations require full-width writes.
+                self.comb += pads.dm[i].eq(0)
 
             # DQ -----------------------------------------------------------------------------------
             for j in range(8*i, 8*(i+1)):

--- a/test/test_ddr3_phy_settings.py
+++ b/test/test_ddr3_phy_settings.py
@@ -7,6 +7,7 @@
 import unittest
 
 from migen import *
+from migen.fhdl.specials import Instance
 
 from litedram.common import get_default_cwl, get_sys_latency
 from litedram.phy.ecp5ddrphy import ECP5DDRPHY
@@ -60,3 +61,18 @@ class TestDDR3PHYSettings(unittest.TestCase):
                         phy.settings.write_latency,
                         cwl_sys_latency + write_latency_offset,
                     )
+
+    def test_ecp5_without_dm(self):
+        with_dm    = ECP5DDRPHY(self.get_pads())
+        without_dm = ECP5DDRPHY(self.get_pads(), with_dm=False)
+
+        def count_oddrx2dqa(phy):
+            fragment = phy.get_fragment()
+            return sum(
+                isinstance(special, Instance) and special.of == "ODDRX2DQA"
+                for special in fragment.specials
+            )
+
+        self.assertTrue(with_dm.settings.with_dm)
+        self.assertFalse(without_dm.settings.with_dm)
+        self.assertEqual(count_oddrx2dqa(with_dm) - count_oddrx2dqa(without_dm), 1)


### PR DESCRIPTION
Simple hack based on https://github.com/enjoy-digital/litedram/issues/299
When dm can't be used signals are fixed to 0.
The target must uses an l2_cache.
Tested with radiona_ulx4m_ld to boot linux