### PR TITLE
gw5ddrphy: fix DDR3 initialization and support 1:2 / 1:4 ratios

### DIFF
--- a/litedram/init.py
+++ b/litedram/init.py
@@ -143,6 +143,9 @@ def get_ddr3_phy_init_sequence(phy_settings, timing_settings):
     cl  = phy_settings.cl
     bl  = 8
     cwl = phy_settings.cwl
+    dll_off = getattr(phy_settings, "dll_off", False)
+    if dll_off and (cl != 6 or cwl != 6):
+        raise ValueError("DDR3 DLL-off mode requires CL=6 and CWL=6.")
 
     def format_mr0(bl, cl, wr, dll_reset):
         bl_to_mr0 = {
@@ -217,10 +220,14 @@ def get_ddr3_phy_init_sequence(phy_settings, timing_settings):
     rtt_wr  = getattr(phy_settings, "rtt_wr",  "60ohm")
     ron     = getattr(phy_settings, "ron",     "34ohm")
     tdqs    = getattr(phy_settings, "tdqs",    0)
+    if dll_off:
+        # Neither nominal nor dynamic ODT is supported with the DRAM DLL off.
+        rtt_nom = rtt_wr = "disabled"
 
     wr  = max(timing_settings.tWTR*phy_settings.nphases, 5) # >= ceiling(tWR/tCK)
     mr0 = format_mr0(bl, cl, wr, 1)
     mr1 = format_mr1(z_to_ron[ron], z_to_rtt_nom[rtt_nom], tdqs)
+    mr1 |= int(dll_off)
     mr2 = format_mr2(cwl, z_to_rtt_wr[rtt_wr])
     mr3 = 0
 

--- a/litedram/init.py
+++ b/litedram/init.py
@@ -140,9 +140,9 @@ def get_ddr2_phy_init_sequence(phy_settings, timing_settings):
 # DDR3 ---------------------------------------------------------------------------------------------
 
 def get_ddr3_phy_init_sequence(phy_settings, timing_settings):
-    cl  = phy_settings.cl
-    bl  = 8
-    cwl = phy_settings.cwl
+    cl      = phy_settings.cl
+    bl      = 8
+    cwl     = phy_settings.cwl
     dll_off = getattr(phy_settings, "dll_off", False)
     if dll_off and (cl != 6 or cwl != 6):
         raise ValueError("DDR3 DLL-off mode requires CL=6 and CWL=6.")

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -152,6 +152,7 @@ class GW5DDRPHY(Module, AutoCSR):
 
         # Init -------------------------------------------------------------------------------------
         self.submodules.init = GW5DDRPHYInit(fast_domain)
+
         pause = Signal()
         self.specials += MultiReg(self.init.pause, pause, "sys")
 
@@ -293,12 +294,14 @@ class GW5DDRPHY(Module, AutoCSR):
         dqs_oe        = Signal()
         dqs_postamble = Signal()
         dqs_preamble  = Signal()
+
         dqs_read = Replicate(dqs_re, 4)
         if dll_on_x4:
             # DLL-on returns DQS one CK later than DLL-off at the same CL.
             dqs_re_d = Signal()
             self.sync += dqs_re_d.eq(dqs_re)
             dqs_read = Cat(dqs_re_d, Replicate(dqs_re, 3))
+
         for i in range(databits//8):
             # DQS
             dqs_i    = Signal()
@@ -360,8 +363,8 @@ class GW5DDRPHY(Module, AutoCSR):
                 self.sync += burstdet_d.eq(burstdet)
                 burst_event = burstdet & ~burstdet_d
             self.sync += [
-                If(self._burstdet_clr.wr_stb,  self._burstdet_seen.status[i].eq(0)),
-                If(burst_event, self._burstdet_seen.status[i].eq(1)),
+                If(self._burstdet_clr.wr_stb, self._burstdet_seen.status[i].eq(0)),
+                If(burst_event,              self._burstdet_seen.status[i].eq(1)),
             ]
 
             # DQS ----------------------------------------------------------------------------------
@@ -375,10 +378,11 @@ class GW5DDRPHY(Module, AutoCSR):
                     i_PCLK  = ClockSignal("sys"),
                     i_FCLK  = ClockSignal(fast_domain),
                     i_TCLK  = dqsw,
-                    **{f"i_TX{n}": ~(dqs_oe |
+                    **{f"i_TX{n}": ~(
+                        dqs_oe |
                         (dqs_postamble if n == 0 else 0) |
-                        (dqs_preamble if n == nphases - 1 else 0))
-                        for n in range(nphases)},
+                        (dqs_preamble if n == nphases - 1 else 0)
+                    ) for n in range(nphases)},
                     **{f"i_D{n}": (0b10101010 >> n) & 0b1 for n in range(serdes_bits)},
                     o_Q0    = dqs_o,
                     o_Q1    = dqs_o_oen

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -7,7 +7,7 @@
 # Copyright (c) 2023 Gwenhael Goavec-Merou <gwenhael@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-# 1:2 frequency-ratio DDR3 PHY for Gowin's GW5A
+# 1:2 / 1:4 frequency-ratio DDR3 PHY for Gowin's GW5A
 # DDR3: 800 MT/s
 
 from functools import reduce
@@ -20,7 +20,7 @@ from migen import *
 from litex.gen import *
 
 from migen.fhdl.specials import Tristate
-from migen.genlib.cdc import MultiReg
+from migen.genlib.cdc import MultiReg, PulseSynchronizer
 
 from litex.gen.genlib.misc import timeline
 
@@ -56,7 +56,7 @@ class BitSlip(Module):
 # Gowin GW5A DDR PHY Initialization -----------------------------------------------------------------
 
 class GW5DDRPHYInit(Module):
-    def __init__(self):
+    def __init__(self, clock_domain="sys2x"):
         self.pause = Signal()
         self.stop  = Signal()
         self.delay = Signal(8)
@@ -77,7 +77,7 @@ class GW5DDRPHYInit(Module):
         self.specials += Instance("DDRDLL",
             p_SCAL_EN  = "false",
             i_RESET    = ResetSignal("init"),
-            i_CLKIN    = ClockSignal("sys2x"),
+            i_CLKIN    = ClockSignal(clock_domain),
             i_UPDNCNTL = ~update,
             i_STOP     = freeze,
             o_STEP     = delay,
@@ -118,6 +118,11 @@ class GW5DDRPHYInit(Module):
 # Gowin GW5A DDR PHY -------------------------------------------------------------------------------
 
 class GW5DDRPHY(Module, AutoCSR):
+    """DDR3 PHY using sys, sys2x/sys4x, and init clock domains.
+
+    Quarter-rate mode also requires sys4x_i, the ungated fast PLL output, to
+    capture short burst-detection pulses. The gated HCLK cannot clock fabric FFs.
+    """
     def __init__(self, pads,
         sys_clk_freq = 100e6,
         cl           = None,
@@ -125,22 +130,27 @@ class GW5DDRPHY(Module, AutoCSR):
         cmd_delay    = 0,
         clk_polarity = 0,
         dm_remapping = None,
-        dll_off      = False):
+        dll_off      = False,
+        nphases      = 2):
+        if nphases not in (2, 4):
+            raise ValueError("GW5DDRPHY supports 2 or 4 DFI phases.")
         assert isinstance(cmd_delay, int) and cmd_delay < 128
         pads        = PHYPadsCombiner(pads)
         memtype     = "DDR3"
-        tck         = 2/(2*2*sys_clk_freq)
+        tck         = 1/(nphases*sys_clk_freq)
         addressbits = len(pads.a)
         bankbits    = len(pads.ba)
         nranks      = 1 if not hasattr(pads, "cs_n") else len(pads.cs_n)
         databits    = len(pads.dq)
-        nphases     = 2
+        serdes_bits = 2*nphases
+        phase_beats = 8//nphases
+        fast_domain = f"sys{nphases}x"
         if not dm_remapping:
             dm_remapping = {}
         assert databits%8 == 0
 
         # Init -------------------------------------------------------------------------------------
-        self.submodules.init = GW5DDRPHYInit()
+        self.submodules.init = GW5DDRPHYInit(fast_domain)
         pause = Signal()
         self.specials += MultiReg(self.init.pause, pause, "sys")
 
@@ -175,23 +185,23 @@ class GW5DDRPHY(Module, AutoCSR):
             phytype       = "GW5DDRPHY",
             memtype       = memtype,
             databits      = databits,
-            dfi_databits  = 4*databits,
+            dfi_databits  = phase_beats*databits,
             nranks        = nranks,
             nphases       = nphases,
             rdphase       = rdphase,
             wrphase       = wrphase,
             cl            = cl,
             cwl           = cwl,
-            read_latency  = cl_sys_latency + 9,
+            read_latency  = cl_sys_latency + (9 if nphases == 2 else 7),
             write_latency = cwl_sys_latency - 1,
             read_leveling = True,
-            bitslips      = 4,
+            bitslips      = serdes_bits,
             delays        = 128,
         )
         self.settings.dll_off = dll_off
 
         # DFI Interface ----------------------------------------------------------------------------
-        self.dfi = dfi = Interface(addressbits, bankbits, nranks, 4*databits, nphases)
+        self.dfi = dfi = Interface(addressbits, bankbits, nranks, phase_beats*databits, nphases)
 
         # # #
 
@@ -202,17 +212,17 @@ class GW5DDRPHY(Module, AutoCSR):
             pads.sel_group(pads_group)
 
             # Clock --------------------------------------------------------------------------------
-            clk_pattern = {0: 0b1010, 1: 0b0101}[clk_polarity]
+            clk_pattern = {0: 0b10101010, 1: 0b01010101}[clk_polarity]
             for i in range(len(pads.clk_p)):
                 pad_oddrx2f = Signal()
                 pad_clk = Signal()
-                self.specials += Instance("OSER4",
+                self.specials += Instance(f"OSER{serdes_bits}",
                     p_TXCLK_POL = 0b0,
                     i_RESET = ResetSignal("sys"),
                     i_PCLK  = ClockSignal("sys"),
-                    i_FCLK  = ClockSignal("sys2x"),
-                    **{f"i_TX{n}": 0b0 for n in range(2)},
-                    **{f"i_D{n}": (clk_pattern >> n) & 0b1 for n in range(4)},
+                    i_FCLK  = ClockSignal(fast_domain),
+                    **{f"i_TX{n}": 0b0 for n in range(nphases)},
+                    **{f"i_D{n}": (clk_pattern >> n) & 0b1 for n in range(serdes_bits)},
                     o_Q0    = pad_oddrx2f,
                     o_Q1    = Open()
                 )
@@ -254,13 +264,13 @@ class GW5DDRPHY(Module, AutoCSR):
                     continue
                 for i in range(len(pad)):
                     pad_oddrx2f = Signal()
-                    self.specials += Instance("OSER4",
+                    self.specials += Instance(f"OSER{serdes_bits}",
                         p_TXCLK_POL = 0b0,
                         i_RESET = ResetSignal("sys"),
                         i_PCLK = ClockSignal("sys"),
-                        i_FCLK = ClockSignal("sys2x"),
-                        **{f"i_TX{n}": 0b0 for n in range(2)},
-                        **{f"i_D{n}": getattr(dfi.phases[n//2], dfi_name)[i] for n in range(4)},
+                        i_FCLK = ClockSignal(fast_domain),
+                        **{f"i_TX{n}": 0b0 for n in range(nphases)},
+                        **{f"i_D{n}": getattr(dfi.phases[n//2], dfi_name)[i] for n in range(serdes_bits)},
                         o_Q0   = pad_oddrx2f,
                         o_Q1   = Open()
                     )
@@ -292,11 +302,11 @@ class GW5DDRPHY(Module, AutoCSR):
             wrpntr   = Signal(3)
             burstdet = Signal()
             self.specials += Instance("DQS",
-                p_DQS_MODE = "X2_DDR3",
+                p_DQS_MODE = "X2_DDR3" if nphases == 2 else "X4",
                 # Clocks / Reset
                 i_RESET    = ResetSignal("sys"),
                 i_PCLK     = ClockSignal("sys"),
-                i_FCLK     = ClockSignal("sys2x"),
+                i_FCLK     = ClockSignal(fast_domain),
                 i_DLLSTEP  = self.init.delay,
                 i_HOLD     = pause | self._dly_sel.storage[i],
 
@@ -327,26 +337,38 @@ class GW5DDRPHY(Module, AutoCSR):
                 o_DQSW0    = dqsw
             )
             burstdet_d = Signal()
+            if nphases == 4:
+                # RBURST can rise and fall between system clock edges in X4 mode.
+                # Capture its edge in the fast domain before crossing to sys.
+                burstdet_sync = PulseSynchronizer(fast_domain + "_i", "sys")
+                self.submodules += burstdet_sync
+                self.sync.sys4x_i += burstdet_d.eq(burstdet)
+                self.comb += burstdet_sync.i.eq(burstdet & ~burstdet_d)
+                burst_event = burstdet_sync.o
+            else:
+                self.sync += burstdet_d.eq(burstdet)
+                burst_event = burstdet & ~burstdet_d
             self.sync += [
-                burstdet_d.eq(burstdet),
                 If(self._burstdet_clr.wr_stb,  self._burstdet_seen.status[i].eq(0)),
-                If(burstdet & ~burstdet_d, self._burstdet_seen.status[i].eq(1)),
+                If(burst_event, self._burstdet_seen.status[i].eq(1)),
             ]
 
             # DQS ----------------------------------------------------------------------------------
             dqs_o     = Signal()
             dqs_o_oen = Signal()
             self.specials += [
-                Instance("OSER4_MEM",
+                Instance(f"OSER{serdes_bits}_MEM",
                     p_TCLK_SOURCE = "DQSW",
                     p_TXCLK_POL   = 0b1,
                     i_RESET = ResetSignal("sys"),
                     i_PCLK  = ClockSignal("sys"),
-                    i_FCLK  = ClockSignal("sys2x"),
+                    i_FCLK  = ClockSignal(fast_domain),
                     i_TCLK  = dqsw,
-                    i_TX0   = ~(dqs_oe | dqs_postamble),
-                    i_TX1   = ~(dqs_oe | dqs_preamble),
-                    **{f"i_D{n}": (0b1010 >> n) & 0b1 for n in range(4)},
+                    **{f"i_TX{n}": ~(dqs_oe |
+                        (dqs_postamble if n == 0 else 0) |
+                        (dqs_preamble if n == nphases - 1 else 0))
+                        for n in range(nphases)},
+                    **{f"i_D{n}": (0b10101010 >> n) & 0b1 for n in range(serdes_bits)},
                     o_Q0    = dqs_o,
                     o_Q1    = dqs_o_oen
                 ),
@@ -362,23 +384,26 @@ class GW5DDRPHY(Module, AutoCSR):
             # DM -----------------------------------------------------------------------------------
             dm_o_data       = Signal(8)
             dm_o_data_d     = Signal(8)
-            dm_o_data_muxed = Signal(4)
+            dm_o_data_muxed = Signal(serdes_bits)
             for n in range(8):
-                self.comb += dm_o_data[n].eq(dfi.phases[n//4].wrdata_mask[n%4*databits//8+dm_remapping.get(i, i)])
-            self.sync += dm_o_data_d.eq(dm_o_data)
-            dm_bl8_cases = {}
-            dm_bl8_cases[0] = dm_o_data_muxed.eq(dm_o_data[:4])
-            dm_bl8_cases[1] = dm_o_data_muxed.eq(dm_o_data_d[4:])
-            self.sync += Case(bl8_chunk, dm_bl8_cases)
-            self.specials += Instance("OSER4_MEM",
+                self.comb += dm_o_data[n].eq(dfi.phases[n//phase_beats].wrdata_mask[n%phase_beats*databits//8+dm_remapping.get(i, i)])
+            if nphases == 2:
+                self.sync += dm_o_data_d.eq(dm_o_data)
+                self.sync += Case(bl8_chunk, {
+                    0: dm_o_data_muxed.eq(dm_o_data[:4]),
+                    1: dm_o_data_muxed.eq(dm_o_data_d[4:]),
+                })
+            else:
+                self.sync += dm_o_data_muxed.eq(dm_o_data)
+            self.specials += Instance(f"OSER{serdes_bits}_MEM",
                 p_TCLK_SOURCE = "DQSW270",
                 p_TXCLK_POL   = 0b0,
                 i_RESET = ResetSignal("sys"),
                 i_PCLK  = ClockSignal("sys"),
-                i_FCLK  = ClockSignal("sys2x"),
+                i_FCLK  = ClockSignal(fast_domain),
                 i_TCLK  = dqsw270,
-                **{f"i_TX{n}": 0b0 for n in range(2)},
-                **{f"i_D{n}": dm_o_data_muxed[n] for n in range(4)},
+                **{f"i_TX{n}": 0b0 for n in range(nphases)},
+                **{f"i_D{n}": dm_o_data_muxed[n] for n in range(serdes_bits)},
                 o_Q0    = pads.dm[i],
                 o_Q1    = Open()
             )
@@ -391,49 +416,54 @@ class GW5DDRPHY(Module, AutoCSR):
                 dq_i_data       = Signal(8)
                 dq_o_data       = Signal(8)
                 dq_o_data_d     = Signal(8)
-                dq_o_data_muxed = Signal(4)
+                dq_o_data_muxed = Signal(serdes_bits)
                 for n in range(8):
-                    self.comb += dq_o_data[n].eq(dfi.phases[n//4].wrdata[n%4*databits+j])
-                self.sync += dq_o_data_d.eq(dq_o_data)
-                dq_bl8_cases = {}
-                dq_bl8_cases[0] = dq_o_data_muxed.eq(dq_o_data[:4])
-                dq_bl8_cases[1] = dq_o_data_muxed.eq(dq_o_data_d[4:])
-                self.sync += Case(bl8_chunk, dq_bl8_cases)
-                self.specials += Instance("OSER4_MEM",
+                    self.comb += dq_o_data[n].eq(dfi.phases[n//phase_beats].wrdata[n%phase_beats*databits+j])
+                if nphases == 2:
+                    self.sync += dq_o_data_d.eq(dq_o_data)
+                    self.sync += Case(bl8_chunk, {
+                        0: dq_o_data_muxed.eq(dq_o_data[:4]),
+                        1: dq_o_data_muxed.eq(dq_o_data_d[4:]),
+                    })
+                else:
+                    self.sync += dq_o_data_muxed.eq(dq_o_data)
+                self.specials += Instance(f"OSER{serdes_bits}_MEM",
                     p_TCLK_SOURCE = "DQSW270",
                     p_TXCLK_POL   = 0b0,
                     i_RESET = ResetSignal("sys"),
                     i_PCLK  = ClockSignal("sys"),
-                    i_FCLK  = ClockSignal("sys2x"),
+                    i_FCLK  = ClockSignal(fast_domain),
                     i_TCLK  = dqsw270,
                     # Enable DQ before the first DQS edge of the write burst.
-                    i_TX0   = ~(dq_oe | dqs_preamble),
-                    i_TX1   = ~(dq_oe | dqs_preamble),
-                    **{f"i_D{n}": dq_o_data_muxed[n] for n in range(4)},
+                    **{f"i_TX{n}": ~(dq_oe | dqs_preamble) for n in range(nphases)},
+                    **{f"i_D{n}": dq_o_data_muxed[n] for n in range(serdes_bits)},
                     o_Q0    = dq_o,
                     o_Q1    = dq_o_oen,
                 )
-                dq_i_bitslip = BitSlip(4,
+                dq_i_bitslip = BitSlip(serdes_bits,
                     rst    = self._dly_sel.storage[i] & self._rdly_dq_bitslip_rst.wr_stb,
                     slp    = self._dly_sel.storage[i] & self._rdly_dq_bitslip.wr_stb,
                     cycles = 1)
                 self.submodules += dq_i_bitslip
-                self.specials += Instance("IDES4_MEM",
+                self.specials += Instance(f"IDES{serdes_bits}_MEM",
                     i_RESET = ResetSignal("sys"),
                     i_PCLK  = ClockSignal("sys"),
-                    i_FCLK  = ClockSignal("sys2x"),
+                    i_FCLK  = ClockSignal(fast_domain),
                     i_ICLK  = dqsr90,
                     i_RADDR = rdpntr,
                     i_WADDR = wrpntr,
                     i_D     = dq_i,
                     i_CALIB = 0,
-                    **{f"o_Q{n}": dq_i_bitslip.i[n] for n in range(4)},
+                    **{f"o_Q{n}": dq_i_bitslip.i[n] for n in range(serdes_bits)},
                 )
-                dq_i_bitslip_o_d = Signal(4)
-                self.sync += dq_i_bitslip_o_d.eq(dq_i_bitslip.o)
-                self.comb += dq_i_data.eq(Cat(dq_i_bitslip_o_d, dq_i_bitslip.o))
+                if nphases == 2:
+                    dq_i_bitslip_o_d = Signal(4)
+                    self.sync += dq_i_bitslip_o_d.eq(dq_i_bitslip.o)
+                    self.comb += dq_i_data.eq(Cat(dq_i_bitslip_o_d, dq_i_bitslip.o))
+                else:
+                    self.comb += dq_i_data.eq(dq_i_bitslip.o)
                 for n in range(8):
-                    self.comb += dfi.phases[n//4].rddata[n%4*databits+j].eq(dq_i_data[n])
+                    self.comb += dfi.phases[n//phase_beats].rddata[n%phase_beats*databits+j].eq(dq_i_data[n])
                 self.specials += Instance("IOBUF",
                     i_I   = dq_o,
                     i_OEN = dq_o_oen,
@@ -448,11 +478,8 @@ class GW5DDRPHY(Module, AutoCSR):
         # control DQS read (internal read pulse of the DQSBUF) and the output of the delay is used
         # signal a valid read data to the DFI interface.
         #
-        # The DQS read must be asserted for 2 sys_clk cycles before the read data is coming back from
-        # the DRAM (see 6.2.4 READ Pulse Positioning Optimization of FPGA-TN-02035-1.2)
-        #
-        # The read data valid is asserted for 1 sys_clk cycle when the data is available on the DFI
-        # interface, the latency is the sum of the ODDRX2DQA, CAS, IDDRX2DQA latencies.
+        # DQS read gates the returning burst. Read data valid marks the cycle in which the
+        # complete BL8 burst is available on the DFI interface.
         rddata_en = TappedDelayLine(
             signal = reduce(or_, [dfi.phases[i].rddata_en for i in range(nphases)]),
             ntaps  = self.settings.read_latency
@@ -460,29 +487,28 @@ class GW5DDRPHY(Module, AutoCSR):
         self.submodules += rddata_en
 
         self.comb += [phase.rddata_valid.eq(rddata_en.output) for phase in dfi.phases]
-        self.comb += dqs_re.eq(rddata_en.taps[rdtap] | rddata_en.taps[rdtap + 1])
+        self.comb += dqs_re.eq(reduce(or_, rddata_en.taps[rdtap:rdtap + 4//nphases]))
 
         # Write Control Path -----------------------------------------------------------------------
         wrtap = cwl_sys_latency - 1
 
         # Create a delay line of write commands coming from the DFI interface. This taps are used to
         # control DQ/DQS tristates and to select write data of the DRAM burst from the DFI interface.
-        # The PHY is operating in halfrate mode (so provide 4 datas every sys_clk cycles: 2x for DDR,
-        # 2x for halfrate) but DDR3 requires a burst of 8 datas (BL8) for best efficiency. Writes are
-        # then performed in 2 sys_clk cycles and data needs to be selected for each cycle.
+        # BL8 occupies two system cycles at 1:2 and one at 1:4. In 1:2 mode the write
+        # data mux selects the appropriate half of the burst for each cycle.
         wrdata_en = TappedDelayLine(
             signal = reduce(or_, [dfi.phases[i].wrdata_en for i in range(nphases)]),
             ntaps  = wrtap + 4
         )
         self.submodules += wrdata_en
 
-        self.comb += dq_oe.eq(wrdata_en.taps[wrtap] | wrdata_en.taps[wrtap + 1])
+        burst_cycles = 4//nphases
+        self.comb += dq_oe.eq(reduce(or_, wrdata_en.taps[wrtap:wrtap + burst_cycles]))
         self.comb += bl8_chunk.eq(wrdata_en.taps[wrtap])
         self.comb += dqs_oe.eq(dq_oe)
 
         # Write DQS Postamble/Preamble Control Path ------------------------------------------------
-        # Generates DQS Preamble 1 cycle before the first write and Postamble 1 cycle after the last
-        # write. During writes, DQS tristate is configured as output for at least 4 sys_clk cycles:
-        # 1 for Preamble, 2 for the Write and 1 for the Postamble.
+        # Extend DQS output enable by one memory clock at each end of the burst. The
+        # serializer selects the last/first TX slot of the preceding/following system cycle.
         self.comb += dqs_preamble.eq( wrdata_en.taps[wrtap - 1]  & ~wrdata_en.taps[wrtap + 0])
-        self.comb += dqs_postamble.eq(wrdata_en.taps[wrtap + 2]  & ~wrdata_en.taps[wrtap + 1])
+        self.comb += dqs_postamble.eq(wrdata_en.taps[wrtap + burst_cycles] & ~wrdata_en.taps[wrtap + burst_cycles - 1])

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -340,10 +340,13 @@ class GW5DDRPHY(Module, AutoCSR):
             if nphases == 4:
                 # RBURST can rise and fall between system clock edges in X4 mode.
                 # Capture its edge in the fast domain before crossing to sys.
+                # Synchronize before edge detection so both inputs are registered.
                 burstdet_sync = PulseSynchronizer(fast_domain + "_i", "sys")
                 self.submodules += burstdet_sync
-                self.sync.sys4x_i += burstdet_d.eq(burstdet)
-                self.comb += burstdet_sync.i.eq(burstdet & ~burstdet_d)
+                burstdet_sample = Signal()
+                self.specials += MultiReg(burstdet, burstdet_sample, fast_domain + "_i")
+                self.sync.sys4x_i += burstdet_d.eq(burstdet_sample)
+                self.comb += burstdet_sync.i.eq(burstdet_sample & ~burstdet_d)
                 burst_event = burstdet_sync.o
             else:
                 self.sync += burstdet_d.eq(burstdet)

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -145,6 +145,7 @@ class GW5DDRPHY(Module, AutoCSR):
         serdes_bits = 2*nphases
         phase_beats = 8//nphases
         fast_domain = f"sys{nphases}x"
+        dll_on_x4   = nphases == 4 and not dll_off
         if not dm_remapping:
             dm_remapping = {}
         assert databits%8 == 0
@@ -292,6 +293,12 @@ class GW5DDRPHY(Module, AutoCSR):
         dqs_oe        = Signal()
         dqs_postamble = Signal()
         dqs_preamble  = Signal()
+        dqs_read = Replicate(dqs_re, 4)
+        if dll_on_x4:
+            # DLL-on returns DQS one CK later than DLL-off at the same CL.
+            dqs_re_d = Signal()
+            self.sync += dqs_re_d.eq(dqs_re)
+            dqs_read = Cat(dqs_re_d, Replicate(dqs_re, 3))
         for i in range(databits//8):
             # DQS
             dqs_i    = Signal()
@@ -312,18 +319,19 @@ class GW5DDRPHY(Module, AutoCSR):
 
                 # Control
                 # Calibrate the read delay, keeping the FIFO clock source fixed.
+                # DLL-on X4 scans toward decreasing delay.
                 i_RLOADN   = ~(self._dly_sel.storage[i] & self._rdly_dq_rst.wr_stb),
                 i_RMOVE    = self._dly_sel.storage[i] & self._rdly_dq_inc.wr_stb,
-                i_RDIR     = 0,
+                i_RDIR     = 1 if dll_on_x4 else 0,
                 i_WLOADN   = 0,
                 i_WMOVE    = 0,
                 i_WDIR     = 1,
                 o_RFLAG    = Open(),
                 o_WFLAG    = Open(),
 
-                # Reads (generate shifted DQS clock for reads)
-                i_READ     = Replicate(dqs_re, 4),
-                i_RCLKSEL  = 0,
+                # Reads (DLL-on X4 uses the opposite read-gate polarity).
+                i_READ     = dqs_read,
+                i_RCLKSEL  = 2 if dll_on_x4 else 0,
                 i_DQSIN    = dqs_i,
                 o_DQSR90   = dqsr90,
                 o_RPOINT   = rdpntr,

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -124,7 +124,8 @@ class GW5DDRPHY(Module, AutoCSR):
         cwl          = None,
         cmd_delay    = 0,
         clk_polarity = 0,
-        dm_remapping = None):
+        dm_remapping = None,
+        dll_off      = False):
         assert isinstance(cmd_delay, int) and cmd_delay < 128
         pads        = PHYPadsCombiner(pads)
         memtype     = "DDR3"
@@ -140,8 +141,14 @@ class GW5DDRPHY(Module, AutoCSR):
 
         # Init -------------------------------------------------------------------------------------
         self.submodules.init = GW5DDRPHYInit()
+        pause = Signal()
+        self.specials += MultiReg(self.init.pause, pause, "sys")
 
         # Parameters -------------------------------------------------------------------------------
+        if dll_off:
+            if cl not in (None, 6) or cwl not in (None, 6):
+                raise ValueError("DDR3 DLL-off mode requires CL=6 and CWL=6.")
+            cl, cwl = 6, 6
         cl  = get_default_cl( memtype, tck) if cl  is None else cl
         cwl = get_default_cwl(memtype, tck) if cwl is None else cwl
         cl_sys_latency  = get_sys_latency(nphases, cl)
@@ -179,8 +186,9 @@ class GW5DDRPHY(Module, AutoCSR):
             write_latency = cwl_sys_latency - 1,
             read_leveling = True,
             bitslips      = 4,
-            delays        = 8,
+            delays        = 128,
         )
+        self.settings.dll_off = dll_off
 
         # DFI Interface ----------------------------------------------------------------------------
         self.dfi = dfi = Interface(addressbits, bankbits, nranks, 4*databits, nphases)
@@ -282,12 +290,7 @@ class GW5DDRPHY(Module, AutoCSR):
             dqsw     = Signal()
             rdpntr   = Signal(3)
             wrpntr   = Signal(3)
-            rdly     = Signal(3)
             burstdet = Signal()
-            self.sync += [
-                If(self._dly_sel.storage[i] & self._rdly_dq_rst.wr_stb, rdly.eq(0)),
-                If(self._dly_sel.storage[i] & self._rdly_dq_inc.wr_stb, rdly.eq(rdly + 1))
-            ]
             self.specials += Instance("DQS",
                 p_DQS_MODE = "X2_DDR3",
                 # Clocks / Reset
@@ -295,13 +298,13 @@ class GW5DDRPHY(Module, AutoCSR):
                 i_PCLK     = ClockSignal("sys"),
                 i_FCLK     = ClockSignal("sys2x"),
                 i_DLLSTEP  = self.init.delay,
-                i_HOLD     = self.init.pause | self._dly_sel.storage[i],
+                i_HOLD     = pause | self._dly_sel.storage[i],
 
                 # Control
-                # Assert LOADNs to use DDRDEL control
-                i_RLOADN   = 0,
-                i_RMOVE    = 0,
-                i_RDIR     = 1,
+                # Calibrate the read delay, keeping the FIFO clock source fixed.
+                i_RLOADN   = ~(self._dly_sel.storage[i] & self._rdly_dq_rst.wr_stb),
+                i_RMOVE    = self._dly_sel.storage[i] & self._rdly_dq_inc.wr_stb,
+                i_RDIR     = 0,
                 i_WLOADN   = 0,
                 i_WMOVE    = 0,
                 i_WDIR     = 1,
@@ -310,7 +313,7 @@ class GW5DDRPHY(Module, AutoCSR):
 
                 # Reads (generate shifted DQS clock for reads)
                 i_READ     = Replicate(dqs_re, 4),
-                i_RCLKSEL  = rdly,
+                i_RCLKSEL  = 0,
                 i_DQSIN    = dqs_i,
                 o_DQSR90   = dqsr90,
                 o_RPOINT   = rdpntr,
@@ -403,8 +406,9 @@ class GW5DDRPHY(Module, AutoCSR):
                     i_PCLK  = ClockSignal("sys"),
                     i_FCLK  = ClockSignal("sys2x"),
                     i_TCLK  = dqsw270,
-                    i_TX0   = ~dq_oe,
-                    i_TX1   = ~dq_oe,
+                    # Enable DQ before the first DQS edge of the write burst.
+                    i_TX0   = ~(dq_oe | dqs_preamble),
+                    i_TX1   = ~(dq_oe | dqs_preamble),
                     **{f"i_D{n}": dq_o_data_muxed[n] for n in range(4)},
                     o_Q0    = dq_o,
                     o_Q1    = dq_o_oen,

--- a/test/test_ddr3_phy_settings.py
+++ b/test/test_ddr3_phy_settings.py
@@ -49,6 +49,14 @@ class TestDDR3PHYSettings(unittest.TestCase):
 
                     self.assertEqual(phy.settings.cwl, expected_cwl)
 
+    def test_gw5_dll_off(self):
+        phy = GW5DDRPHY(self.get_pads(), sys_clk_freq=50e6, dll_off=True)
+        self.assertTrue(phy.settings.dll_off)
+        self.assertEqual((phy.settings.cl, phy.settings.cwl), (6, 6))
+        self.assertEqual((phy.settings.rdphase, phy.settings.wrphase), (0, 0))
+        with self.assertRaises(ValueError):
+            GW5DDRPHY(self.get_pads(), sys_clk_freq=50e6, dll_off=True, cwl=5)
+
     def test_write_latency_matches_phy_pipeline(self):
         for name, phy_cls, write_latency_offset in self.phys:
             for sys_clk_freq in self.sys_clk_freqs:

--- a/test/test_gw5ddrphy.py
+++ b/test/test_gw5ddrphy.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: BSD-2-Clause
+import unittest
+
+from migen import *
+from migen.sim import run_simulation
+
+from litedram.phy.gw5ddrphy import GW5DDRPHY
+from test import test_ddr3_phy_settings
+
+
+class TestGW5DDRPHY(unittest.TestCase):
+    def test_quarter_rate_data_order(self):
+        phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(), nphases=4,
+            sys_clk_freq=25e6, dll_off=True)
+        fragment = phy.get_fragment()
+        instances = sorted((s for s in fragment.specials if isinstance(s, Instance)), key=lambda s: s.duid)
+        def ports(instance):
+            return {p.name: p.expr for p in instance.items if isinstance(p, (Instance.Input, Instance.Output))}
+        serializers = []
+        for instance in instances:
+            if instance.of == "OSER8_MEM":
+                params = {p.name: p.value for p in instance.items if isinstance(p, Instance.Parameter)}
+                if params["TCLK_SOURCE"] == "DQSW270":
+                    serializers.append(ports(instance))
+        dm, *dq = serializers
+        ides = [ports(s) for s in instances if s.of == "IDES8_MEM"]
+        # Simulate the fabric data path, driving the memory primitive outputs directly.
+        fragment.specials.clear()
+        written = [0x13, 0x27, 0x45, 0x89, 0xab, 0xcd, 0xef, 0x01]
+        read = [0x91, 0x82, 0x74, 0x68, 0x5f, 0x4e, 0x3d, 0x2c]
+        masks = 0b10100110
+        def generator():
+            for p, phase in enumerate(phy.dfi.phases):
+                yield phase.wrdata.eq(written[2*p] | written[2*p+1] << 8)
+                yield phase.wrdata_mask.eq((masks >> (2*p)) & 3)
+            for j, deserializer in enumerate(ides):
+                for n in range(8):
+                    yield deserializer[f"Q{n}"].eq((read[n] >> j) & 1)
+            for _ in range(4):
+                yield
+            for n in range(8):
+                actual = 0
+                for j, serializer in enumerate(dq):
+                    actual |= (yield serializer[f"D{n}"]) << j
+                self.assertEqual(actual, written[n])
+                self.assertEqual((yield dm[f"D{n}"]), (masks >> n) & 1)
+            for p, phase in enumerate(phy.dfi.phases):
+                self.assertEqual((yield phase.rddata), read[2*p] | read[2*p+1] << 8)
+        run_simulation(fragment, generator(), clocks={"sys": 40, "init": 20, "sys4x_i": 10})
+
+    def test_quarter_rate_short_burst_flag(self):
+        phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(),
+            nphases=4, sys_clk_freq=25e6, dll_off=True)
+        fragment = phy.get_fragment()
+        dqs = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "DQS")
+        burst = next(p.expr for p in dqs.items if isinstance(p, Instance.Output) and p.name == "RBURST")
+        fragment.specials = {s for s in fragment.specials if not isinstance(s, Instance)}
+        def fast_generator():
+            yield burst.eq(0)
+            for _ in range(8):
+                yield
+            # A ten-unit pulse from t=85 to t=95 misses the sys edges at t=60/100.
+            yield burst.eq(1)
+            yield
+            yield burst.eq(0)
+        def sys_generator():
+            yield phy._burstdet_clr.wr_stb.eq(1)
+            yield
+            yield phy._burstdet_clr.wr_stb.eq(0)
+            for _ in range(8):
+                yield
+            self.assertEqual((yield phy._burstdet_seen.status), 1)
+            yield phy._burstdet_clr.wr_stb.eq(1)
+            yield
+            yield phy._burstdet_clr.wr_stb.eq(0)
+            for _ in range(4):
+                yield
+            self.assertEqual((yield phy._burstdet_seen.status), 0)
+        run_simulation(fragment, {"sys": sys_generator(), "sys4x_i": fast_generator()},
+            clocks={"sys": 40, "sys4x_i": 10, "init": 20})
+
+    def test_supported_ratios(self):
+        for nphases in (2, 4):
+            phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(), nphases=nphases)
+            self.assertEqual(sum(len(p.wrdata) for p in phy.dfi.phases), 64)
+            self.assertEqual(phy.settings.bitslips, 2*nphases)
+        with self.assertRaises(ValueError):
+            GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(), nphases=3)

--- a/test/test_gw5ddrphy.py
+++ b/test/test_gw5ddrphy.py
@@ -86,3 +86,24 @@ class TestGW5DDRPHY(unittest.TestCase):
             self.assertEqual(phy.settings.bitslips, 2*nphases)
         with self.assertRaises(ValueError):
             GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(), nphases=3)
+
+    def test_quarter_rate_read_window(self):
+        for dll_off, expected in ((True, [0xf]), (False, [0xe, 0x1])):
+            with self.subTest(dll_off=dll_off):
+                phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(),
+                    nphases=4, sys_clk_freq=25e6 if dll_off else 100e6, dll_off=dll_off)
+                fragment = phy.get_fragment()
+                dqs = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "DQS")
+                read = next(p.expr for p in dqs.items if isinstance(p, Instance.Input) and p.name == "READ")
+                fragment.specials.clear()
+                windows = []
+                def generator():
+                    yield phy.dfi.phases[phy.settings.rdphase].rddata_en.eq(1)
+                    yield
+                    yield phy.dfi.phases[phy.settings.rdphase].rddata_en.eq(0)
+                    for _ in range(10):
+                        windows.append((yield read))
+                        yield
+                run_simulation(fragment, generator(), clocks={"sys": 40, "sys4x_i": 10, "init": 20})
+                # Keep the BL8 gate four CK long, delayed one CK for DLL-on.
+                self.assertEqual([window for window in windows if window], expected)

--- a/test/test_gw5ddrphy.py
+++ b/test/test_gw5ddrphy.py
@@ -1,4 +1,8 @@
+#
+# This file is part of LiteDRAM.
+#
 # SPDX-License-Identifier: BSD-2-Clause
+
 import unittest
 
 from migen import *
@@ -10,12 +14,17 @@ from test import test_ddr3_phy_settings
 
 class TestGW5DDRPHY(unittest.TestCase):
     def test_quarter_rate_data_order(self):
-        phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(), nphases=4,
-            sys_clk_freq=25e6, dll_off=True)
-        fragment = phy.get_fragment()
+        phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(),
+            nphases      = 4,
+            sys_clk_freq = 25e6,
+            dll_off      = True,
+        )
+        fragment  = phy.get_fragment()
         instances = sorted((s for s in fragment.specials if isinstance(s, Instance)), key=lambda s: s.duid)
+
         def ports(instance):
             return {p.name: p.expr for p in instance.items if isinstance(p, (Instance.Input, Instance.Output))}
+
         serializers = []
         for instance in instances:
             if instance.of == "OSER8_MEM":
@@ -24,11 +33,13 @@ class TestGW5DDRPHY(unittest.TestCase):
                     serializers.append(ports(instance))
         dm, *dq = serializers
         ides = [ports(s) for s in instances if s.of == "IDES8_MEM"]
+
         # Simulate the fabric data path, driving the memory primitive outputs directly.
         fragment.specials.clear()
         written = [0x13, 0x27, 0x45, 0x89, 0xab, 0xcd, 0xef, 0x01]
-        read = [0x91, 0x82, 0x74, 0x68, 0x5f, 0x4e, 0x3d, 0x2c]
-        masks = 0b10100110
+        read    = [0x91, 0x82, 0x74, 0x68, 0x5f, 0x4e, 0x3d, 0x2c]
+        masks   = 0b10100110
+
         def generator():
             for p, phase in enumerate(phy.dfi.phases):
                 yield phase.wrdata.eq(written[2*p] | written[2*p+1] << 8)
@@ -46,15 +57,20 @@ class TestGW5DDRPHY(unittest.TestCase):
                 self.assertEqual((yield dm[f"D{n}"]), (masks >> n) & 1)
             for p, phase in enumerate(phy.dfi.phases):
                 self.assertEqual((yield phase.rddata), read[2*p] | read[2*p+1] << 8)
+
         run_simulation(fragment, generator(), clocks={"sys": 40, "init": 20, "sys4x_i": 10})
 
     def test_quarter_rate_short_burst_flag(self):
         phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(),
-            nphases=4, sys_clk_freq=25e6, dll_off=True)
+            nphases      = 4,
+            sys_clk_freq = 25e6,
+            dll_off      = True,
+        )
         fragment = phy.get_fragment()
-        dqs = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "DQS")
-        burst = next(p.expr for p in dqs.items if isinstance(p, Instance.Output) and p.name == "RBURST")
+        dqs      = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "DQS")
+        burst    = next(p.expr for p in dqs.items if isinstance(p, Instance.Output) and p.name == "RBURST")
         fragment.specials = {s for s in fragment.specials if not isinstance(s, Instance)}
+
         def fast_generator():
             yield burst.eq(0)
             for _ in range(8):
@@ -63,6 +79,7 @@ class TestGW5DDRPHY(unittest.TestCase):
             yield burst.eq(1)
             yield
             yield burst.eq(0)
+
         def sys_generator():
             yield phy._burstdet_clr.wr_stb.eq(1)
             yield
@@ -76,8 +93,10 @@ class TestGW5DDRPHY(unittest.TestCase):
             for _ in range(4):
                 yield
             self.assertEqual((yield phy._burstdet_seen.status), 0)
+
         run_simulation(fragment, {"sys": sys_generator(), "sys4x_i": fast_generator()},
-            clocks={"sys": 40, "sys4x_i": 10, "init": 20})
+            clocks = {"sys": 40, "sys4x_i": 10, "init": 20},
+        )
 
     def test_supported_ratios(self):
         for nphases in (2, 4):
@@ -91,12 +110,16 @@ class TestGW5DDRPHY(unittest.TestCase):
         for dll_off, expected in ((True, [0xf]), (False, [0xe, 0x1])):
             with self.subTest(dll_off=dll_off):
                 phy = GW5DDRPHY(test_ddr3_phy_settings.TestDDR3PHYSettings.get_pads(),
-                    nphases=4, sys_clk_freq=25e6 if dll_off else 100e6, dll_off=dll_off)
+                    nphases      = 4,
+                    sys_clk_freq = 25e6 if dll_off else 100e6,
+                    dll_off      = dll_off,
+                )
                 fragment = phy.get_fragment()
-                dqs = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "DQS")
-                read = next(p.expr for p in dqs.items if isinstance(p, Instance.Input) and p.name == "READ")
+                dqs      = next(s for s in fragment.specials if isinstance(s, Instance) and s.of == "DQS")
+                read     = next(p.expr for p in dqs.items if isinstance(p, Instance.Input) and p.name == "READ")
                 fragment.specials.clear()
                 windows = []
+
                 def generator():
                     yield phy.dfi.phases[phy.settings.rdphase].rddata_en.eq(1)
                     yield
@@ -104,6 +127,7 @@ class TestGW5DDRPHY(unittest.TestCase):
                     for _ in range(10):
                         windows.append((yield read))
                         yield
+
                 run_simulation(fragment, generator(), clocks={"sys": 40, "sys4x_i": 10, "init": 20})
                 # Keep the BL8 gate four CK long, delayed one CK for DLL-on.
                 self.assertEqual([window for window in windows if window], expected)

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -26,6 +26,25 @@ def update_c_reference(content, filename):
     f.close()
 
 class TestInit(unittest.TestCase):
+    def test_ddr3_dll_off(self):
+        from types import SimpleNamespace
+        from litedram.init import get_ddr3_phy_init_sequence
+
+        phy = SimpleNamespace(cl=6, cwl=6, nphases=2, dll_off=True)
+        timing = SimpleNamespace(tWTR=3)
+        sequence, registers = get_ddr3_phy_init_sequence(phy, timing)
+        modes = {bank: address for label, address, bank, command, delay in sequence
+                 if label.startswith("Load Mode Register")}
+        self.assertEqual(modes[1], 0x3)  # DLL off, RZQ/7 drive, RTT_NOM disabled.
+        self.assertEqual(modes[2], 0x8)  # CWL6, RTT_WR disabled.
+        self.assertEqual(registers[1], modes[1])
+
+        for cl, cwl in ((5, 6), (6, 5), (7, 7)):
+            with self.subTest(cl=cl, cwl=cwl):
+                phy.cl, phy.cwl = cl, cwl
+                with self.assertRaises(ValueError):
+                    get_ddr3_phy_init_sequence(phy, timing)
+
     def test_sdr(self):
         from litex_boards.targets.scarabhardware_minispartan6 import BaseSoC
         soc       = BaseSoC()

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -30,13 +30,15 @@ class TestInit(unittest.TestCase):
         from types import SimpleNamespace
         from litedram.init import get_ddr3_phy_init_sequence
 
-        phy = SimpleNamespace(cl=6, cwl=6, nphases=2, dll_off=True)
+        phy    = SimpleNamespace(cl=6, cwl=6, nphases=2, dll_off=True)
         timing = SimpleNamespace(tWTR=3)
         sequence, registers = get_ddr3_phy_init_sequence(phy, timing)
-        modes = {bank: address for label, address, bank, command, delay in sequence
-                 if label.startswith("Load Mode Register")}
-        self.assertEqual(modes[1], 0x3)  # DLL off, RZQ/7 drive, RTT_NOM disabled.
-        self.assertEqual(modes[2], 0x8)  # CWL6, RTT_WR disabled.
+        modes = {
+            bank: address for label, address, bank, command, delay in sequence
+            if label.startswith("Load Mode Register")
+        }
+        self.assertEqual(modes[1], 0x3) # DLL off, RZQ/7 drive, RTT_NOM disabled.
+        self.assertEqual(modes[2], 0x8) # CWL6, RTT_WR disabled.
         self.assertEqual(registers[1], modes[1])
 
         for cl, cwl in ((5, 6), (6, 5), (7, 7)):


### PR DESCRIPTION
The Tang Mega 138K Pro fails DDR3 initialization at its default 50 MHz system clock. Fix initialization and read leveling, and support both 1:2 (default) and opt-in 1:4 controller-to-memory clock ratios. Both ratios pass DLL-off hardware tests at 100 MHz DDR CK / 200 MT/s. Quarter-rate DLL-on also passes automatic calibration and controller memory tests at 400 MHz DDR CK / 800 MT/s (100 MHz system).

- Enable DQ during the existing DQS preamble. Hardware A/B testing showed a corrupt first word with the old enable; extending it restored all eight burst words.
- Calibrate the actual DQS delay through `RLOADN`/`RMOVE`, using 128 software steps. `RCLKSEL` selects a clock source/polarity, rather than consecutive delay taps. DLL-off uses `RDIR=0`/`RCLKSEL=0`; DLL-on X4 uses `RDIR=1`/`RCLKSEL=2`.
- Add opt-in DLL-off initialization with CL6/CWL6, MR1.A0 set, and nominal/dynamic ODT disabled. Synchronize the initialization pause into `sys` before driving DQS HOLD.
- Select OSER4/8, OSER4/8_MEM and IDES4/8_MEM from `nphases=2/4`. Quarter-rate mode uses DQS X4 and four DFI phases carrying two beats each, transferring a complete BL8 burst per system cycle. Commands, data/masks, bitslips, output enables and read gating follow the selected ratio.
- In X4 mode, synchronize native burst detection using the ungated fast PLL clock (`sys4x_i`), detect its edge from registered samples, and synchronize events into `sys`. Registering the signal before edge detection avoids asynchronous fanout to both the delayed sample and toggle logic; the regular target now finds all four calibration windows. Otherwise a pulse can fall between system clock edges and BIOS calibration rejects correct reads. Gowin's gated HCLK cannot drive those fabric registers. LiteScope captures established quarter-rate read latency as CL system latency + 7.
- For DLL-on X4, delay the four-CK DQS READ gate by one CK and change its polarity. DLL-on returns read DQS one CK later than DLL-off at the same CL. Scanning decreasing read delay yields valid data and native burst detection on all four lanes. These settings are selected by the existing `dll_off`/`nphases` configuration; host timing controls are unnecessary.

Hardware validation on Tang Mega 138K Pro, GW5AST-138B, Gowin 1.9.12, full 32-bit / 1 GiB DDR3:

| Ratio | System / DDR CK | Results |
| --- | --- | --- |
| 1:2 | 50 / 100 MHz | Automatic calibration, BIOS 2 MiB/32 MiB tests, random controller accesses and full-range address checks pass. Two additional SRAM reloads after the quarter-rate changes also pass. |
| 1:4 | 25 / 100 MHz | The regular target passes two SRAM reloads with all four calibration windows (bitslip 2, delay 63), BIOS 2 MiB, 16,384 random word checks and 1,392 address checks spanning 1 GiB combined. A separate manual BIOS 32 MiB test also passes on this final image. |
| 1:4 DLL-on | 100 / 400 MHz | Regular target: four SRAM loads, all four calibration windows, BIOS 2 MiB and 32 MiB tests, 32,768 random word checks and 2,784 address checks spanning 1 GiB combined. CL6/CWL5. |
| 1:4 DLL-on | 93.75 / 375 MHz | Regular target: automatic calibration, BIOS 2 MiB/32 MiB, 8,192 random words and 696 address comparisons pass. |

For each DLL-off ratio, independent BIST ports checked 544 MiB with zero errors, including concurrent reads/writes to separate regions and alternating counter/PRBS patterns. Deliberately wrong expected patterns produced the expected errors (8,388,608 with 32-bit ports). DLL-on at sys100/CK400 also passed 544 MiB with zero errors using 256-bit BIST ports in the 50 MHz init domain and a registered read FIFO; the deliberately wrong pattern produced exactly 1,048,576 errors. An additional stress run checked **64.5 GiB with zero errors across the entire 1 GiB**, alternating counter/PRBS writes between two 512 MiB regions while checking the other region. Its deliberately wrong pattern produced exactly 16,777,216 errors. Measured tester throughput was 1,405 MiB/s read and 1,793 MiB/s combined concurrent traffic. These are tester measurements, not a maximum DDR bandwidth claim. Debug CSRs, LiteScope, BIST and host timing sweeps are excluded from this PR.

`pytest -q test/test_init.py test/test_ddr3_phy_settings.py test/test_phy_utils.py test/test_gw5ddrphy.py`: **39 passed, 49 subtests passed**. The new fabric simulations check eight-beat data/mask ordering, capture of a burst flag shorter than one system cycle, and the DLL-on four-CK read window; they do not model external DRAM timing.

**Limits:** DLL-on at 100 MHz system is experimental, with incomplete timing closure and placement sensitivity. The regular build reports 396 setup / 41 hold endpoints, including approximately -0.3 ns on ordinary CPU/controller setup paths. At 93.75 MHz those ordinary setup paths are nonnegative, but initialization, reset and clock-crossing violations remain (108/5). A different instrumented sys100 build missed one calibration lane. Unbuffered testers clocked at sys100 had much larger timing violations and stalled; only the completed 50 MHz tester results above are counted. The 128 calibration values are software steps, not a measured 128-tap physical timing margin. DLL-on 1:2 and operation across temperature/voltage corners are not qualified. DLL-off behavior and the default ratio remain unchanged.

Requires the companion board configuration in https://github.com/litex-hub/litex-boards/pull/780. References: litex-hub/litex-boards#549, enjoy-digital/litex#1793; Gowin UG304 (OSER8_MEM/IDES8_MEM) and UG306 section 5.3 (DQS); [SK Hynix DDR3 Device Operation](https://e2e.ti.com/cfs-file/__key/communityserver-discussions-components-files/791/device_5F00_operation_5F00_H5TQ4G63EFR_2D00_RDI_5F00_TR_2D00_20210526224525093-_2800_1_2900_.pdf) sections 1.4.3.1 and 2.5.

The final style cleanup follows the surrounding signal/argument alignment and test layout. Python ASTs are identical before and after this cleanup; the focused PHY/init suite passes again (39 tests and 49 subtests).

CI is green on `f7c1189`: both push and pull-request build/test workflows pass.
