### PR TITLE
phy/gw5ddrphy: fix reset and calibrate physical read/write delays

### DIFF
--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -151,6 +151,7 @@ class GW5DDRPHY(Module, AutoCSR):
         assert databits%8 == 0
 
         # Init -------------------------------------------------------------------------------------
+        # Reset the I/O counters with CLKDIV while the fast clock is stopped.
         self.submodules.init = GW5DDRPHYInit(fast_domain)
 
         pause = Signal()
@@ -221,7 +222,7 @@ class GW5DDRPHY(Module, AutoCSR):
                 pad_clk = Signal()
                 self.specials += Instance(f"OSER{serdes_bits}",
                     p_TXCLK_POL = 0b0,
-                    i_RESET = ResetSignal("sys"),
+                    i_RESET = self.init.reset,
                     i_PCLK  = ClockSignal("sys"),
                     i_FCLK  = ClockSignal(fast_domain),
                     **{f"i_TX{n}": 0b0 for n in range(nphases)},
@@ -269,7 +270,7 @@ class GW5DDRPHY(Module, AutoCSR):
                     pad_oddrx2f = Signal()
                     self.specials += Instance(f"OSER{serdes_bits}",
                         p_TXCLK_POL = 0b0,
-                        i_RESET = ResetSignal("sys"),
+                        i_RESET = self.init.reset,
                         i_PCLK = ClockSignal("sys"),
                         i_FCLK = ClockSignal(fast_domain),
                         **{f"i_TX{n}": 0b0 for n in range(nphases)},
@@ -315,7 +316,7 @@ class GW5DDRPHY(Module, AutoCSR):
             self.specials += Instance("DQS",
                 p_DQS_MODE = "X2_DDR3" if nphases == 2 else "X4",
                 # Clocks / Reset
-                i_RESET    = ResetSignal("sys"),
+                i_RESET    = self.init.reset,
                 i_PCLK     = ClockSignal("sys"),
                 i_FCLK     = ClockSignal(fast_domain),
                 i_DLLSTEP  = self.init.delay,
@@ -374,7 +375,7 @@ class GW5DDRPHY(Module, AutoCSR):
                 Instance(f"OSER{serdes_bits}_MEM",
                     p_TCLK_SOURCE = "DQSW",
                     p_TXCLK_POL   = 0b1,
-                    i_RESET = ResetSignal("sys"),
+                    i_RESET = self.init.reset,
                     i_PCLK  = ClockSignal("sys"),
                     i_FCLK  = ClockSignal(fast_domain),
                     i_TCLK  = dqsw,
@@ -413,7 +414,7 @@ class GW5DDRPHY(Module, AutoCSR):
             self.specials += Instance(f"OSER{serdes_bits}_MEM",
                 p_TCLK_SOURCE = "DQSW270",
                 p_TXCLK_POL   = 0b0,
-                i_RESET = ResetSignal("sys"),
+                i_RESET = self.init.reset,
                 i_PCLK  = ClockSignal("sys"),
                 i_FCLK  = ClockSignal(fast_domain),
                 i_TCLK  = dqsw270,
@@ -445,7 +446,7 @@ class GW5DDRPHY(Module, AutoCSR):
                 self.specials += Instance(f"OSER{serdes_bits}_MEM",
                     p_TCLK_SOURCE = "DQSW270",
                     p_TXCLK_POL   = 0b0,
-                    i_RESET = ResetSignal("sys"),
+                    i_RESET = self.init.reset,
                     i_PCLK  = ClockSignal("sys"),
                     i_FCLK  = ClockSignal(fast_domain),
                     i_TCLK  = dqsw270,
@@ -461,7 +462,7 @@ class GW5DDRPHY(Module, AutoCSR):
                     cycles = 1)
                 self.submodules += dq_i_bitslip
                 self.specials += Instance(f"IDES{serdes_bits}_MEM",
-                    i_RESET = ResetSignal("sys"),
+                    i_RESET = self.init.reset,
                     i_PCLK  = ClockSignal("sys"),
                     i_FCLK  = ClockSignal(fast_domain),
                     i_ICLK  = dqsr90,

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -176,6 +176,11 @@ class GW5DDRPHY(Module, AutoCSR):
         self._rdly_dq_bitslip_rst = CSR()
         self._rdly_dq_bitslip     = CSR()
 
+        if dll_on_x4:
+            self._wdly_dq_rst = CSR()
+            self._wdly_dq_inc = CSR()
+            self._wdly_dq_dir = CSRStorage()
+
         self._burstdet_clr  = CSR()
         self._burstdet_seen = CSRStatus(databits//8)
 
@@ -199,6 +204,7 @@ class GW5DDRPHY(Module, AutoCSR):
             read_latency  = cl_sys_latency + (9 if nphases == 2 else 7),
             write_latency = cwl_sys_latency - 1,
             read_leveling = True,
+            write_dq_dqs_training = dll_on_x4,
             bitslips      = serdes_bits,
             delays        = 256,
         )
@@ -313,6 +319,9 @@ class GW5DDRPHY(Module, AutoCSR):
             rdpntr   = Signal(3)
             wrpntr   = Signal(3)
             burstdet = Signal()
+            wloadn = 0
+            if dll_on_x4:
+                wloadn = ~(self.init.reset | (self._dly_sel.storage[i] & self._wdly_dq_rst.wr_stb))
             self.specials += Instance("DQS",
                 p_DQS_MODE = "X2_DDR3" if nphases == 2 else "X4",
                 # Clocks / Reset
@@ -327,9 +336,9 @@ class GW5DDRPHY(Module, AutoCSR):
                 i_RLOADN   = ~(self._dly_sel.storage[i] & self._rdly_dq_rst.wr_stb),
                 i_RMOVE    = self._dly_sel.storage[i] & self._rdly_dq_inc.wr_stb,
                 i_RDIR     = self._rdly_dq_dir.storage,
-                i_WLOADN   = 0,
-                i_WMOVE    = 0,
-                i_WDIR     = 1,
+                i_WLOADN   = wloadn,
+                i_WMOVE    = self._dly_sel.storage[i] & self._wdly_dq_inc.wr_stb if dll_on_x4 else 0,
+                i_WDIR     = self._wdly_dq_dir.storage if dll_on_x4 else 1,
                 o_RFLAG    = Open(),
                 o_WFLAG    = Open(),
 

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -204,11 +204,11 @@ class GW5DDRPHY(Module, AutoCSR):
             read_latency  = cl_sys_latency + (9 if nphases == 2 else 7),
             write_latency = cwl_sys_latency - 1,
             read_leveling = True,
-            write_dq_dqs_training = dll_on_x4,
             bitslips      = serdes_bits,
             delays        = 256,
         )
-        self.settings.dll_off = dll_off
+        self.settings.dll_off               = dll_off
+        self.settings.write_dq_dqs_training = dll_on_x4
 
         # DFI Interface ----------------------------------------------------------------------------
         self.dfi = dfi = Interface(addressbits, bankbits, nranks, phase_beats*databits, nphases)
@@ -319,6 +319,7 @@ class GW5DDRPHY(Module, AutoCSR):
             rdpntr   = Signal(3)
             wrpntr   = Signal(3)
             burstdet = Signal()
+
             wloadn = 0
             if dll_on_x4:
                 wloadn = ~(self.init.reset | (self._dly_sel.storage[i] & self._wdly_dq_rst.wr_stb))

--- a/litedram/phy/gw5ddrphy.py
+++ b/litedram/phy/gw5ddrphy.py
@@ -171,6 +171,7 @@ class GW5DDRPHY(Module, AutoCSR):
 
         self._rdly_dq_rst         = CSR()
         self._rdly_dq_inc         = CSR()
+        self._rdly_dq_dir         = CSRStorage(reset=int(dll_on_x4))
         self._rdly_dq_bitslip_rst = CSR()
         self._rdly_dq_bitslip     = CSR()
 
@@ -198,7 +199,7 @@ class GW5DDRPHY(Module, AutoCSR):
             write_latency = cwl_sys_latency - 1,
             read_leveling = True,
             bitslips      = serdes_bits,
-            delays        = 128,
+            delays        = 256,
         )
         self.settings.dll_off = dll_off
 
@@ -322,10 +323,9 @@ class GW5DDRPHY(Module, AutoCSR):
 
                 # Control
                 # Calibrate the read delay, keeping the FIFO clock source fixed.
-                # DLL-on X4 scans toward decreasing delay.
                 i_RLOADN   = ~(self._dly_sel.storage[i] & self._rdly_dq_rst.wr_stb),
                 i_RMOVE    = self._dly_sel.storage[i] & self._rdly_dq_inc.wr_stb,
-                i_RDIR     = 1 if dll_on_x4 else 0,
+                i_RDIR     = self._rdly_dq_dir.storage,
                 i_WLOADN   = 0,
                 i_WMOVE    = 0,
                 i_WDIR     = 1,


### PR DESCRIPTION
The connected Tang Console 60K reproduces the reported quarter-rate DDR3 failures. The fixes address three separate issues in the common Gowin5 PHY:

- Reset the I/O counters with the same initialization reset as CLKDIV, while the fast clock is stopped. Releasing them through the synchronized system reset can give a different serializer phase.
- Expose read-delay direction and all 256 taps. Reset loads the DLL value and increments saturate, so BIOS must home the counter before treating its scan as physical tap positions.
- Enable write DQ-to-DQS training in DLL-on 1:4 mode, with reset/increment/direction controls for the write delay. This adjusts DQ relative to DQS; it does not implement JEDEC write leveling.

**Merge https://github.com/enjoy-digital/litex/pull/2574 first** for delay homing and training support. Clock constraints and Console PLL limits are in https://github.com/enjoy-digital/litex/pull/2577 and https://github.com/litex-hub/litex-boards/pull/791.

Validation: 8 PHY/settings tests and 38 subtests pass. The Console 60K passes repeated SRAM loads, BIOS memory tests and host random/address checks at 83⅓ MHz system / 333⅓ MHz DDR clock, 1:4 with the DLL enabled. A full 512 MiB BIOS write/read test passes without errors or read retries. The equivalent native generated-clock build also passes three reloads. Final combined-source CLI builds pass two reloads at 50 MHz / 1:2, two at 25 MHz / 1:4, and a final 83⅓ MHz / 1:4 reload. Each includes the BIOS test, 8192 host random-word checks and 688 address comparisons across 512 MiB. The 25 MHz console capture required reconnection during BIOS progress; it recovered `Memtest OK`, and the subsequent memory-data checks ran without retries or errors.

All four Gowin5 target/device combinations build. Only the Console 60K is connected for this review; the new revision has not been run on the other boards. 100 MHz system clock remains intermittent on the Console and is not qualified. Startup/delay-control timing crossings remain reported; no blanket false paths are added.

This follows https://github.com/litex-hub/litex-boards/issues/549#issuecomment-5608017895. The original PR #402 is already merged.
